### PR TITLE
Whitespace / comment style fixes

### DIFF
--- a/src/main/scala/Chisel/Builder.scala
+++ b/src/main/scala/Chisel/Builder.scala
@@ -1,3 +1,5 @@
+// See LICENSE for license details.
+
 package Chisel
 import scala.util.DynamicVariable
 import scala.collection.mutable.{ArrayBuffer, HashMap}

--- a/src/main/scala/Chisel/Core.scala
+++ b/src/main/scala/Chisel/Core.scala
@@ -1,3 +1,5 @@
+// See LICENSE for license details.
+
 package Chisel
 import scala.collection.immutable.ListMap
 import scala.collection.mutable.{ArrayBuffer, HashSet, LinkedHashMap}
@@ -143,7 +145,7 @@ object Reg {
     pushCommand(DefRegister(x, Node(x._parent.get.clock), Node(x._parent.get.reset))) // TODO multi-clock
     if (init != null)
       pushCommand(ConnectInit(x.lref, init.ref))
-    if (next != null) 
+    if (next != null)
       x := next
     x
   }
@@ -257,7 +259,7 @@ object Vec {
     * @note elements are NOT assigned by default and have no value
     */
   def apply[T <: Data](n: Int, gen: T): Vec[T] = new Vec(gen.cloneType, n)
-  
+
   @deprecated("Chisel3 vec argument order should be n, gen - this will be removed by Chisel3 official release", "now")
   def apply[T <: Data](gen: T, n: Int): Vec[T] = new Vec(gen.cloneType, n)
 
@@ -559,7 +561,8 @@ sealed class Clock(dirArg: Direction) extends Element(dirArg, Width(1)) {
 /** A data type for values represented by a single bitvector. Provides basic
   * bitwise operations.
   */
-sealed abstract class Bits(dirArg: Direction, width: Width, override val litArg: Option[LitArg]) extends Element(dirArg, width) {
+sealed abstract class Bits(dirArg: Direction, width: Width, override val litArg: Option[LitArg])
+    extends Element(dirArg, width) {
   // REVIEW TODO: should this be abstract? It may be good to use Bits for values
   // where you don't need artihmetic operations / arithmetic doesn't make sense
   // like opcodes and stuff.
@@ -779,7 +782,8 @@ abstract trait Num[T <: Data] {
 /** A data type for unsigned integers, represented as a binary bitvector.
   * Defines arithmetic operations between other integer types.
   */
-sealed class UInt private[Chisel] (dir: Direction, width: Width, lit: Option[ULit] = None) extends Bits(dir, width, lit) with Num[UInt] {
+sealed class UInt private[Chisel] (dir: Direction, width: Width, lit: Option[ULit] = None)
+    extends Bits(dir, width, lit) with Num[UInt] {
   private[Chisel] override def cloneTypeWidth(w: Width): this.type =
     new UInt(dir, w).asInstanceOf[this.type]
   private[Chisel] def toType = s"UInt<$width>"
@@ -909,7 +913,8 @@ object UInt extends UIntFactory
   * Identical in functionality to the UInt companion object. */
 object Bits extends UIntFactory
 
-sealed class SInt private (dir: Direction, width: Width, lit: Option[SLit] = None) extends Bits(dir, width, lit) with Num[SInt] {
+sealed class SInt private (dir: Direction, width: Width, lit: Option[SLit] = None)
+    extends Bits(dir, width, lit) with Num[SInt] {
   private[Chisel] override def cloneTypeWidth(w: Width): this.type =
     new SInt(dir, w).asInstanceOf[this.type]
   private[Chisel] def toType = s"SInt<$width>"
@@ -1160,7 +1165,7 @@ class Bundle extends Aggregate(NO_DIR) {
     }
     ArrayBuffer(nameMap.toSeq:_*) sortWith {case ((an, a), (bn, b)) => (a._id > b._id) || ((a eq b) && (an > bn))}
   }
-  private[Chisel] def toType = s"{${namedElts.reverse.map(e => (if (e._2.isFlip) "flip " else "")+e._2.getRef.name+" : "+e._2.toType).reduce(_+", "+_)}}"
+  private[Chisel] def toType = s"{${namedElts.reverse.map(e => (if (e._2.isFlip) "flip " else "") + e._2.getRef.name + " : " + e._2.toType).reduce(_ + ", " + _)}}"
   private[Chisel] lazy val flatten = namedElts.flatMap(_._2.flatten)
   private[Chisel] def addElt(name: String, elt: Data): Unit =
     namedElts += name -> elt

--- a/src/main/scala/Chisel/Driver.scala
+++ b/src/main/scala/Chisel/Driver.scala
@@ -1,32 +1,4 @@
-/*
- Copyright (c) 2011, 2012, 2013, 2014 The Regents of the University of
- California (Regents). All Rights Reserved.  Redistribution and use in
- source and binary forms, with or without modification, are permitted
- provided that the following conditions are met:
-
-    * Redistributions of source code must retain the above
-      copyright notice, this list of conditions and the following
-      two paragraphs of disclaimer.
-    * Redistributions in binary form must reproduce the above
-      copyright notice, this list of conditions and the following
-      two paragraphs of disclaimer in the documentation and/or other materials
-      provided with the distribution.
-    * Neither the name of the Regents nor the names of its contributors
-      may be used to endorse or promote products derived from this
-      software without specific prior written permission.
-
- IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT,
- SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS,
- ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
- REGENTS HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
- REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT
- LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
- A PARTICULAR PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF
- ANY, PROVIDED HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION
- TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR
- MODIFICATIONS.
-*/
+// See LICENSE for license details.
 
 package Chisel
 
@@ -68,12 +40,12 @@ object Driver extends FileSystemUtilities {
       gen: () => T,
       config: ChiselConfig,
       collectConstraints: Boolean = false): Unit = {
-    val world = if(collectConstraints) config.toCollector else config.toInstance 
+    val world = if(collectConstraints) config.toCollector else config.toInstance
     val p = Parameters.root(world)
     config.topConstraints.foreach(c => p.constrain(c))
     elaborate(gen, p, config)
   }
-    
+
   /** Elaborates the circuit specified in the gen function, optionally uses
     * a parameter space to supply context-aware values.
     *  TODO: Distinguish between cases where we dump to file vs return IR for

--- a/src/main/scala/Chisel/Emitter.scala
+++ b/src/main/scala/Chisel/Emitter.scala
@@ -1,3 +1,5 @@
+// See LICENSE for license details.
+
 package Chisel
 
 private class Emitter(circuit: Circuit) {
@@ -6,7 +8,7 @@ private class Emitter(circuit: Circuit) {
   private def emitPort(e: Port): String =
     s"${e.dir} ${e.id.getRef.name} : ${e.id.toType}"
   private def emit(e: Command, ctx: Component): String = e match {
-    case e: DefPrim[_] => s"node ${e.name} = ${e.op.name}(${e.args.map(_.fullName(ctx)).reduce(_+", "+_)})"
+    case e: DefPrim[_] => s"node ${e.name} = ${e.op.name}(${e.args.map(_.fullName(ctx)).reduce(_ + ", " + _)})"
     case e: DefWire => s"wire ${e.name} : ${e.id.toType}"
     case e: DefPoison[_] => s"poison ${e.name} : ${e.id.toType}"
     case e: DefRegister => s"reg ${e.name} : ${e.id.toType}, ${e.clock.fullName(ctx)}, ${e.reset.fullName(ctx)}"
@@ -18,7 +20,7 @@ private class Emitter(circuit: Circuit) {
     case e: ConnectInit => s"onreset ${e.loc.fullName(ctx)} := ${e.exp.fullName(ctx)}"
     case e: DefInstance => {
       val modName = moduleMap.getOrElse(e.id.name, e.id.name)
-     s"inst ${e.name} of $modName"
+      s"inst ${e.name} of $modName"
     }
 
     case w: WhenBegin =>

--- a/src/main/scala/Chisel/Error.scala
+++ b/src/main/scala/Chisel/Error.scala
@@ -1,32 +1,4 @@
-/*
- Copyright (c) 2011, 2012, 2013, 2014 The Regents of the University of
- California (Regents). All Rights Reserved.  Redistribution and use in
- source and binary forms, with or without modification, are permitted
- provided that the following conditions are met:
-
-    * Redistributions of source code must retain the above
-      copyright notice, this list of conditions and the following
-      two paragraphs of disclaimer.
-    * Redistributions in binary form must reproduce the above
-      copyright notice, this list of conditions and the following
-      two paragraphs of disclaimer in the documentation and/or other materials
-      provided with the distribution.
-    * Neither the name of the Regents nor the names of its contributors
-      may be used to endorse or promote products derived from this
-      software without specific prior written permission.
-
- IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT,
- SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS,
- ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
- REGENTS HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
- REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT
- LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
- A PARTICULAR PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF
- ANY, PROVIDED HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION
- TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR
- MODIFICATIONS.
-*/
+// See LICENSE for license details.
 
 package Chisel
 import scala.collection.mutable.ArrayBuffer
@@ -60,7 +32,7 @@ private class ErrorLog {
   /** Throw an exception if any errors have yet occurred. */
   def checkpoint(): Unit = if(hasErrors) {
     import Console._
-    throwException(errors.map(_ + "\n").reduce(_+_) +
+    throwException(errors.map(_ + "\n").reduce(_ + _) +
       UNDERLINED + "CODE HAS " + errors.filter(_.isFatal).length + RESET +
       UNDERLINED + " " + RED + "ERRORS" + RESET +
       UNDERLINED + " and " + errors.filterNot(_.isFatal).length + RESET +

--- a/src/main/scala/Chisel/FP.scala
+++ b/src/main/scala/Chisel/FP.scala
@@ -1,32 +1,4 @@
-/*
- Copyright (c) 2011, 2012, 2013, 2014 The Regents of the University of
- California (Regents). All Rights Reserved.  Redistribution and use in
- source and binary forms, with or without modification, are permitted
- provided that the following conditions are met:
-
-    * Redistributions of source code must retain the above
-      copyright notice, this list of conditions and the following
-      two paragraphs of disclaimer.
-    * Redistributions in binary form must reproduce the above
-      copyright notice, this list of conditions and the following
-      two paragraphs of disclaimer in the documentation and/or other materials
-      provided with the distribution.
-    * Neither the name of the Regents nor the names of its contributors
-      may be used to endorse or promote products derived from this
-      software without specific prior written permission.
-
- IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT,
- SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS,
- ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
- REGENTS HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
- REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT
- LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
- A PARTICULAR PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF
- ANY, PROVIDED HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION
- TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR
- MODIFICATIONS.
-*/
+// See LICENSE for license details.
 
 package Chisel
 import Chisel._
@@ -100,7 +72,7 @@ class Flo(dir: Direction = NO_DIR, val value:Option[FloLit] = None) extends FloB
   private[Chisel] def toType = "Flo"
   def cloneType: this.type = new Flo(dir).asInstanceOf[this.type]
 
-  def fromInt(x: Int): Flo = 
+  def fromInt(x: Int): Flo =
     Flo(x.toFloat).asInstanceOf[this.type]
 
   def unary_-() = unop(FloNeg)
@@ -180,7 +152,7 @@ class Dbl(dir: Direction, val value: Option[DblLit] = None) extends FloBase[Dbl]
   private[Chisel] def toType = "Dbl"
   def cloneType: this.type = new Dbl(dir).asInstanceOf[this.type]
 
-  def fromInt(x: Int): this.type = 
+  def fromInt(x: Int): this.type =
     Dbl(x.toDouble).asInstanceOf[this.type]
 
   def unary_-() = unop(DblNeg)

--- a/src/main/scala/Chisel/IR.scala
+++ b/src/main/scala/Chisel/IR.scala
@@ -1,3 +1,5 @@
+// See LICENSE for license details.
+
 package Chisel
 
 case class PrimOp(val name: String) {

--- a/src/main/scala/Chisel/ImplicitConversions.scala
+++ b/src/main/scala/Chisel/ImplicitConversions.scala
@@ -1,3 +1,5 @@
+// See LICENSE for license details.
+
 package Chisel
 
 object ImplicitConversions {

--- a/src/main/scala/Chisel/Utils.scala
+++ b/src/main/scala/Chisel/Utils.scala
@@ -1,3 +1,5 @@
+// See LICENSE for license details.
+
 package Chisel
 import Builder._
 import scala.math._
@@ -207,11 +209,11 @@ object Fill {
       case 0 => UInt(width=0)
       case 1 => x
       case y if n > 1 =>
-        val p2 = Array.ofDim[UInt](log2Up(n+1))
+        val p2 = Array.ofDim[UInt](log2Up(n + 1))
         p2(0) = x
         for (i <- 1 until p2.length)
           p2(i) = Cat(p2(i-1), p2(i-1))
-        Cat((0 until log2Up(y+1)).filter(i => (y & (1 << i)) != 0).map(p2(_)))
+        Cat((0 until log2Up(y + 1)).filter(i => (y & (1 << i)) != 0).map(p2(_)))
       case _ => throw new IllegalArgumentException(s"n (=$n) must be nonnegative integer.")
     }
   }
@@ -454,9 +456,10 @@ class QueueIO[T <: Data](gen: T, entries: Int) extends Bundle
 /** A hardware module implementing a Queue
   * @param gen The type of data to queue
   * @param entries The max number of entries in the queue
-  * @param pipe True if a single entry queue can run at full throughput (like a pipeline). The ''ready'' signals are combinationally coupled.
-  * @param flow True if the inputs can be consumed on the same cycle
-(the inputs "flow" through the queue immediately). The ''valid'' signals are coupled.
+  * @param pipe True if a single entry queue can run at full throughput (like a pipeline). The ''ready'' signals are
+  * combinationally coupled.
+  * @param flow True if the inputs can be consumed on the same cycle (the inputs "flow" through the queue immediately).
+  * The ''valid'' signals are coupled.
   *
   * Example usage:
   *    {{{ val q = new Queue(UInt(), 16)
@@ -561,7 +564,8 @@ object ArbiterCtrl
   }
 }
 
-abstract class LockingArbiterLike[T <: Data](gen: T, n: Int, count: Int, needsLock: Option[T => Bool] = None) extends Module {
+abstract class LockingArbiterLike[T <: Data](gen: T, n: Int, count: Int, needsLock: Option[T => Bool] = None)
+    extends Module {
   require(isPow2(count))
   def grant: Seq[Bool]
   val io = new ArbiterIO(gen, n)
@@ -595,7 +599,8 @@ abstract class LockingArbiterLike[T <: Data](gen: T, n: Int, count: Int, needsLo
   }
 }
 
-class LockingRRArbiter[T <: Data](gen: T, n: Int, count: Int, needsLock: Option[T => Bool] = None) extends LockingArbiterLike[T](gen, n, count, needsLock) {
+class LockingRRArbiter[T <: Data](gen: T, n: Int, count: Int, needsLock: Option[T => Bool] = None)
+    extends LockingArbiterLike[T](gen, n, count, needsLock) {
   lazy val last_grant = Reg(init=UInt(0, log2Up(n)))
   override def grant: Seq[Bool] = {
     val ctrl = ArbiterCtrl((0 until n).map(i => io.in(i).valid && UInt(i) > last_grant) ++ io.in.map(_.valid))
@@ -612,7 +617,8 @@ class LockingRRArbiter[T <: Data](gen: T, n: Int, count: Int, needsLock: Option[
   when (io.out.fire()) { last_grant := chosen }
 }
 
-class LockingArbiter[T <: Data](gen: T, n: Int, count: Int, needsLock: Option[T => Bool] = None) extends LockingArbiterLike[T](gen, n, count, needsLock) {
+class LockingArbiter[T <: Data](gen: T, n: Int, count: Int, needsLock: Option[T => Bool] = None)
+    extends LockingArbiterLike[T](gen, n, count, needsLock) {
   def grant: Seq[Bool] = ArbiterCtrl(io.in.map(_.valid))
 
   var choose = UInt(n-1)

--- a/src/main/scala/Chisel/testers/BasicTester.scala
+++ b/src/main/scala/Chisel/testers/BasicTester.scala
@@ -1,32 +1,4 @@
-/*
- Copyright (c) 2011, 2012, 2013, 2014 The Regents of the University of
- California (Regents). All Rights Reserved.  Redistribution and use in
- source and binary forms, with or without modification, are permitted
- provided that the following conditions are met:
-
-    * Redistributions of source code must retain the above
-      copyright notice, this list of conditions and the following
-      two paragraphs of disclaimer.
-    * Redistributions in binary form must reproduce the above
-      copyright notice, this list of conditions and the following
-      two paragraphs of disclaimer in the documentation and/or other materials
-      provided with the distribution.
-    * Neither the name of the Regents nor the names of its contributors
-      may be used to endorse or promote products derived from this
-      software without specific prior written permission.
-
- IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT,
- SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS,
- ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
- REGENTS HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
- REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT
- LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
- A PARTICULAR PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF
- ANY, PROVIDED HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION
- TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR
- MODIFICATIONS.
-*/
+// See LICENSE for license details.
 
 package Chisel.testers
 import Chisel._

--- a/src/main/scala/Chisel/testers/Driver.scala
+++ b/src/main/scala/Chisel/testers/Driver.scala
@@ -1,38 +1,10 @@
-/*
- Copyright (c) 2011, 2012, 2013, 2014 The Regents of the University of
- California (Regents). All Rights Reserved.  Redistribution and use in
- source and binary forms, with or without modification, are permitted
- provided that the following conditions are met:
-
-    * Redistributions of source code must retain the above
-      copyright notice, this list of conditions and the following
-      two paragraphs of disclaimer.
-    * Redistributions in binary form must reproduce the above
-      copyright notice, this list of conditions and the following
-      two paragraphs of disclaimer in the documentation and/or other materials
-      provided with the distribution.
-    * Neither the name of the Regents nor the names of its contributors
-      may be used to endorse or promote products derived from this
-      software without specific prior written permission.
-
- IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT,
- SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS,
- ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
- REGENTS HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
- REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT
- LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
- A PARTICULAR PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF
- ANY, PROVIDED HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION
- TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR
- MODIFICATIONS.
-*/
+// See LICENSE for license details.
 
 package Chisel.testers
 import Chisel._
 
 object TesterDriver {
-  /** For use with modules that should successfully be elaborated by the 
+  /** For use with modules that should successfully be elaborated by the
     * frontend, and which can be turned into executeables with error codes. */
   def execute(t: => BasicTester): Boolean = {
     val circuit = Builder.build(Module(t))


### PR DESCRIPTION
Whitespace / comment style changes to make Scalastyle happier and bring down the style violation count.

Lines are wrapped to 120 characters (at least in cases where a rewrite isn't necessary) and the license notice has been changed to a briefer style.
