### PR TITLE
Add Module.currentModule for getting a reference to the current Module

### DIFF
--- a/chiselFrontend/src/main/scala/chisel3/core/Module.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Module.scala
@@ -75,6 +75,8 @@ object Module {
   def clock: Clock = Builder.forcedClock
   /** Returns the implicit Reset */
   def reset: Reset = Builder.forcedReset
+  /** Returns the current Module */
+  def currentModule: Option[BaseModule] = Builder.currentModule
 }
 
 /** Abstract base class for Modules, an instantiable organizational unit for RTL.

--- a/src/test/scala/chiselTests/Module.scala
+++ b/src/test/scala/chiselTests/Module.scala
@@ -3,6 +3,7 @@
 package chiselTests
 
 import chisel3._
+import chisel3.experimental.{withClock, withReset}
 
 class SimpleIO extends Bundle {
   val in  = Input(UInt(32.W))
@@ -26,36 +27,12 @@ class ModuleVec(val n: Int) extends Module {
   }
 }
 
-/*
-class ModuleVecTester(c: ModuleVec) extends Tester(c) {
-  for (t <- 0 until 16) {
-    val test_ins = Array.fill(c.n){ rnd.nextInt(256) }
-    for (i <- 0 until c.n)
-      poke(c.io.ins(i), test_ins(i))
-    step(1)
-    for (i <- 0 until c.n)
-      expect(c.io.outs(i), test_ins(i) + 1)
-  }
-}
-*/
-
 class ModuleWire extends Module {
   val io = IO(new SimpleIO)
   val inc = Wire(chiselTypeOf(Module(new PlusOne).io))
   inc.in := io.in
   io.out := inc.out
 }
-
-/*
-class ModuleWireTester(c: ModuleWire) extends Tester(c) {
-  for (t <- 0 until 16) {
-    val test_in = rnd.nextInt(256)
-    poke(c.io.in, test_in)
-    step(1)
-    expect(c.io.out, test_in + 1)
-  }
-}
-*/
 
 class ModuleWhen extends Module {
   val io = IO(new Bundle {
@@ -121,5 +98,32 @@ class ModuleSpec extends ChiselPropSpec {
     (the [ChiselException] thrownBy {
       elaborate { new ModuleRewrap }
     }).getMessage should include("This is probably due to rewrapping a Module instance")
+  }
+
+  property("object Module.clock should return a reference to the currently in scope clock") {
+    elaborate(new Module {
+      val io = IO(new Bundle {
+        val clock2 = Input(Clock())
+      })
+      assert(Module.clock eq this.clock)
+      withClock(io.clock2) { assert(Module.clock eq io.clock2) }
+    })
+  }
+  property("object Module.reset should return a reference to the currently in scope reset") {
+    elaborate(new Module {
+      val io = IO(new Bundle {
+        val reset2 = Input(Bool())
+      })
+      assert(Module.reset eq this.reset)
+      withReset(io.reset2) { assert(Module.reset eq io.reset2) }
+    })
+  }
+  property("object Module.currentModule should return an Option reference to the current Module") {
+    def checkModule(mod: Module): Boolean = Module.currentModule.map(_ eq mod).getOrElse(false)
+    elaborate(new Module {
+      val io = IO(new Bundle { })
+      assert(Module.currentModule.get eq this)
+      assert(checkModule(this))
+    })
   }
 }


### PR DESCRIPTION
Resolves #809 and https://github.com/freechipsproject/rocket-chip/pull/1363

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**

Add ability to get a reference to the current Module