### PR TITLE
Add operators to Scalastyle configuration MethodNamesChecker ignore list

### DIFF
--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -90,6 +90,7 @@
  <check level="warning" class="org.scalastyle.scalariform.MethodNamesChecker" enabled="true">
   <parameters>
    <parameter name="regex"><![CDATA[^[a-z][A-Za-z0-9]*$]]></parameter>
+   <parameter name="ignoreRegex"><![CDATA[^(\+[&%]?|\-[&%]?|\*|/|%|&|\||\^|<|>|\|\||&&|:=|<>|<=|>=|!=|===|<<|>>|unary_(~|\-%?|!))$]]></parameter>
   </parameters>
  </check>
  <check level="warning" class="org.scalastyle.scalariform.NumberOfMethodsInTypeChecker" enabled="true">


### PR DESCRIPTION
... so Scalastyle can stop complaining about our operators ...
