### PR TITLE
(encore) Builder: use LazyLogging.logger.warn to print elaboration message

### DIFF
--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -10,6 +10,7 @@ import chisel3.internal.firrtl._
 import chisel3.internal.naming._
 import _root_.firrtl.annotations.{CircuitName, ComponentName, IsMember, ModuleName, Named, ReferenceTarget}
 import chisel3.internal.Builder.Prefix
+import logger.LazyLogging
 
 import scala.collection.mutable
 
@@ -324,7 +325,7 @@ private[chisel3] class DynamicContext() {
   val namingStack = new NamingStack
 }
 
-private[chisel3] object Builder {
+private[chisel3] object Builder extends LazyLogging {
 
   // Represents the current state of the prefixes given
   type Prefix = List[String]
@@ -638,11 +639,11 @@ private[chisel3] object Builder {
   private [chisel3] def build[T <: RawModule](f: => T, dynamicContext: DynamicContext): (Circuit, T) = {
     dynamicContextVar.withValue(Some(dynamicContext)) {
       checkScalaVersion()
-      errors.info("Elaborating design...")
+      logger.warn("Elaborating design...")
       val mod = f
       mod.forceName(None, mod.name, globalNamespace)
       errors.checkpoint()
-      errors.info("Done elaborating.")
+      logger.warn("Done elaborating.")
 
       (Circuit(components.last.name, components, annotations), mod)
     }

--- a/core/src/main/scala/chisel3/internal/Error.scala
+++ b/core/src/main/scala/chisel3/internal/Error.scala
@@ -102,6 +102,7 @@ private[chisel3] class ErrorLog {
     errors += new Warning(m, getUserLineNumber)
 
   /** Emit an informational message */
+  @deprecated("This method will be removed in 3.5", "3.4")
   def info(m: String): Unit =
     println(new Info("[%2.3f] %s".format(elapsedTime/1e3, m), None))
 

--- a/src/test/scala/chiselTests/stage/ChiselMainSpec.scala
+++ b/src/test/scala/chiselTests/stage/ChiselMainSpec.scala
@@ -132,6 +132,16 @@ class ChiselMainSpec extends AnyFeatureSpec with GivenWhenThen with Matchers wit
   }
 
   info("As a Chisel user")
+  info("I compile a design")
+  Feature("show elaborating message") {
+    runStageExpectFiles(
+      ChiselMainTest(args = Array("-X", "high"),
+        generator = Some(classOf[SameTypesModule]),
+        stdout = Some("Done elaborating.")
+      )
+    )
+  }
+
   info("I screw up and compile some bad code")
   Feature("Stack trace trimming") {
     Seq(


### PR DESCRIPTION
This PR is the encore of #1474 and add test and deprecation notes requested by review. 

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [x] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.0, 3.5.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
