### PR TITLE
Move Cat into utils

### DIFF
--- a/src/main/scala/Chisel/Bits.scala
+++ b/src/main/scala/Chisel/Bits.scala
@@ -175,7 +175,10 @@ sealed abstract class Bits(dirArg: Direction, width: Width, override val litArg:
     *
     * The width of the output is sum of the inputs. Generates no logic.
     */
-  def ## (other: Bits): UInt = Cat(this, other)
+  def ## (other: Bits): UInt = {
+    val w = this.width + other.width
+    pushOp(DefPrim(UInt(w), ConcatOp, this.ref, other.ref))
+  }
 
   @deprecated("Use asBits, which makes the reinterpret cast more explicit and actually returns Bits", "chisel3")
   override def toBits: UInt = asUInt

--- a/src/main/scala/Chisel/util/Cat.scala
+++ b/src/main/scala/Chisel/util/Cat.scala
@@ -1,11 +1,7 @@
 // See LICENSE for license details.
 
 package Chisel
-import Builder.pushOp
-import PrimOp._
 
-// REVIEW TODO: Should the FIRRTL emission be part of Bits, with a separate
-// Cat in stdlib that can do a reduction among multiple elements?
 object Cat {
   /** Combine data elements together
     * @param a Data to combine with
@@ -24,8 +20,7 @@ object Cat {
     } else {
       val left = apply(r.slice(0, r.length/2))
       val right = apply(r.slice(r.length/2, r.length))
-      val w = left.width + right.width
-      pushOp(DefPrim(UInt(w), ConcatOp, left.ref, right.ref))
+      left ## right
     }
   }
 }


### PR DESCRIPTION
Moves around what uses the FIRRTL internals to make it most consistent with everything else. The FIRRTL-aware part goes into Bits, and Cat can be mobed into utils.
