### PR TITLE
Fixes inconsistencies declaring FixedPoint and Interval literals

### DIFF
--- a/core/src/main/scala/chisel3/package.scala
+++ b/core/src/main/scala/chisel3/package.scala
@@ -4,6 +4,7 @@ import chisel3.internal.firrtl.BinaryPoint
 
 /** This package contains the main chisel3 API.
  */
+//scalastyle:off number.of.methods
 package object chisel3 {    // scalastyle:ignore package.object.name
   import internal.firrtl.{Port, Width}
   import internal.Builder
@@ -117,6 +118,9 @@ package object chisel3 {    // scalastyle:ignore package.object.name
 
   implicit class fromBigDecimalToLiteral(bigDecimal: BigDecimal)
     extends experimental.FixedPoint.Implicits.fromBigDecimalToLiteral(bigDecimal)
+
+  implicit class fromBigIntToLiteralFixedPoint(bigInt: BigInt)
+    extends experimental.FixedPoint.Implicits.fromBigIntToLiteral(bigInt)
 
   // Interval is experimental for now, but we alias the implicit conversion classes here
   //  to minimize disruption with existing code.

--- a/src/test/scala/chiselTests/FixedPointSpec.scala
+++ b/src/test/scala/chiselTests/FixedPointSpec.scala
@@ -167,4 +167,11 @@ class FixedPointSpec extends ChiselPropSpec with Utils {
   property("Bit extraction on literals should work for all non-negative indices") {
     assertTesterPasses(new FixedPointLitExtractTester)
   }
+  property("FixedPoint literals generated from equivalent values should all be the same") {
+    BigDecimal(-2.0).F(2.BP).litToBigDecimal should be(BigDecimal(-2.0)) // From BigDecimal
+    (-2.0).F(2.BP).litToBigDecimal should be(BigDecimal(-2.0)) // From Double
+    BigInt(-2).F(2.BP).litToBigDecimal should be(BigDecimal(-2.0)) // From BigInt
+    (-2L).F(2.BP).litToBigDecimal should be(BigDecimal(-2.0)) // From Long
+    (-2).F(2.BP).litToBigDecimal should be(BigDecimal(-2.0)) // From Int
+  }
 }

--- a/src/test/scala/chiselTests/IntervalSpec.scala
+++ b/src/test/scala/chiselTests/IntervalSpec.scala
@@ -962,4 +962,18 @@ class IntervalSpec extends AnyFreeSpec with Matchers with ChiselRunners {
       })
     }
   }
+
+  "Interval literals generated from equivalent values should all be the same" in {
+    BigDecimal(-2.0).I(2.BP).litToBigDecimal should be(BigDecimal(-2.0)) // From BigDecimal
+    (-2.0).I(2.BP).litToBigDecimal should be(BigDecimal(-2.0)) // From Double
+    BigInt(-2).I(2.BP).litToBigDecimal should be(BigDecimal(-2.0)) // From BigInt
+    (-2L).I(2.BP).litToBigDecimal should be(BigDecimal(-2.0)) // From Long
+    (-2).I(2.BP).litToBigDecimal should be(BigDecimal(-2.0)) // From Int
+
+    BigDecimal(-2.0).I(range"[?,?].2").litToBigDecimal should be(BigDecimal(-2.0)) // From BigDecimal
+    (-2.0).I(range"[?,?].2").litToBigDecimal should be(BigDecimal(-2.0)) // From Double
+    BigInt(-2).I(range"[?,?].2").litToBigDecimal should be(BigDecimal(-2.0)) // From BigInt
+    (-2L).I(range"[?,?].2").litToBigDecimal should be(BigDecimal(-2.0)) // From Long
+    (-2).I(range"[?,?].2").litToBigDecimal should be(BigDecimal(-2.0)) // From Int
+  }
 }


### PR DESCRIPTION
Now all follow a what you see is what you get pattern.
Formerly Longs and BigInts would be interpreted as a bit pattern. Now they are handled as the literal value.
Also FixedPoints could not be created from a BigInt, now they can.
Creating literals using the range"range-string" interpolator has been made more robust.
Tests have been added to show the new behavior

| Statement  | Original Hardware Value |  PR  Hardware Value | 
| ------------- | ------------- |  ------------- |
| BigInt(-2).I(2.BP)       | -0.50  |  -2.0  |
| -2L.I(2.BP)       | -0.50  |  -2.0  |
| BigDecimal(-2.0).I(2.BP)  | -2.0  | -2.0  | 
| -2.0.I(2.BP)  | -2.0  | -2.0  | 

**Type of change**:  enhancement

**Impact**: Minor API modification
Prior to this fix. Declaring a literal for `Interval` like `3.0.I(2.BP)` would give you a literal value of 3.00. But 
declaring `3.I(2.BP)` would create a literal with the value 0.75. This is inconsistent and counter intuitive. `FixedPoint`
literals shared the same inconsistency

**Development Phase**: implementation
With these changes `FixedPoint` and `Interval` literal declaration follow the convention of least surprise.

**Release Notes**
Creation of Interval and FixedPoint literals is consistent across the different number types BigDecimal, BigInt, Double, Long, Int. Now 