### PR TITLE
Fix some nits: add that line to .gitignore that keeps coming back, do parallel testing by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 generated/
+/bin/

--- a/build.sbt
+++ b/build.sbt
@@ -19,3 +19,4 @@ ghpages.settings
 git.remoteRepo := "git@github.com:ucb-bar/chisel3.git"
 
 (scalastyleConfig in Test) := baseDirectory.value / "scalastyle-test-config.xml"
+(parallelExecution in Test) := true


### PR DESCRIPTION
I don't know what keeps adding /bin/ to .gitignore, but I'm tired of dealing with it all the time.
Parallel testing makes the testbenches run significantly faster, but makes the output hard to read. Although given the number of tests, if you care about the test output, you should probably be using test-only...
