### PR TITLE
Add a dummy chiselMain

### DIFF
--- a/src/main/scala/Chisel/Main.scala
+++ b/src/main/scala/Chisel/Main.scala
@@ -1,0 +1,8 @@
+// See LICENSE for details
+
+package Chisel
+
+@deprecated("chiselMain doesn't exist in Chisel3", "3.0") object chiselMain {
+  def apply[T <: Module](args: Array[String], gen: () => T) =
+    Predef.assert(false)
+}


### PR DESCRIPTION
We don't have this in Chisel3, but for compatibility with berkeley-hardfloat I
want a function header.  This lets me keep the test harness in upstream
hardfloat so I don't have to fork it for Chisel3 testing.
