### PR TITLE
Fix RegInit of Bundle lits

### DIFF
--- a/core/src/main/scala/chisel3/Element.scala
+++ b/core/src/main/scala/chisel3/Element.scala
@@ -40,16 +40,6 @@ abstract class Element extends Data {
   override def litOption: Option[BigInt] = litArgOption.map(_.num)
   private[chisel3] def litIsForcedWidth: Option[Boolean] = litArgOption.map(_.forcedWidth)
 
-  // provide bits-specific literal handling functionality here
-  override private[chisel3] def ref: Arg = topBindingOpt match {
-    case Some(ElementLitBinding(litArg)) => litArg
-    case Some(BundleLitBinding(litMap)) => litMap.get(this) match {
-      case Some(litArg) => litArg
-      case _ => throwException(s"internal error: DontCare should be caught before getting ref")
-    }
-    case _ => super.ref
-  }
-
   private[chisel3] def legacyConnect(that: Data)(implicit sourceInfo: SourceInfo): Unit = {
     // If the source is a DontCare, generate a DefInvalid for the sink,
     //  otherwise, issue a Connect.


### PR DESCRIPTION
Implemented by folding Element.ref into Data.ref. Element.ref had
special handling for literals, but because Bundles can also be literals,
there were code paths that tried to get the ref of a Bundle literal
which was non-existent. Now, all literals are handled together.

Because FIRRTL does not have support for Bundle literals, Bundle literal
refs are implemented by materializing a Wire.

This also handles the DontCare fields of partially initialized Bundle literals in the same way.

Fixes #1671

I could not find a good way to fix the related issue with Bundle literals and Printable. Given the v3.4.1 release going out tomorrow, I thought it prudent to at least get this fix in.

This basically does 2 things:
1. Support literals and DontCares in `requireVisible` and improve error message when that fails
2. Unify `Element.ref` and `Data.ref` - previously, `Element` was overriding `def ref` to add support for literals, since we also have aggregate literals (for now, just Bundle literals), I thought it better to handle all the logic in 1 place.

The approach is to materialize a `Wire` whenever a Bundle literal or `DontCare` shows up. `RegInit` was the motivator for this work, but any Expression (except direct connection) with an uninitialized field from a Bundle literal has a similar issue. For example, from the tests:
```scala
(new MyBundle).Lit(_.a -> 42.U).b || true.B
```
You get a similar issue to #1671 on the `||`.

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [NA] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

  - bug fix     
 - code refactoring 

#### API Impact

No impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

  - Squash

#### Release Notes

Fix bug where RegInit could not accept Bundle literals

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.0, 3.5.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
