### PR TITLE
Split internal and FIRRTL packages

### DIFF
--- a/src/main/scala/Chisel/Aggregate.scala
+++ b/src/main/scala/Chisel/Aggregate.scala
@@ -1,9 +1,13 @@
 // See LICENSE for license details.
 
 package Chisel
+
 import scala.collection.immutable.ListMap
 import scala.collection.mutable.{ArrayBuffer, HashSet, LinkedHashMap}
-import Builder.pushCommand
+
+import internal._
+import internal.Builder.pushCommand
+import firrtl._
 
 /** An abstract class for data types that solely consist of (are an aggregate
   * of) other Data objects.

--- a/src/main/scala/Chisel/BitPat.scala
+++ b/src/main/scala/Chisel/BitPat.scala
@@ -21,7 +21,7 @@ object BitPat {
     var mask = BigInt(0)
     for (d <- x.tail) {
       if (d != '_') {
-        if (!"01?".contains(d)) Builder.error({"Literal: " + x + " contains illegal character: " + d})
+        require("01?".contains(d), "Literal: " + x + " contains illegal character: " + d)
         mask = (mask << 1) + (if (d == '?') 0 else 1)
         bits = (bits << 1) + (if (d == '1') 1 else 0)
       }

--- a/src/main/scala/Chisel/Bits.scala
+++ b/src/main/scala/Chisel/Bits.scala
@@ -1,8 +1,11 @@
 // See LICENSE for license details.
 
 package Chisel
-import Builder.pushOp
-import PrimOp._
+
+import internal._
+import internal.Builder.pushOp
+import firrtl._
+import firrtl.PrimOp._
 
 /** Element is a leaf data type: it cannot contain other Data objects. Example
   * uses are for representing primitive data types, like integers and bits.

--- a/src/main/scala/Chisel/Data.scala
+++ b/src/main/scala/Chisel/Data.scala
@@ -1,7 +1,10 @@
 // See LICENSE for license details.
 
 package Chisel
-import Builder.pushCommand
+
+import internal._
+import internal.Builder.pushCommand
+import firrtl._
 
 sealed abstract class Direction(name: String) {
   override def toString: String = name

--- a/src/main/scala/Chisel/Driver.scala
+++ b/src/main/scala/Chisel/Driver.scala
@@ -5,6 +5,9 @@ package Chisel
 import scala.sys.process._
 import java.io._
 
+import internal._
+import firrtl._
+
 trait FileSystemUtilities {
   def writeTempFile(pre: String, post: String, contents: String): File = {
     val t = File.createTempFile(pre, post)

--- a/src/main/scala/Chisel/Mem.scala
+++ b/src/main/scala/Chisel/Mem.scala
@@ -1,7 +1,10 @@
 // See LICENSE for license details.
 
 package Chisel
-import Builder.pushCommand
+
+import internal._
+import internal.Builder.pushCommand
+import firrtl._
 
 object Mem {
   @deprecated("Mem argument order should be size, t; this will be removed by the official release", "chisel3")

--- a/src/main/scala/Chisel/Module.scala
+++ b/src/main/scala/Chisel/Module.scala
@@ -1,9 +1,13 @@
 // See LICENSE for license details.
 
 package Chisel
+
 import scala.collection.mutable.{ArrayBuffer, HashSet}
-import Builder.pushCommand
-import Builder.dynamicContext
+
+import internal._
+import internal.Builder.pushCommand
+import internal.Builder.dynamicContext
+import firrtl._
 
 object Module {
   /** A wrapper method that all Module instantiations must be wrapped in

--- a/src/main/scala/Chisel/Reg.scala
+++ b/src/main/scala/Chisel/Reg.scala
@@ -1,7 +1,10 @@
 // See LICENSE for license details.
 
 package Chisel
-import Builder.pushCommand
+
+import internal._
+import internal.Builder.pushCommand
+import firrtl._
 
 object Reg {
   private[Chisel] def makeType[T <: Data](t: T = null, next: T = null, init: T = null): T = {

--- a/src/main/scala/Chisel/When.scala
+++ b/src/main/scala/Chisel/When.scala
@@ -1,7 +1,10 @@
 // See LICENSE for license details.
 
 package Chisel
-import Builder.pushCommand
+
+import internal._
+import internal.Builder.pushCommand
+import firrtl._
 
 object when {  // scalastyle:ignore object.name
   /** Create a `when` condition block, where whether a block of logic is

--- a/src/main/scala/Chisel/firrtl/Emitter.scala
+++ b/src/main/scala/Chisel/firrtl/Emitter.scala
@@ -1,6 +1,7 @@
 // See LICENSE for license details.
 
-package Chisel
+package Chisel.firrtl
+import Chisel._
 
 private class Emitter(circuit: Circuit) {
   override def toString: String = res.toString

--- a/src/main/scala/Chisel/firrtl/IR.scala
+++ b/src/main/scala/Chisel/firrtl/IR.scala
@@ -1,6 +1,8 @@
 // See LICENSE for license details.
 
-package Chisel
+package Chisel.firrtl
+import Chisel._
+import Chisel.internal._
 
 case class PrimOp(val name: String) {
   override def toString: String = name

--- a/src/main/scala/Chisel/internal/Builder.scala
+++ b/src/main/scala/Chisel/internal/Builder.scala
@@ -1,10 +1,14 @@
 // See LICENSE for license details.
 
-package Chisel
+package Chisel.internal
+
 import scala.util.DynamicVariable
 import scala.collection.mutable.{ArrayBuffer, HashMap}
 
-private class Namespace(parent: Option[Namespace], keywords: Set[String]) {
+import Chisel._
+import Chisel.firrtl._
+
+private[Chisel] class Namespace(parent: Option[Namespace], keywords: Set[String]) {
   private var i = 0L
   private val names = collection.mutable.HashSet[String]()
 
@@ -28,7 +32,7 @@ private class Namespace(parent: Option[Namespace], keywords: Set[String]) {
   def child: Namespace = child(Set())
 }
 
-private class IdGen {
+private[Chisel] class IdGen {
   private var counter = -1L
   def next: Long = {
     counter += 1
@@ -68,7 +72,7 @@ class RefMap {
   def apply(id: HasId): Arg = _refmap(id._id)
 }
 
-private class DynamicContext {
+private[Chisel] class DynamicContext {
   val idGen = new IdGen
   val globalNamespace = new Namespace(None, Set())
   val globalRefMap = new RefMap
@@ -77,7 +81,7 @@ private class DynamicContext {
   val errors = new ErrorLog
 }
 
-private object Builder {
+private[Chisel] object Builder {
   // All global mutable state must be referenced via dynamicContextVar!!
   private val dynamicContextVar = new DynamicVariable[Option[DynamicContext]](None)
 

--- a/src/main/scala/Chisel/internal/Error.scala
+++ b/src/main/scala/Chisel/internal/Error.scala
@@ -1,17 +1,20 @@
 // See LICENSE for license details.
 
-package Chisel
+package Chisel.internal
+
 import scala.collection.mutable.ArrayBuffer
+
+import Chisel._
 
 class ChiselException(message: String, cause: Throwable) extends Exception(message, cause)
 
-private object throwException {
+private[Chisel] object throwException {
   def apply(s: String, t: Throwable = null): Nothing =
     throw new ChiselException(s, t)
 }
 
 /** Records and reports runtime errors and warnings. */
