### PR TITLE
Add '=/=' to bits, which does the same as '!='

### DIFF
--- a/src/main/scala/Chisel/Bits.scala
+++ b/src/main/scala/Chisel/Bits.scala
@@ -302,6 +302,7 @@ sealed class UInt private[Chisel] (dir: Direction, width: Width, lit: Option[ULi
   def <= (other: UInt): Bool = compop(LessEqOp, other)
   def >= (other: UInt): Bool = compop(GreaterEqOp, other)
   def != (other: UInt): Bool = compop(NotEqualOp, other)
+  def =/= (other: UInt): Bool = compop(NotEqualOp, other)
   def === (other: UInt): Bool = compop(EqualOp, other)
   def unary_! : Bool = this === Bits(0)
 


### PR DESCRIPTION
It looks like this is in Chisel2 now, and some stuff in uncore is using it.
IIRC, we decided that this was the correct thing to do for some Scala style
reasons.
