### PR TITLE
Style fixes for test code

### DIFF
--- a/src/test/scala/chiselTests/ComplexAssign.scala
+++ b/src/test/scala/chiselTests/ComplexAssign.scala
@@ -41,7 +41,7 @@ class ComplexAssignTester(enList: List[Boolean], re: Int, im: Int) extends Basic
     io.done := Bool(true); io.error := cnt
   } .elsewhen(wrap) { io.done := Bool(true) }
 }
-   
+
 class ComplexAssignSpec extends ChiselPropSpec {
 
   property("All complex assignments should return the correct result") {

--- a/src/test/scala/chiselTests/GCD.scala
+++ b/src/test/scala/chiselTests/GCD.scala
@@ -38,7 +38,7 @@ class GCDTester(a: Int, b: Int, z: Int) extends BasicTester {
 }
 
 class GCDSpec extends ChiselPropSpec {
-  
+
   //TODO: use generators and this function to make z's
   def gcd(a: Int, b: Int): Int = if(b == 0) a else gcd(b, a%b)
 

--- a/src/test/scala/chiselTests/Harness.scala
+++ b/src/test/scala/chiselTests/Harness.scala
@@ -1,13 +1,15 @@
+// See LICENSE for license details.
+
 package chiselTests
 import Chisel.testers.BasicTester
 import org.scalatest._
 import org.scalatest.prop._
 import java.io.File
 
-class HarnessSpec extends ChiselPropSpec 
+class HarnessSpec extends ChiselPropSpec
   with Chisel.BackendCompilationUtilities {
 
-  def makeTrivialVerilog = makeHarness((prefix: String) => s"""
+  def makeTrivialVerilog: (File => File) = makeHarness((prefix: String) => s"""
 module ${prefix};
   initial begin
     $$display("$prefix!");
@@ -16,7 +18,7 @@ module ${prefix};
 endmodule
 """, ".v") _
 
-  def makeFailingVerilog = makeHarness((prefix: String) => s"""
+  def makeFailingVerilog: (File => File) = makeHarness((prefix: String) => s"""
 module $prefix;
   initial begin
     assert (1 == 0) else $$error("My specific, expected error message!");
@@ -26,7 +28,7 @@ module $prefix;
 endmodule
 """, ".v") _
 
-  def makeCppHarness = makeHarness((prefix: String) => s"""
+  def makeCppHarness: (File => File) = makeHarness((prefix: String) => s"""
 #include "V$prefix.h"
 #include "verilated.h"
 
@@ -72,4 +74,4 @@ int main(int argc, char **argv, char **env) {
     assert(!executeExpectingFailure(prefix, dir, "A string that doesn't match any test output"))
   }
 }
- 
+


### PR DESCRIPTION
Back down to zero style errors, so we can automatically start checking this for CI tests.
