### PR TITLE
Modify TestDriver to take resource paths instead of Files

### DIFF
--- a/src/main/scala/Chisel/testers/TesterDriver.scala
+++ b/src/main/scala/Chisel/testers/TesterDriver.scala
@@ -2,13 +2,23 @@
 
 package Chisel.testers
 import Chisel._
+import scala.io.Source
 import scala.sys.process._
-import java.io.File
+import java.io._
 
 object TesterDriver extends BackendCompilationUtilities {
+  /** Copy the contents of a resource to a destination file.
+    */
+  def copyResourceToFile(name: String, file: File) {
+    val in = getClass().getResourceAsStream(name)
+    val out = new FileOutputStream(file)
+    Iterator.continually(in.read).takeWhile(-1 !=).foreach(out.write)
+    out.close()
+  }
+
   /** For use with modules that should successfully be elaborated by the
     * frontend, and which can be turned into executeables with assertions. */
-  def execute(t: () => BasicTester, additionalVSources: Seq[File] = Seq()): Boolean = {
+  def execute(t: () => BasicTester, additionalVResources: Seq[String] = Seq()): Boolean = {
     // Invoke the chisel compiler to get the circuit's IR
     val circuit = Driver.elaborate(t)
 
@@ -19,14 +29,23 @@ object TesterDriver extends BackendCompilationUtilities {
     val path = createTempDirectory(target)
     val fname = File.createTempFile(target, "", path)
     val prefix = fname.toString.split("/").last
-    val cppHarness = new File(System.getProperty("user.dir") + "/src/main/resources/top.cpp")
 
     // For now, dump the IR out to a file
     Driver.dumpFirrtl(circuit, Some(new File(fname.toString + ".fir")))
 
+    // Copy CPP harness and other Verilog sources from resources into files
+    val cppHarness =  new File(path, "top.cpp")
+    copyResourceToFile("/top.cpp", cppHarness)
+    val additionalVFiles = additionalVResources.map((name: String) => {
+      val mangledResourceName = name.replace("/", "_")
+      val out = new File(path, mangledResourceName)
+      copyResourceToFile(name, out)
+      out
+    })
+
     // Use sys.Process to invoke a bunch of backend stuff, then run the resulting exe
     if ((firrtlToVerilog(prefix, path) #&&
-        verilogToCpp(prefix, path, additionalVSources, cppHarness) #&&
+        verilogToCpp(prefix, path, additionalVFiles, cppHarness) #&&
         cppToExe(prefix, path)).! == 0) {
       executeExpectingSuccess(prefix, path)
     } else {


### PR DESCRIPTION
Attempts to address issue #69 - TestDriver now takes in resource names and copies them to the temp directory before using them.
