### PR TITLE
Fix stylistic issues and document standard Chisel generators for test code

### DIFF
--- a/src/test/scala/chiselTests/ChiselSpec.scala
+++ b/src/test/scala/chiselTests/ChiselSpec.scala
@@ -19,30 +19,48 @@ class ChiselFlatSpec extends FlatSpec with ChiselRunners with Matchers
 
 /** Spec base class for property-based testers. */
 class ChiselPropSpec extends PropSpec with ChiselRunners with PropertyChecks {
-  def popCount(n: Long) = n.toBinaryString.count(_=='1')
+  /** Returns the number of 1s in the binary representation of the input. */
+  def popCount(n: Long): Int = n.toBinaryString.count(_ == '1')
 
+  // Generator for small positive integers.
   val smallPosInts = Gen.choose(1, 7)
-  val safeUIntWidth = Gen.choose(1, 30)
-  val safeUInts = Gen.choose(0, (1 << 30))
-  val vecSizes = Gen.choose(0, 4)
-  val binaryString = for(i <- Arbitrary.arbitrary[Int]) yield "b" + i.toBinaryString
-  def enSequence(n: Int) = Gen.containerOfN[List,Boolean](n,Gen.oneOf(true,false))
 
-  def safeUIntN(n: Int) = for {
+  // Generator for widths considered "safe".
+  val safeUIntWidth = Gen.choose(1, 30)
+
+  // Generators for integers that fit within "safe" widths.
+  val safeUInts = Gen.choose(0, (1 << 30))
+
+  // Generators for vector sizes.
+  val vecSizes = Gen.choose(0, 4)
+
+  // Generator for string representing an arbitrary integer.
+  val binaryString = for (i <- Arbitrary.arbitrary[Int]) yield "b" + i.toBinaryString
+
+  // Generator for a sequence of Booleans of size n.
+  def enSequence(n: Int): Gen[List[Boolean]] = Gen.containerOfN[List, Boolean](n, Gen.oneOf(true, false))
+
+  // Generator which gives a width w and a list (of size n) of numbers up to w bits.
+  def safeUIntN(n: Int): Gen[(Int, List[Int])] = for {
     w <- smallPosInts
-    i <- Gen.containerOfN[List,Int](n, Gen.choose(0, (1 << w) - 1))
+    i <- Gen.containerOfN[List, Int](n, Gen.choose(0, (1 << w) - 1))
   } yield (w, i)
+
+  // Generator which gives a width w and a numbers up to w bits.
   val safeUInt = for {
     w <- smallPosInts
     i <- Gen.choose(0, (1 << w) - 1)
   } yield (w, i)
 
-  def safeUIntPairN(n: Int) = for {
+  // Generator which gives a width w and a list (of size n) of a pair of numbers up to w bits.
+  def safeUIntPairN(n: Int): Gen[(Int, List[(Int, Int)])] = for {
     w <- smallPosInts
-    i <- Gen.containerOfN[List,Int](n, Gen.choose(0, (1 << w) - 1))
-    j <- Gen.containerOfN[List,Int](n, Gen.choose(0, (1 << w) - 1))
+    i <- Gen.containerOfN[List, Int](n, Gen.choose(0, (1 << w) - 1))
+    j <- Gen.containerOfN[List, Int](n, Gen.choose(0, (1 << w) - 1))
   } yield (w, i zip j)
-  val safeUIntPair= for {
+
+  // Generator which gives a width w and a pair of numbers up to w bits.
+  val safeUIntPair = for {
     w <- smallPosInts
     i <- Gen.choose(0, (1 << w) - 1)
     j <- Gen.choose(0, (1 << w) - 1)

--- a/src/test/scala/chiselTests/Decoder.scala
+++ b/src/test/scala/chiselTests/Decoder.scala
@@ -33,7 +33,7 @@ class DecoderSpec extends ChiselPropSpec {
     val bp = bs.map(if(rnd.nextBoolean) _ else "?").mkString
     ("b" + bs, "b" + bp)
   }
-  def nPairs(n: Int) = Gen.containerOfN[List, (String,String)](n,bitpatPair)
+  private def nPairs(n: Int) = Gen.containerOfN[List, (String,String)](n,bitpatPair)
 
   property("BitPat wildcards should be usable in decoding") {
     forAll(nPairs(16)){ (pairs: List[(String, String)]) =>


### PR DESCRIPTION
Zero scalastyle issues left for test code after this!

@hcook you should probably check that the documentation is correct and useful for generators that appear to be testing infrastructure.
