### PR TITLE
Ignore 8,10,16 as magic number constants

### DIFF
--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -48,7 +48,7 @@
  </check>
  <check level="warning" class="org.scalastyle.scalariform.MagicNumberChecker" enabled="true">
   <parameters>
-   <parameter name="ignore"><![CDATA[-1,0,1,2,3]]></parameter>
+   <parameter name="ignore"><![CDATA[-1,0,1,2,8,10,16]]></parameter>
   </parameters>
  </check>
  <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceBeforeLeftBracketChecker" enabled="true"></check>


### PR DESCRIPTION
Add 8, 10, 16 to the magic number ignore list (for hardware design, they're used somewhat often) and remove 3 (which does seem a bit magical, and in any case isn't used).
