### PR TITLE
Fix new style errors

### DIFF
--- a/src/main/scala/Chisel/Driver.scala
+++ b/src/main/scala/Chisel/Driver.scala
@@ -55,7 +55,7 @@ trait BackendCompilationUtilities {
         "--Wno-fatal",
         "--trace",
         "-O2",
-        "+define+TOP_TYPE=V"+prefix,
+        "+define+TOP_TYPE=V" + prefix,
         "-CFLAGS", s"""-Wno-undefined-bool-conversion -O2 -DTOP_TYPE=V$prefix -include ${vH.toString}""",
         "-Mdir", dir.toString,
         "--exe", cppHarness.toString)
@@ -81,14 +81,14 @@ trait BackendCompilationUtilities {
 
 object Driver extends FileSystemUtilities with BackendCompilationUtilities {
 
-  /** Elaborates the Module specified in the gen function into a Circuit 
+  /** Elaborates the Module specified in the gen function into a Circuit
     *
     *  @param gen a function that creates a Module hierarchy
     *
     *  @return the resulting Chisel IR in the form of a Circuit (TODO: Should be FIRRTL IR)
     */
   def elaborate[T <: Module](gen: () => T): Circuit = Builder.build(Module(gen()))
-  
+
   def emit[T <: Module](gen: () => T): String = elaborate(gen).emit
 
   def dumpFirrtl(ir: Circuit, optName: Option[File]): File = {

--- a/src/main/scala/Chisel/testers/BasicTester.scala
+++ b/src/main/scala/Chisel/testers/BasicTester.scala
@@ -11,5 +11,5 @@ class BasicTester extends Module {
   io.done := Bool(false)
   io.error := UInt(0)
 
-  def popCount(n: Long) = n.toBinaryString.count(_=='1')
+  def popCount(n: Long): Int = n.toBinaryString.count(_=='1')
 }

--- a/src/main/scala/Chisel/testers/TesterDriver.scala
+++ b/src/main/scala/Chisel/testers/TesterDriver.scala
@@ -27,11 +27,13 @@ object TesterDriver extends BackendCompilationUtilities with FileSystemUtilities
     Driver.dumpFirrtl(circuit, Some(new File(fname.toString + ".fir")))
 
     // Use sys.Process to invoke a bunch of backend stuff, then run the resulting exe
-    if(((new File(System.getProperty("user.dir") + "/src/main/resources/top.cpp") #> cppHarness) #&&
+    if (((new File(System.getProperty("user.dir") + "/src/main/resources/top.cpp") #> cppHarness) #&&
         firrtlToVerilog(prefix, dir) #&&
         verilogToCpp(prefix, dir, vDut, cppHarness, vH) #&&
         cppToExe(prefix, dir)).! == 0) {
       executeExpectingSuccess(prefix, dir)
-    } else false
+    } else {
+      false
+    }
   }
 }


### PR DESCRIPTION
Fixes new style errors introduced by the parameters system. Only a slight handful, compared to the 112 that was in the previous implementation.

We need to decide how to fix the last 8 more difficult style errors sometime, so scalastyle can be run as part of the CI system.
