### PR TITLE
Tests and documentation for BlackBox

### DIFF
--- a/src/main/scala/Chisel/BlackBox.scala
+++ b/src/main/scala/Chisel/BlackBox.scala
@@ -8,16 +8,14 @@ package Chisel
   *
   * @example
   * {{{
-  * class DSP48E1 extends BlackBox {
-  *   val io = new Bundle // Create I/O with same as DSP
-  *   val dspParams = new VerilogParameters // Create Parameters to be specified
-  *   setVerilogParams(dspParams)
-  *   // Implement functionality of DSP to allow simulation verification
-  * }
+  * ... to be written once a spec is finalized ...
   * }}}
   */
-// TODO: actually implement BlackBox (this hack just allows them to compile)
 // REVIEW TODO: make Verilog parameters part of the constructor interface?
-abstract class BlackBox(_clock: Clock = null, _reset: Bool = null) extends Module(_clock = _clock, _reset = _reset) {
+abstract class BlackBox(_clock: Clock = null, _reset: Bool = null)
+    extends Module(_clock = _clock, _reset = _reset) {
+  // TODO: actually implement this.
   def setVerilogParameters(s: String): Unit = {}
+
+  // The body of a BlackBox is empty, the real logic happens in firrtl/Emitter.scala
 }

--- a/src/test/resources/BlackBoxTest.v
+++ b/src/test/resources/BlackBoxTest.v
@@ -1,0 +1,17 @@
+module BlackBoxInverter(
+    input  [0:0] clk,
+    input  [0:0] reset,
+    output [0:0] io_in,
+    output [0:0] io_out
+);
+  assign io_out = !io_in;
+endmodule
+
+module BlackBoxPassthrough(
+    input  [0:0] clk,
+    input  [0:0] reset,
+    output [0:0] io_in,
+    output [0:0] io_out
+);
+  assign io_out = io_in;
+endmodule

--- a/src/test/scala/chiselTests/Assert.scala
+++ b/src/test/scala/chiselTests/Assert.scala
@@ -18,9 +18,9 @@ class SucceedingAssertTester() extends BasicTester {
 
 class AssertSpec extends ChiselFlatSpec {
   "A failing assertion" should "fail the testbench" in {
-    assert(!execute{ new FailingAssertTester })
+    assert(!runTester{ new FailingAssertTester })
   }
   "A succeeding assertion" should "not fail the testbench" in {
-    assert(execute{ new SucceedingAssertTester })
+    assertTesterPasses{ new SucceedingAssertTester }
   }
 }

--- a/src/test/scala/chiselTests/BitwiseOps.scala
+++ b/src/test/scala/chiselTests/BitwiseOps.scala
@@ -21,7 +21,7 @@ class BitwiseOpsTester(w: Int, _a: Int, _b: Int) extends BasicTester {
 class BitwiseOpsSpec extends ChiselPropSpec {
   property("All bit-wise ops should return the correct result") {
     forAll(safeUIntPair) { case(w: Int, a: Int, b: Int) =>
-      assert(execute{ new BitwiseOpsTester(w, a, b) })
+      assertTesterPasses{ new BitwiseOpsTester(w, a, b) }
     }
   }
 }

--- a/src/test/scala/chiselTests/BlackBox.scala
+++ b/src/test/scala/chiselTests/BlackBox.scala
@@ -1,0 +1,68 @@
+// See LICENSE for license details.
+
+package chiselTests
+
+import java.io.File
+import org.scalatest._
+import Chisel._
+import Chisel.testers.BasicTester
+
+class BlackBoxInverter extends BlackBox {
+  val io = new Bundle() {
+    val in = Bool(INPUT)
+    val out = Bool(OUTPUT)
+  }
+}
+
+class BlackBoxPassthrough extends BlackBox {
+  val io = new Bundle() {
+    val in = Bool(INPUT)
+    val out = Bool(OUTPUT)
+  }
+}
+
+class BlackBoxTester extends BasicTester {
+  val blackBoxPos = Module(new BlackBoxInverter)
+  val blackBoxNeg = Module(new BlackBoxInverter)
+
+  blackBoxPos.io.in := UInt(1)
+  blackBoxNeg.io.in := UInt(0)
+
+  assert(blackBoxNeg.io.out === UInt(1))
+  assert(blackBoxPos.io.out === UInt(0))
+  stop()
+}
+
+/** Instantiate multiple BlackBoxes with similar interfaces but different
+  * functionality. Used to detect failures in BlackBox naming and module
+  * deduplication.
+  */
+
+class MultiBlackBoxTester extends BasicTester {
+  val blackBoxInvPos = Module(new BlackBoxInverter)
+  val blackBoxInvNeg = Module(new BlackBoxInverter)
+  val blackBoxPassPos = Module(new BlackBoxPassthrough)
+  val blackBoxPassNeg = Module(new BlackBoxPassthrough)
+
+  blackBoxInvPos.io.in := UInt(1)
+  blackBoxInvNeg.io.in := UInt(0)
+  blackBoxPassPos.io.in := UInt(1)
+  blackBoxPassNeg.io.in := UInt(0)
+
+  assert(blackBoxInvNeg.io.out === UInt(1))
+  assert(blackBoxInvPos.io.out === UInt(0))
+  assert(blackBoxPassNeg.io.out === UInt(0))
+  assert(blackBoxPassPos.io.out === UInt(1))
+  stop()
+}
+
+class BlackBoxSpec extends ChiselFlatSpec {
+  "A BlackBoxed inverter" should "work" in {
+    assertTesterPasses({ new BlackBoxTester },
+        Seq("/BlackBoxTest.v"))
+  }
+  "Multiple BlackBoxes" should "work" in {
+    assertTesterPasses({ new MultiBlackBoxTester },
+        Seq("/BlackBoxTest.v"))
+  }
+}

--- a/src/test/scala/chiselTests/BundleWire.scala
+++ b/src/test/scala/chiselTests/BundleWire.scala
@@ -38,7 +38,7 @@ class BundleWireSpec extends ChiselPropSpec {
 
   property("All vec elems should match the inputs") {
     forAll(vecSizes, safeUInts, safeUInts) { (n: Int, x: Int, y: Int) =>
-      assert(execute{ new BundleWireTester(n, x, y) })
+      assertTesterPasses{ new BundleWireTester(n, x, y) }
     }
   }
 }

--- a/src/test/scala/chiselTests/ChiselSpec.scala
+++ b/src/test/scala/chiselTests/ChiselSpec.scala
@@ -2,6 +2,7 @@
 
 package chiselTests
 
+import java.io.File
 import org.scalatest._
 import org.scalatest.prop._
 import org.scalacheck._
@@ -9,9 +10,15 @@ import Chisel._
 import Chisel.testers._
 
 /** Common utility functions for Chisel unit tests. */
-trait ChiselRunners {
-  def execute(t: => BasicTester): Boolean = TesterDriver.execute(() => t)
+trait ChiselRunners extends Assertions {
+  def runTester(t: => BasicTester, additionalVResources: Seq[String] = Seq()): Boolean = {
+    TesterDriver.execute(() => t, additionalVResources)
+  }
+  def assertTesterPasses(t: => BasicTester, additionalVResources: Seq[String] = Seq()): Unit = {
+    assert(runTester(t, additionalVResources))
+  }
   def elaborate(t: => Module): Unit = Driver.elaborate(() => t)
+
 }
 
 /** Spec base class for BDD-style testers. */

--- a/src/test/scala/chiselTests/ComplexAssign.scala
+++ b/src/test/scala/chiselTests/ComplexAssign.scala
@@ -46,7 +46,7 @@ class ComplexAssignTester(enList: List[Boolean], re: Int, im: Int) extends Basic
 class ComplexAssignSpec extends ChiselPropSpec {
   property("All complex assignments should return the correct result") {
     forAll(enSequence(2), safeUInts, safeUInts) { (en: List[Boolean], re: Int, im: Int) =>
-      assert(execute{ new ComplexAssignTester(en, re, im) })
+      assertTesterPasses{ new ComplexAssignTester(en, re, im) }
     }
   }
 }

--- a/src/test/scala/chiselTests/Counter.scala
+++ b/src/test/scala/chiselTests/Counter.scala
@@ -37,14 +37,14 @@ class WrapTester(max: Int) extends BasicTester {
 
 class CounterSpec extends ChiselPropSpec {
   property("Counter should count up") {
-    forAll(smallPosInts) { (max: Int) => assert(execute{ new CountTester(max) }) }
+    forAll(smallPosInts) { (max: Int) => assertTesterPasses{ new CountTester(max) } }
   }
 
   property("Counter can be en/disabled") {
-    forAll(safeUInts) { (seed: Int) => assert(execute{ new EnableTester(seed) }) }
+    forAll(safeUInts) { (seed: Int) => assertTesterPasses{ new EnableTester(seed) } }
   }
 
   property("Counter should wrap") {
-    forAll(smallPosInts) { (max: Int) => assert(execute{ new WrapTester(max) }) }
+    forAll(smallPosInts) { (max: Int) => assertTesterPasses{ new WrapTester(max) } }
   }
 }

--- a/src/test/scala/chiselTests/Decoder.scala
+++ b/src/test/scala/chiselTests/Decoder.scala
@@ -42,7 +42,7 @@ class DecoderSpec extends ChiselPropSpec {
 
   property("BitPat wildcards should be usable in decoding") {
     forAll(nPairs(4)){ (pairs: List[(String, String)]) =>
-      assert(execute{ new DecoderTester(pairs) })
+      assertTesterPasses{ new DecoderTester(pairs) }
     }
   }
 }

--- a/src/test/scala/chiselTests/GCD.scala
+++ b/src/test/scala/chiselTests/GCD.scala
@@ -54,7 +54,7 @@ class GCDSpec extends ChiselPropSpec {
 
   property("GCDTester should return the correct result") {
     forAll (gcds) { (a: Int, b: Int, z: Int) =>
-      assert(execute{ new GCDTester(a, b, z) })
+      assertTesterPasses{ new GCDTester(a, b, z) }
     }
   }
 }

--- a/src/test/scala/chiselTests/MulLookup.scala
+++ b/src/test/scala/chiselTests/MulLookup.scala
@@ -34,7 +34,7 @@ class MulLookupSpec extends ChiselPropSpec {
 
   property("Mul lookup table should return the correct result") {
     forAll(smallPosInts, smallPosInts) { (x: Int, y: Int) =>
-      assert(execute{ new MulLookupTester(3, x, y) })
+      assertTesterPasses{ new MulLookupTester(3, x, y) }
     }
   }
 }

--- a/src/test/scala/chiselTests/OptionBundle.scala
+++ b/src/test/scala/chiselTests/OptionBundle.scala
@@ -46,12 +46,12 @@ class InvalidOptionBundleTester() extends BasicTester {
 
 class OptionBundleSpec extends ChiselFlatSpec {
   "A Bundle with an Option field" should "work properly if the Option field is not None" in {
-    assert(execute { new SomeOptionBundleTester(true) })
-    assert(execute { new SomeOptionBundleTester(false) })
+    assertTesterPasses { new SomeOptionBundleTester(true) }
+    assertTesterPasses { new SomeOptionBundleTester(false) }
   }
 
   "A Bundle with an Option field" should "compile if the Option field is None" in {
-    assert(execute { new NoneOptionBundleTester() })
+    assertTesterPasses { new NoneOptionBundleTester() }
   }
 
   "A Bundle with an Option field" should "assert out accessing a None Option field" in {

--- a/src/test/scala/chiselTests/ParameterizedModule.scala
+++ b/src/test/scala/chiselTests/ParameterizedModule.scala
@@ -36,6 +36,6 @@ class ParameterizedModuleTester() extends BasicTester {
 
 class ParameterizedModuleSpec extends ChiselFlatSpec {
   "Different parameterized modules" should "have different behavior" in {
-    assert(execute{ new ParameterizedModuleTester() })
+    assertTesterPasses(new ParameterizedModuleTester())
   }
 }

--- a/src/test/scala/chiselTests/Printf.scala
+++ b/src/test/scala/chiselTests/Printf.scala
@@ -21,9 +21,9 @@ class MultiPrintfTester() extends BasicTester {
 
 class PrintfSpec extends ChiselFlatSpec {
   "A printf with a single argument" should "run" in {
-    assert(execute{ new SinglePrintfTester })
+    assertTesterPasses { new SinglePrintfTester }
   }
   "A printf with multiple arguments" should "run" in {
-    assert(execute{ new MultiPrintfTester })
+    assertTesterPasses { new MultiPrintfTester }
   }
 }

--- a/src/test/scala/chiselTests/Stop.scala
+++ b/src/test/scala/chiselTests/Stop.scala
@@ -12,6 +12,6 @@ class StopTester() extends BasicTester {
 
 class StopSpec extends ChiselFlatSpec {
   "stop()" should "stop and succeed the testbench" in {
-    assert(execute{ new StopTester })
+    assertTesterPasses { new StopTester }
   }
 }

--- a/src/test/scala/chiselTests/Tbl.scala
+++ b/src/test/scala/chiselTests/Tbl.scala
@@ -51,9 +51,8 @@ class TblTester(w: Int, n: Int, idxs: List[Int], values: List[Int]) extends Basi
 class TblSpec extends ChiselPropSpec {
   property("All table reads should return the previous write") {
     forAll(safeUIntPairN(8)) { case(w: Int, pairs: List[(Int, Int)]) =>
-      require(w > 0)
       val (idxs, values) = pairs.unzip
-      assert(execute{ new TblTester(w, 1 << w, idxs, values) })
+      assertTesterPasses{ new TblTester(w, 1 << w, idxs, values) }
     }
   }
 }

--- a/src/test/scala/chiselTests/Vec.scala
+++ b/src/test/scala/chiselTests/Vec.scala
@@ -44,15 +44,15 @@ class ShiftRegisterTester(n: Int) extends BasicTester {
 class VecSpec extends ChiselPropSpec {
   property("Vecs should be assignable") {
     forAll(safeUIntN(8)) { case(w: Int, v: List[Int]) =>
-      assert(execute{ new ValueTester(w, v) })
+      assertTesterPasses{ new ValueTester(w, v) }
     }
   }
 
   property("Vecs should tabulate correctly") {
-    forAll(smallPosInts) { (n: Int) => assert(execute{ new TabulateTester(n) }) }
+    forAll(smallPosInts) { (n: Int) => assertTesterPasses{ new TabulateTester(n) } }
   }
 
   property("Regs of vecs should be usable as shift registers") {
-    forAll(smallPosInts) { (n: Int) => assert(execute{ new ShiftRegisterTester(n) }) }
+    forAll(smallPosInts) { (n: Int) => assertTesterPasses{ new ShiftRegisterTester(n) } }
   }
 }

--- a/src/test/scala/chiselTests/When.scala
+++ b/src/test/scala/chiselTests/When.scala
@@ -52,9 +52,9 @@ class OverlappedWhenTester() extends BasicTester {
 
 class WhenSpec extends ChiselFlatSpec {
   "When, elsewhen, and otherwise with orthogonal conditions" should "work" in {
-    assert(execute{ new WhenTester })
+    assertTesterPasses{ new WhenTester }
   }
   "When, elsewhen, and otherwise with overlapped conditions" should "work" in {
-    assert(execute{ new OverlappedWhenTester })
+    assertTesterPasses{ new OverlappedWhenTester }
   }
 }


### PR DESCRIPTION
Make sure #78 is merged first, otherwise this will pull in changes from there too.
Mainly changes assert(execute(...)) to assertTesterPasses(...), because execute is already used by ScalaTest and don't work nicely with the optional additionalVSources.
