### PR TITLE
Create new IR subpackage, and make FIRRTL a subpackage of IR.

### DIFF
--- a/src/main/scala/Chisel/Aggregate.scala
+++ b/src/main/scala/Chisel/Aggregate.scala
@@ -7,7 +7,7 @@ import scala.collection.mutable.{ArrayBuffer, HashSet, LinkedHashMap}
 
 import internal._
 import internal.Builder.pushCommand
-import firrtl._
+import ir.firrtl._
 
 /** An abstract class for data types that solely consist of (are an aggregate
   * of) other Data objects.

--- a/src/main/scala/Chisel/Bits.scala
+++ b/src/main/scala/Chisel/Bits.scala
@@ -4,8 +4,8 @@ package Chisel
 
 import internal._
 import internal.Builder.pushOp
-import firrtl._
-import firrtl.PrimOp._
+import ir.firrtl._
+import ir.firrtl.PrimOp._
 
 /** Element is a leaf data type: it cannot contain other Data objects. Example
   * uses are for representing primitive data types, like integers and bits.

--- a/src/main/scala/Chisel/CoreUtil.scala
+++ b/src/main/scala/Chisel/CoreUtil.scala
@@ -4,7 +4,7 @@ package Chisel
 
 import internal._
 import internal.Builder.pushCommand
-import firrtl._
+import ir.firrtl._
 
 object assert {
   /** Checks for a condition to be valid in the circuit at all times. If the

--- a/src/main/scala/Chisel/Data.scala
+++ b/src/main/scala/Chisel/Data.scala
@@ -4,7 +4,7 @@ package Chisel
 
 import internal._
 import internal.Builder.pushCommand
-import firrtl._
+import ir.firrtl._
 
 sealed abstract class Direction(name: String) {
   override def toString: String = name

--- a/src/main/scala/Chisel/Driver.scala
+++ b/src/main/scala/Chisel/Driver.scala
@@ -6,7 +6,7 @@ import scala.sys.process._
 import java.io._
 
 import internal._
-import firrtl._
+import ir.firrtl._
 
 trait BackendCompilationUtilities {
   /** Create a temporary directory with the prefix name. Exists here because it doesn't in Java 6.

--- a/src/main/scala/Chisel/Mem.scala
+++ b/src/main/scala/Chisel/Mem.scala
@@ -4,7 +4,7 @@ package Chisel
 
 import internal._
 import internal.Builder.pushCommand
-import firrtl._
+import ir.firrtl._
 
 object Mem {
   @deprecated("Mem argument order should be size, t; this will be removed by the official release", "chisel3")

--- a/src/main/scala/Chisel/Module.scala
+++ b/src/main/scala/Chisel/Module.scala
@@ -7,7 +7,7 @@ import scala.collection.mutable.{ArrayBuffer, HashSet}
 import internal._
 import internal.Builder.pushCommand
 import internal.Builder.dynamicContext
-import firrtl._
+import ir.firrtl._
 
 object Module {
   /** A wrapper method that all Module instantiations must be wrapped in

--- a/src/main/scala/Chisel/Reg.scala
+++ b/src/main/scala/Chisel/Reg.scala
@@ -4,7 +4,7 @@ package Chisel
 
 import internal._
 import internal.Builder.pushCommand
-import firrtl._
+import ir.firrtl._
 
 object Reg {
   private[Chisel] def makeType[T <: Data](t: T = null, next: T = null, init: T = null): T = {

--- a/src/main/scala/Chisel/When.scala
+++ b/src/main/scala/Chisel/When.scala
@@ -4,7 +4,7 @@ package Chisel
 
 import internal._
 import internal.Builder.pushCommand
-import firrtl._
+import ir.firrtl._
 
 object when {  // scalastyle:ignore object.name
   /** Create a `when` condition block, where whether a block of logic is

--- a/src/main/scala/Chisel/internal/Builder.scala
+++ b/src/main/scala/Chisel/internal/Builder.scala
@@ -6,7 +6,7 @@ import scala.util.DynamicVariable
 import scala.collection.mutable.{ArrayBuffer, HashMap}
 
 import Chisel._
-import Chisel.firrtl._
+import Chisel.ir.firrtl._
 
 private[Chisel] class Namespace(parent: Option[Namespace], keywords: Set[String]) {
   private var i = 0L

--- a/src/main/scala/Chisel/ir/firrtl/Emitter.scala
+++ b/src/main/scala/Chisel/ir/firrtl/Emitter.scala
@@ -1,6 +1,6 @@
 // See LICENSE for license details.
 
-package Chisel.firrtl
+package Chisel.ir.firrtl
 import Chisel._
 
 private class Emitter(circuit: Circuit) {

--- a/src/main/scala/Chisel/ir/firrtl/IR.scala
+++ b/src/main/scala/Chisel/ir/firrtl/IR.scala
@@ -1,6 +1,6 @@
 // See LICENSE for license details.
 
-package Chisel.firrtl
+package Chisel.ir.firrtl
 import Chisel._
 import Chisel.internal._
 

--- a/src/main/scala/Chisel/testers/BasicTester.scala
+++ b/src/main/scala/Chisel/testers/BasicTester.scala
@@ -5,7 +5,7 @@ import Chisel._
 
 import internal._
 import internal.Builder.pushCommand
-import firrtl._
+import ir.firrtl._
 
 class BasicTester extends Module {
   // The testbench has no IOs, rather it should communicate using printf, assert, and stop.


### PR DESCRIPTION
 (This prevents namespace collisions with Scala FIRRTL implementation).

Currently, Scala FIRRTL uses the package name "firrtl". This causes a problem when writing FIRRTL passes because it often makes sense to do:

``` scala
import Chisel._
import firrtl._
```

It seems unlikely that people will ever want to do `import Chisel.ir._`

I think it makes most sense to add an intermediate subpackage that can contain any targets of Chisel 3 (even if firrtl is the only one we ever add). Of course, I'm not sure if "ir" is the right name for this package, perhaps "target" or "backend" or "output" might be better?

It also might make sense to rename the Scala firrtl package, but my best reading of style guidelines suggests "firrtl" is the best name for it. We could do "Firrtl" to be consistent with "Chisel."

Feedback would be appreciated.
