### PR TITLE
Add some Chisel2 driver emulation methods

### DIFF
--- a/src/main/scala/Chisel/Driver.scala
+++ b/src/main/scala/Chisel/Driver.scala
@@ -113,4 +113,7 @@ object Driver extends BackendCompilationUtilities {
     w.close()
     f
   }
+
+  // FIXME: This is hard coded and should come in from a command-line argument
+  def targetDir(): String = { "vsim/generated-src" }
 }

--- a/src/main/scala/Chisel/FileSystemUtilities.scala
+++ b/src/main/scala/Chisel/FileSystemUtilities.scala
@@ -1,0 +1,10 @@
+// See LICENSE for details
+
+package Chisel
+
+@deprecated("FileSystemUtilities doesn't exist in chisel3", "3.0.0")
+trait FileSystemUtilities {
+  def createOutputFile(name: String) = {
+    new java.io.FileWriter(Driver.targetDir + "/" + name)
+  }
+}

--- a/src/main/scala/Chisel/Main.scala
+++ b/src/main/scala/Chisel/Main.scala
@@ -2,7 +2,15 @@
 
 package Chisel
 
+import java.io.File
+
 @deprecated("chiselMain doesn't exist in Chisel3", "3.0") object chiselMain {
   def apply[T <: Module](args: Array[String], gen: () => T) =
     Predef.assert(false)
+
+  def run[T <: Module] (args: Array[String], gen: () => T) = {
+    def circuit = Driver.elaborate(gen)
+    def output_file = new File(Driver.targetDir + "/" + circuit.name + ".fir")
+    Driver.dumpFirrtl(circuit, Option(output_file))
+  }
 }

--- a/src/main/scala/Chisel/throwException.scala
+++ b/src/main/scala/Chisel/throwException.scala
@@ -1,0 +1,11 @@
+// See LICENSE for details
+
+package Chisel
+
+@deprecated("throwException doesn't exist in Chisel3", "3.0.0")
+object throwException {
+  def apply(s: String, t: Throwable = null) = {
+    val xcpt = new Exception(s, t)
+    throw xcpt
+  }
+}


### PR DESCRIPTION
I don't want to have to maintain a big rocket-chip fork to have it run
through Chisel3, so instead I'm adding back some of the driver routines
that existed in Chisel2.
