### PR TITLE
Add stop() in BasicTester as a replacement for io.done

### DIFF
--- a/src/main/scala/Chisel/testers/BasicTester.scala
+++ b/src/main/scala/Chisel/testers/BasicTester.scala
@@ -3,6 +3,10 @@
 package Chisel.testers
 import Chisel._
 
+import internal._
+import internal.Builder.pushCommand
+import firrtl._
+
 class BasicTester extends Module {
   val io = new Bundle {
     val done = Bool()
@@ -12,4 +16,10 @@ class BasicTester extends Module {
   io.error := UInt(0)
 
   def popCount(n: Long): Int = n.toBinaryString.count(_=='1')
+
+  /** Ends the test, reporting success.
+    */
+  def stop() {
+    pushCommand(Stop(Node(clock), 0))
+  }
 }

--- a/src/test/scala/chiselTests/Stop.scala
+++ b/src/test/scala/chiselTests/Stop.scala
@@ -1,0 +1,18 @@
+// See LICENSE for license details.
+
+package chiselTests
+
+import org.scalatest._
+import Chisel._
+import Chisel.testers.BasicTester
+
+class StopTester() extends BasicTester {
+  io.done := Bool(false)
+  stop()
+}
+
+class StopSpec extends ChiselFlatSpec {
+  "stop()" should "stop and succeed the testbench" in {
+    assert(execute{ new StopTester })
+  }
+}


### PR DESCRIPTION
io.done will be removed in a much larger refactor pull request.
