### PR TITLE
Handle IllegalArgumentExcetions that mean a cloneType is needed

### DIFF
--- a/src/main/scala/Chisel/Core.scala
+++ b/src/main/scala/Chisel/Core.scala
@@ -791,7 +791,7 @@ class Bundle extends Aggregate(NO_DIR) {
             Builder.error(s"Parameterized Bundle ${this.getClass} needs cloneType method. You are probably using an anonymous Bundle object that captures external state and hence is un-cloneTypeable")
             this
         }
-      case _: java.lang.reflect.InvocationTargetException =>
+      case _: java.lang.reflect.InvocationTargetException | _: java.lang.IllegalArgumentException =>
         Builder.error(s"Parameterized Bundle ${this.getClass} needs cloneType method")
         this
     }


### PR DESCRIPTION
When trying to cloneType() on classes that take a builtin (like Int),
we get an IllegalArgumentException instead of a InvocationTargetException.
This change prints a nice error message instead of a stack trace.