-private class ErrorLog {
+private[Chisel] class ErrorLog {
   def hasErrors: Boolean = errors.exists(_.isFatal)
 
   /** Log an error message */

--- a/src/main/scala/Chisel/util/Conditional.scala
+++ b/src/main/scala/Chisel/util/Conditional.scala
@@ -31,15 +31,15 @@ class SwitchContext[T <: Bits](cond: T) {
 object is {   // scalastyle:ignore object.name
   // Begin deprecation of non-type-parameterized is statements.
   def apply(v: Iterable[Bits])(block: => Unit) {
-    Builder.error("The 'is' keyword may not be used outside of a switch.")
+    require(false, "The 'is' keyword may not be used outside of a switch.")
   }
 
   def apply(v: Bits)(block: => Unit) {
-    Builder.error("The 'is' keyword may not be used outside of a switch.")
+    require(false, "The 'is' keyword may not be used outside of a switch.")
   }
 
   def apply(v: Bits, vr: Bits*)(block: => Unit) {
-    Builder.error("The 'is' keyword may not be used outside of a switch.")
+    require(false, "The 'is' keyword may not be used outside of a switch.")
   }
 }
 

--- a/src/test/scala/chiselTests/ChiselSpec.scala
+++ b/src/test/scala/chiselTests/ChiselSpec.scala
@@ -11,7 +11,7 @@ import Chisel.testers._
 /** Common utility functions for Chisel unit tests. */
 trait ChiselRunners {
   def execute(t: => BasicTester): Boolean = TesterDriver.execute(() => t)
-  def elaborate(t: => Module): Circuit = Driver.elaborate(() => t)
+  def elaborate(t: => Module): Unit = Driver.elaborate(() => t)
 }
 
 /** Spec base class for BDD-style testers. */

--- a/src/test/scala/chiselTests/Reg.scala
+++ b/src/test/scala/chiselTests/Reg.scala
@@ -8,7 +8,7 @@ import Chisel.testers.BasicTester
 
 class RegSpec extends ChiselFlatSpec {
   "A Reg" should "throw an exception if not given any parameters" in {
-    a [ChiselException] should be thrownBy {
+    a [Exception] should be thrownBy {
       val reg = Reg()
     }
   }


### PR DESCRIPTION
Makes firrtl and internal actually have their own package, not just their own folder. This helps sort the Scaladoc (so FIRRTL classes are under Chisel.firrtl) as well as enforce what should / should not be user-visible. Most changes are just adding the imports in the Chisel API classes (Chisel._), but there are two functional changes:
- Builder.error replaced with require in Chisel.util classes, since Builder is an internal class (and stateful!). We may want to come up with a consistent way of throwing errors, both for core Chisel and library writers.
- ChiselSpec elaborate now returns nothing. Circuit is a FIRRTL internal detail, and in any case the tests don't utilize it (instead just checking if compile at all).

This doesn't touch the split between internal / firrtl and core or visibility. That definitely could use improvement, but another job for another day.
