### PR TITLE
Make Data GC-able

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
         if: matrix.scala == '2.12.13'
         run: sbt ++${{ matrix.scala }} docs/mdoc
       - name: Test
-        run: sbt ++${{ matrix.scala }} test
+        run: sbt ++${{ matrix.scala }} test noPluginTests/test
       - name: Binary compatibility
         run: sbt ++${{ matrix.scala }} mimaReportBinaryIssues
 

--- a/build.sbt
+++ b/build.sbt
@@ -201,6 +201,11 @@ lazy val chisel = (project in file(".")).
     )
   )
 
+lazy val noPluginTests = (project in file ("no-plugin-tests")).
+  dependsOn(chisel).
+  settings(commonSettings: _*).
+  settings(chiselSettings: _*)
+
 lazy val docs = project       // new documentation project
   .in(file("docs-target")) // important: it must not be docs/
   .dependsOn(chisel)

--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -20,7 +20,8 @@ class AliasedAggregateFieldException(message: String) extends ChiselException(me
   * of) other Data objects.
   */
 sealed abstract class Aggregate extends Data {
-  private[chisel3] override def bind(target: Binding, parentDirection: SpecifiedDirection) {
+  private[chisel3] override def bind(target: Binding, parentDirection: SpecifiedDirection): Unit = {
+    _parent.foreach(_.addId(this))
     binding = target
 
     val resolvedDirection = SpecifiedDirection.fromParent(parentDirection, specifiedDirection)
@@ -166,7 +167,8 @@ sealed class Vec[T <: Data] private[chisel3] (gen: => T, val length: Int)
     case _ => false
   }
 
-  private[chisel3] override def bind(target: Binding, parentDirection: SpecifiedDirection) {
+  private[chisel3] override def bind(target: Binding, parentDirection: SpecifiedDirection): Unit = {
+    _parent.foreach(_.addId(this))
     binding = target
 
     val resolvedDirection = SpecifiedDirection.fromParent(parentDirection, specifiedDirection)

--- a/core/src/main/scala/chisel3/BlackBox.scala
+++ b/core/src/main/scala/chisel3/BlackBox.scala
@@ -81,6 +81,8 @@ package experimental {
         id._onModuleClose
       }
 
+      closeUnboundIds(names)
+
       val firrtlPorts = getModulePorts map {port => Port(port, port.specifiedDirection)}
       val component = DefBlackBox(this, name, firrtlPorts, SpecifiedDirection.Unspecified, params)
       _component = Some(component)

--- a/core/src/main/scala/chisel3/Data.scala
+++ b/core/src/main/scala/chisel3/Data.scala
@@ -339,13 +339,14 @@ abstract class Data extends HasId with NamedComponent with SourceInfoDoc {
   private[chisel3] final def isSynthesizable: Boolean = _binding.map {
     case ChildBinding(parent) => parent.isSynthesizable
     case _: TopBinding => true
-    case _: SampleElementBinding[_] => false
+    case (_: SampleElementBinding[_] | _: MemTypeBinding[_]) => false
   }.getOrElse(false)
 
   private[chisel3] def topBindingOpt: Option[TopBinding] = _binding.flatMap {
     case ChildBinding(parent) => parent.topBindingOpt
     case bindingVal: TopBinding => Some(bindingVal)
     case SampleElementBinding(parent) => parent.topBindingOpt
+    case _: MemTypeBinding[_] => None
   }
 
   private[chisel3] def topBinding: TopBinding = topBindingOpt.get
@@ -355,7 +356,7 @@ abstract class Data extends HasId with NamedComponent with SourceInfoDoc {
     * node is the top-level.
     * binding and direction are valid after this call completes.
     */
-  private[chisel3] def bind(target: Binding, parentDirection: SpecifiedDirection = SpecifiedDirection.Unspecified)
+  private[chisel3] def bind(target: Binding, parentDirection: SpecifiedDirection = SpecifiedDirection.Unspecified): Unit
 
   // Both _direction and _resolvedUserDirection are saved versions of computed variables (for
   // efficiency, avoid expensive recomputation of frequent operations).

--- a/core/src/main/scala/chisel3/Element.scala
+++ b/core/src/main/scala/chisel3/Element.scala
@@ -17,7 +17,8 @@ abstract class Element extends Data {
   def widthKnown: Boolean = width.known
   def name: String = getRef.name
 
-  private[chisel3] override def bind(target: Binding, parentDirection: SpecifiedDirection) {
+  private[chisel3] override def bind(target: Binding, parentDirection: SpecifiedDirection): Unit = {
+    _parent.foreach(_.addId(this))
     binding = target
     val resolvedDirection = SpecifiedDirection.fromParent(parentDirection, specifiedDirection)
     direction = ActualDirection.fromSpecified(resolvedDirection)

--- a/core/src/main/scala/chisel3/Mem.scala
+++ b/core/src/main/scala/chisel3/Mem.scala
@@ -35,6 +35,7 @@ object Mem {
     }
     val mt  = t.cloneTypeFull
     val mem = new Mem(mt, size)
+    mt.bind(MemTypeBinding(mem))
     pushCommand(DefMemory(sourceInfo, mem, mt, size))
     mem
   }
@@ -45,6 +46,8 @@ object Mem {
 }
 
 sealed abstract class MemBase[T <: Data](val t: T, val length: BigInt) extends HasId with NamedComponent with SourceInfoDoc {
+  _parent.foreach(_.addId(this))
+
   // REVIEW TODO: make accessors (static/dynamic, read/write) combinations consistent.
 
   /** Creates a read accessor into the memory with static addressing. See the
@@ -174,6 +177,7 @@ object SyncReadMem {
     }
     val mt  = t.cloneTypeFull
     val mem = new SyncReadMem(mt, size, ruw)
+    mt.bind(MemTypeBinding(mem))
     pushCommand(DefSeqMemory(sourceInfo, mem, mt, size, ruw))
     mem
   }

--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -209,6 +209,8 @@ package experimental {
     */
   // TODO: seal this?
   abstract class BaseModule extends HasId {
+    _parent.foreach(_.addId(this))
+
     //
     // Builder Internals - this tracks which Module RTL construction belongs to.
     //
@@ -380,6 +382,17 @@ package experimental {
       }
 
       names
+    }
+
+    /** Invokes _onModuleClose on HasIds found via reflection but not bound to hardware
+      * (thus not part of _ids)
+      * This maintains old naming behavior for non-hardware Data
+      */
+    private[chisel3] def closeUnboundIds(names: HashMap[HasId, String]): Unit = {
+      val idLookup = _ids.toSet
+      for ((id, _) <- names if !idLookup(id)) {
+        id._onModuleClose
+      }
     }
 
     /** Compatibility function. Allows Chisel2 code which had ports without the IO wrapper to

--- a/core/src/main/scala/chisel3/RawModule.scala
+++ b/core/src/main/scala/chisel3/RawModule.scala
@@ -98,6 +98,8 @@ abstract class RawModule(implicit moduleCompileOptions: CompileOptions)
       id._onModuleClose
     }
 
+    closeUnboundIds(names)
+
     val firrtlPorts = getModulePorts map { port: Data =>
       // Special case Vec to make FIRRTL emit the direction of its
       // element.

--- a/core/src/main/scala/chisel3/experimental/Analog.scala
+++ b/core/src/main/scala/chisel3/experimental/Analog.scala
@@ -45,7 +45,8 @@ final class Analog private (private[chisel3] val width: Width) extends Element {
 
   // Define setter/getter pairing
   // Analog can only be bound to Ports and Wires (and Unbound)
-  private[chisel3] override def bind(target: Binding, parentDirection: SpecifiedDirection) {
+  private[chisel3] override def bind(target: Binding, parentDirection: SpecifiedDirection): Unit = {
+    _parent.foreach(_.addId(this))
     SpecifiedDirection.fromParent(parentDirection, specifiedDirection) match {
       case SpecifiedDirection.Unspecified | SpecifiedDirection.Flip =>
       case x => throwException(s"Analog may not have explicit direction, got '$x'")

--- a/core/src/main/scala/chisel3/internal/Binding.scala
+++ b/core/src/main/scala/chisel3/internal/Binding.scala
@@ -110,6 +110,10 @@ case class ChildBinding(parent: Data) extends Binding {
 case class SampleElementBinding[T <: Data](parent: Vec[T]) extends Binding {
   def location = parent.topBinding.location
 }
+/** Special binding for Mem types */
+case class MemTypeBinding[T <: Data](parent: MemBase[T]) extends Binding {
+  def location: Option[BaseModule] = parent._parent
+}
 // A DontCare element has a specific Binding, somewhat like a literal.
 // It is a source (RHS). It may only be connected/applied to sinks.
 case class DontCareBinding() extends UnconstrainedBinding

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -84,7 +84,6 @@ trait InstanceId {
 private[chisel3] trait HasId extends InstanceId {
   private[chisel3] def _onModuleClose: Unit = {}
   private[chisel3] val _parent: Option[BaseModule] = Builder.currentModule
-  _parent.foreach(_.addId(this))
 
   private[chisel3] val _id: Long = Builder.idGen.next
 

--- a/no-plugin-tests/src/test/scala/chisel3/testers/TestUtils.scala
+++ b/no-plugin-tests/src/test/scala/chisel3/testers/TestUtils.scala
@@ -1,0 +1,1 @@
+../../../../../../src/test/scala/chisel3/testers/TestUtils.scala

--- a/no-plugin-tests/src/test/scala/chiselTests/ChiselSpec.scala
+++ b/no-plugin-tests/src/test/scala/chiselTests/ChiselSpec.scala
@@ -1,0 +1,1 @@
+../../../../../src/test/scala/chiselTests/ChiselSpec.scala

--- a/no-plugin-tests/src/test/scala/chiselTests/InstanceNameSpec.scala
+++ b/no-plugin-tests/src/test/scala/chiselTests/InstanceNameSpec.scala
@@ -1,0 +1,1 @@
+../../../../../src/test/scala/chiselTests/InstanceNameSpec.scala

--- a/src/test/scala/chiselTests/ChiselSpec.scala
+++ b/src/test/scala/chiselTests/ChiselSpec.scala
@@ -90,62 +90,8 @@ trait ChiselRunners extends Assertions with BackendCompilationUtilities {
 /** Spec base class for BDD-style testers. */
 abstract class ChiselFlatSpec extends AnyFlatSpec with ChiselRunners with Matchers
 
-class ChiselTestUtilitiesSpec extends ChiselFlatSpec {
-  import org.scalatest.exceptions.TestFailedException
-  // Who tests the testers?
-  "assertKnownWidth" should "error when the expected width is wrong" in {
-    val caught = intercept[ChiselException] {
-      assertKnownWidth(7) {
-        Wire(UInt(8.W))
-      }
-    }
-    assert(caught.getCause.isInstanceOf[TestFailedException])
-  }
-
-  it should "error when the width is unknown" in {
-    a [ChiselException] shouldBe thrownBy {
-      assertKnownWidth(7) {
-        Wire(UInt())
-      }
-    }
-  }
-
-  it should "work if the width is correct" in {
-    assertKnownWidth(8) {
-      Wire(UInt(8.W))
-    }
-  }
-
-  "assertInferredWidth" should "error if the width is known" in {
-    val caught = intercept[ChiselException] {
-      assertInferredWidth(8) {
-        Wire(UInt(8.W))
-      }
-    }
-    assert(caught.getCause.isInstanceOf[TestFailedException])
-  }
-
-  it should "error if the expected width is wrong" in {
-    a [TestFailedException] shouldBe thrownBy {
-      assertInferredWidth(8) {
-        val w = Wire(UInt())
-        w := 2.U(2.W)
-        w
-      }
-    }
-  }
-
-  it should "pass if the width is correct" in {
-    assertInferredWidth(4) {
-      val w = Wire(UInt())
-      w := 2.U(4.W)
-      w
-    }
-  }
-}
-
 /** Spec base class for property-based testers. */
-class ChiselPropSpec extends PropSpec with ChiselRunners with ScalaCheckPropertyChecks with Matchers {
+abstract class ChiselPropSpec extends PropSpec with ChiselRunners with ScalaCheckPropertyChecks with Matchers {
 
   // Constrain the default number of instances generated for every use of forAll.
   implicit override val generatorDrivenConfig: PropertyCheckConfiguration =

--- a/src/test/scala/chiselTests/ChiselTestUtilitiesSpec.scala
+++ b/src/test/scala/chiselTests/ChiselTestUtilitiesSpec.scala
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiselTests
+
+import chisel3._
+import org.scalatest.exceptions.TestFailedException
+
+class ChiselTestUtilitiesSpec extends ChiselFlatSpec {
+  // Who tests the testers?
+  "assertKnownWidth" should "error when the expected width is wrong" in {
+    val caught = intercept[ChiselException] {
+      assertKnownWidth(7) {
+        Wire(UInt(8.W))
+      }
+    }
+    assert(caught.getCause.isInstanceOf[TestFailedException])
+  }
+
+  it should "error when the width is unknown" in {
+    a [ChiselException] shouldBe thrownBy {
+      assertKnownWidth(7) {
+        Wire(UInt())
+      }
+    }
+  }
+
+  it should "work if the width is correct" in {
+    assertKnownWidth(8) {
+      Wire(UInt(8.W))
+    }
+  }
+
+  "assertInferredWidth" should "error if the width is known" in {
+    val caught = intercept[ChiselException] {
+      assertInferredWidth(8) {
+        Wire(UInt(8.W))
+      }
+    }
+    assert(caught.getCause.isInstanceOf[TestFailedException])
+  }
+
+  it should "error if the expected width is wrong" in {
+    a [TestFailedException] shouldBe thrownBy {
+      assertInferredWidth(8) {
+        val w = Wire(UInt())
+        w := 2.U(2.W)
+        w
+      }
+    }
+  }
+
+  it should "pass if the width is correct" in {
+    assertInferredWidth(4) {
+      val w = Wire(UInt())
+      w := 2.U(4.W)
+      w
+    }
+  }
+}
+

--- a/src/test/scala/chiselTests/CompatibilitySpec.scala
+++ b/src/test/scala/chiselTests/CompatibilitySpec.scala
@@ -451,6 +451,18 @@ class CompatibiltySpec extends ChiselFlatSpec with ScalaCheckDrivenPropertyCheck
     ChiselStage.elaborate(new Foo)
   }
 
+  it should "support data-types of mixed directionality" in {
+    class Foo extends Module {
+      val io = IO(new Bundle {})
+      val tpe = new Bundle { val foo = UInt(OUTPUT, width = 4); val bar = UInt(width = 4) }
+      // NOTE for some reason, the old bug this hit did not occur when `tpe` is inlined
+      val mem = SeqMem(tpe, 8)
+      mem(3.U)
+
+    }
+    ChiselStage.elaborate((new Foo))
+  }
+
   behavior of "debug"
 
   it should "still exist" in {


### PR DESCRIPTION
As you can see in the diff of `Builder.scala`, currently, every single `HasId` (which `Data`, `BaseModule` and `MemBase` extend) is added to the `_ids` of its parent Module. Thus, no `HasId` can ever be garbage collected. This is obviously terrible for memory use, especially because we create a lot of unnecessary `Data` objects that are never used. By changing the behavior so that `BaseModule` and `MemBase` are still added, but `Data` is only added upon binding, now `Data` can be GC-ed.

This PR also adds a new test-suite `noPluginTests`. This is essentially a Scala project that just recompiles some of the normal Chisel tests without the Chisel compiler plugin and runs them. I found that the tests `InstanceNameSpec.scala` failed without the plugin, so I made a minimal project that just uses symlinks to build it (and necessary dependencies) without the plugin. (Note: `ChiselTestUtilitiesSpec` simply got split out of `ChiselSpec` because I didn't want those tests to also run in `noPluginTests`).

There are 2 changes related to making GC-able:
1. Add MemTypeBinding
2. Add `closeUnboundIds`

To explain these, I need to touch on some of the internals of Chisel
* Refs are used for determining the "names" of things, mainly for emitting FIRRTL
* Refs of Record elements are set upon binding or by _onModuleClose
* _onModuleClose is only called on Records added to the _ids of a Module
* Data are only added to _ids of Module on binding (new behavior in this PR)

(1) Mem types are technically not hardware, but are Data needed for emitting FIRRTL, so I added a pseudo-binding for them.
For (2), there are some legacy APIs still in use (see `InstanceNameSpec`) that need the refs to be set to work. `closeUnBoundIds` ensures that at least any reflectively namable Records, even unbound, have `_onModuleClose` called on them. It's a little weird but at least it's a fairly self-contained way to handle this. If we deprecate and remove these legacy APIs (not part of this PR), we can ultimately remove it.

## Measurements

### Validation

I validated this with a simple Module to create lots of useless `Data`:
```scala
class MyModule(n: Int, gen: () => Data) extends Module {
  val io = IO(new Bundle {
    val in  = Input(UInt(8.W))
    val out = Output(UInt(8.W))
  })

  for (i <- 0 until n) {
    for (j <- 0 until n) {
      for (k <- 0 until n) {
        for (l <- 0 until n) {
          gen()
        }
      }
    }
  }

  io.out := io.in
}
```

Using `openjdk version "1.8.0_265"`, I validated these numbers on Feb 9, 2021.
Comparing this PR (commit 0a0d7c6aac4326f2127d6d95efa5a4e10c81946c) vs. master (commit 2ed343e2305b7c22000f3f46fa81d73a369907eb)

| n | gen | min `-Xmx` master | min `-Xmx` this PR |
| --- | --- | --- | --- |
| 50 | `Bool()` |  1270M | 6M |
| 30 | `new MyBundle` | > 500M | 10M |
| 50 | `Vec(4, Bool())` | > 2G | 10M |

### Results in Practice


(these measurements are old, I'm rerunning)

Resident Set Size (RSS) is the system measured memory use which includes the virtual machine as measured by `/usr/bin/time -v`

| design | min `-Xmx` master | RSS master (MiB) | min `-Xmx` this PR | RSS this PR (MiB) |
| --- | --- | --- | --- | --- |
| medium | 400M | 1034 | 300M | 930 |
| large | 3600M | 4857 | 2600M | 3652 |
| very large | 17G | 19394 | 14G | 16400 |

In summary, a reduction of 10-25% in total memory use. It's actually smaller than I expected but I think there are other issues in Chisel and a couple in the SiFive generator that when also fixed, will result in much bigger reductions. Regardless this is a pretty big improvement on its own.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [NA] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
  - performance improvement           
  - code refactoring                  

#### API Impact

No impact

#### Backend Code Generation Impact

No impact

(TODO fix Record field name sanitation bug)

#### Desired Merge Strategy

 - Squash

#### Release Notes

Decrease memory use of Chisel by 10%+

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.0, 3.5.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
