### PR TITLE
Print test stdout/stderr to console

### DIFF
--- a/src/main/scala/Chisel/Driver.scala
+++ b/src/main/scala/Chisel/Driver.scala
@@ -81,8 +81,11 @@ trait BackendCompilationUtilities {
       dir: File,
       assertionMsg: String = "Assertion failed"): Boolean = {
     var triggered = false
-    val e = Process(s"./V${prefix}", dir) ! ProcessLogger(line =>
-      triggered = triggered || line.contains(assertionMsg))
+    val e = Process(s"./V${prefix}", dir) !
+      ProcessLogger(line => {
+        triggered = triggered || line.contains(assertionMsg)
+        System.out.println(line)
+      })
     triggered
   }
 


### PR DESCRIPTION
Should address #71 and make debugging less painful, no more need to muck around in your /tmp directory trying to manually run the latest test executable.
