### PR TITLE
Switch to using Github Actions CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,45 @@
+name: Continuous Integration
+
+on: [pull_request]
+
+jobs:
+  ci:
+    name: ci
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        scala: [2.12.12, 2.11.12]
+    container:
+      image: ucbbar/chisel3-tools
+      options: --user github --entrypoint /bin/bash
+    env:
+      CONTAINER_HOME: /home/github
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Scala
+        uses: olafurpg/setup-scala@v10
+        with:
+          java-version: adopt@1.8
+      - name: Cache Scala
+        uses: coursier/cache-action@v5
+      - name: Documentation (Scala 2.12 only)
+        if: matrix.scala == '2.12.12'
+        run: sbt ++${{ matrix.scala }} docs/mdoc
+      - name: Test
+        run: sbt ++${{ matrix.scala }} test
+      - name: Binary compatibility
+        run: sbt ++${{ matrix.scala }} mimaReportBinaryIssues
+
+
+  # Sentinel job to simplify how we specify which checks need to pass in branch
+  # protection and in Mergify
+  #
+  # When adding new jobs, please add them to `needs` below
+  all_tests_passed:
+    name: "all tests passed"
+    needs: [ci]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo Success!

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,135 +1,107 @@
 pull_request_rules:
-  - name: remove outdated reviews
-    conditions:
-      - base=master
-    actions:
-      dismiss_reviews:
+- name: automatic squash-and-merge on CI success and review
+  conditions:
+  - status-success=all tests passed
+  - '#approved-reviews-by>=1'
+  - '#changes-requested-reviews-by=0'
+  - base=master
+  - label="Please Merge"
+  - label!="DO NOT MERGE"
+  - label!="bp-conflict"
+  actions:
+    merge:
+      method: squash
+      strict: smart
+      strict_method: merge
+- name: backport to 3.4.x
+  conditions:
+  - merged
+  - base=master
+  - milestone=3.4.x
+  actions:
+    backport:
+      branches:
+      - 3.4.x
+      ignore_conflicts: true
+      label_conflicts: bp-conflict
+    label:
+      add:
+      - Backported
+- name: backport to 3.3.x, 3.4.x
+  conditions:
+  - merged
+  - base=master
+  - milestone=3.3.x
+  actions:
+    backport:
+      branches:
+      - 3.3.x
+      - 3.4.x
+      ignore_conflicts: true
+      label_conflicts: bp-conflict
+    label:
+      add:
+      - Backported
+- name: backport to 3.2.x, 3.3.x, 3.4.x
+  conditions:
+  - merged
+  - base=master
+  - milestone=3.2.x
+  actions:
+    backport:
+      branches:
+      - 3.2.x
+      - 3.3.x
+      - 3.4.x
+      ignore_conflicts: true
+      label_conflicts: bp-conflict
+    label:
+      add:
+      - Backported
+- name: label Mergify backport PR
+  conditions:
+  - body~=This is an automated backport of pull request \#\d+ done by Mergify
+  actions:
+    label:
+      add:
+      - Backport
+- name: automatic squash-and-mege of 3.2.x backport PRs
+  conditions:
+  - status-success=all tests passed
+  - '#changes-requested-reviews-by=0'
+  - base=3.2.x
+  - label="Backport"
+  - label!="DO NOT MERGE"
+  - label!="bp-conflict"
+  actions:
+    merge:
+      method: squash
+      strict: smart
+      strict_method: merge
+- name: automatic squash-and-mege of 3.3.x backport PRs
+  conditions:
+  - status-success=all tests passed
+  - '#changes-requested-reviews-by=0'
+  - base=3.3.x
+  - label="Backport"
+  - label!="DO NOT MERGE"
+  - label!="bp-conflict"
+  actions:
+    merge:
+      method: squash
+      strict: smart
+      strict_method: merge
+- name: automatic squash-and-mege of 3.4.x backport PRs
+  conditions:
+  - status-success=all tests passed
+  - '#changes-requested-reviews-by=0'
+  - base=3.4.x
+  - label="Backport"
+  - label!="DO NOT MERGE"
+  - label!="bp-conflict"
+  actions:
+    merge:
+      method: squash
+      strict: smart
+      strict_method: merge
 
-pull_request_rules:
-  - name: automatic squash-and-merge on CI success and review
-    conditions:
-      - "status-success=ci/circleci: build-firrtl"
-      - "status-success=ci/circleci: build-prep"
-      - "status-success=ci/circleci: test-chisel-2_11"
-      - "status-success=ci/circleci: test-chisel-2_12"
-      - status-success=license/cla
-      - "#approved-reviews-by>=1"
-      - "#changes-requested-reviews-by=0"
-      - base=master
-      - label="Please Merge"
-      - label!="DO NOT MERGE"
-      - label!="bp-conflict"
-    actions:
-      merge:
-        method: squash
-        strict: smart
-        strict_method: merge
-
-  - name: backport to 3.4.x
-    conditions:
-      - merged
-      - base=master
-      - milestone=3.4.x
-    actions:
-      backport:
-        branches:
-          - 3.4.x
-        ignore_conflicts: True
-        label_conflicts: "bp-conflict"
-      label:
-        add: [Backported]
-
-  - name: backport to 3.3.x and 3.4.x
-    conditions:
-      - merged
-      - base=master
-      - milestone=3.3.x
-    actions:
-      backport:
-        branches:
-          - 3.3.x
-          - 3.4.x
-        ignore_conflicts: True
-        label_conflicts: "bp-conflict"
-      label:
-        add: [Backported]
-
-  - name: backport to 3.2.x, 3.3.x, and 3.4.x
-    conditions:
-      - merged
-      - base=master
-      - milestone=3.2.x
-    actions:
-      backport:
-        branches:
-          - 3.2.x
-          - 3.3.x
-          - 3.4.x
-        ignore_conflicts: True
-        label_conflicts: "bp-conflict"
-      label:
-        add: [Backported]
-
-  - name: label Mergify backport PR
-    conditions:
-      - body~=This is an automated backport of pull request \#\d+ done by Mergify
-    actions:
-      label:
-        add: [Backport]
-
-  - name: automatic squash-and-merge of 3.4.x backport PRs
-    conditions:
-      - "status-success=ci/circleci: build-firrtl"
-      - "status-success=ci/circleci: build-prep"
-      - "status-success=ci/circleci: test-chisel-2_11"
-      - "status-success=ci/circleci: test-chisel-2_12"
-      - "status-success=ci/circleci: check-binary-compatibility"
-      - status-success=license/cla
-      - "#changes-requested-reviews-by=0"
-      - base=3.4.x
-      - label="Backport"
-      - label!="DO NOT MERGE"
-      - label!="bp-conflict"
-    actions:
-      merge:
-        method: squash
-        strict: smart
-        strict_method: merge
-
-  - name: automatic squash-and-merge of 3.3.x backport PRs
-    conditions:
-      - "status-success=ci/circleci: build-firrtl"
-      - "status-success=ci/circleci: build-prep"
-      - "status-success=ci/circleci: test-chisel-2_11"
-      - "status-success=ci/circleci: test-chisel-2_12"
-      - "status-success=ci/circleci: check-binary-compatibility"
-      - status-success=license/cla
-      - "#changes-requested-reviews-by=0"
-      - base=3.3.x
-      - label="Backport"
-      - label!="DO NOT MERGE"
-      - label!="bp-conflict"
-    actions:
-      merge:
-        method: squash
-        strict: smart
-        strict_method: merge
-
-  - name: automatic squash-and-merge of 3.2.x backport PRs
-    conditions:
-      - "status-success=ci/circleci: build-firrtl"
-      - "status-success=ci/circleci: build-prep"
-      - "status-success=ci/circleci: test-chisel-2_11"
-      - "status-success=ci/circleci: test-chisel-2_12"
-      - "status-success=ci/circleci: check-binary-compatibility"
-      - status-success=license/cla
-      - "#changes-requested-reviews-by=0"
-      - base=3.2.x
-      - label="Backport"
-      - label!="DO NOT MERGE"
-      - label!="bp-conflict"
-    actions:
-      merge:
-        method: squash
-        strict: smart
-        strict_method: merge

--- a/build.sbt
+++ b/build.sbt
@@ -147,6 +147,13 @@ lazy val plugin = (project in file("plugin")).
     },
     // Only publish for Scala 2.12
     publish / skip := !scalaVersion.value.startsWith("2.12")
+  ).
+  settings(
+    mimaPreviousArtifacts := {
+      // Not published for 2.11, do not try to check binary compatibility with a 2.11 artifact
+      if (scalaVersion.value.startsWith("2.11")) Set()
+      else Set()
+    }
   )
 
 lazy val usePluginSettings = Seq(
@@ -163,7 +170,8 @@ lazy val usePluginSettings = Seq(
 lazy val macros = (project in file("macros")).
   settings(name := "chisel3-macros").
   settings(commonSettings: _*).
-  settings(publishSettings: _*)
+  settings(publishSettings: _*).
+  settings(mimaPreviousArtifacts := Set())
 
 lazy val firrtlRef = ProjectRef(workspaceDirectory / "firrtl", "firrtl")
 
@@ -177,6 +185,7 @@ lazy val core = (project in file("core")).
     buildInfoKeys := Seq[BuildInfoKey](buildInfoPackage, version, scalaVersion, sbtVersion)
   ).
   settings(publishSettings: _*).
+  settings(mimaPreviousArtifacts := Set()).
   settings(
     name := "chisel3-core",
     scalacOptions := scalacOptions.value ++ Seq(
@@ -205,6 +214,7 @@ lazy val chisel = (project in file(".")).
   dependsOn(core).
   aggregate(macros, core, plugin).
   settings(
+    mimaPreviousArtifacts := Set(),
     libraryDependencies += defaultVersions("treadle") % "test",
     scalacOptions in Test ++= Seq("-language:reflectiveCalls"),
     scalacOptions in Compile in doc ++= Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -20,5 +20,7 @@ addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.2.5" )
 
 addSbtPlugin("com.eed3si9n" % "sbt-sriracha" % "0.1.0")
 
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.8.1")
+
 // From FIRRTL for building from source
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.19")


### PR DESCRIPTION
~~Currently WIP,~~ this is partially in the interest of reducing the number of CI vendors for Chisel Working Group Projects. Once this is done we can turn on auto publishing of SNAPSHOTs as in https://github.com/chipsalliance/treadle/pull/277

Notably, this no longer builds dependencies (`firrtl` and `treadle`) from source. Those projects publish up-to-date `SNAPSHOT`s on every push to a release branch and master, so there's no need to build them.

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [NA] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [NA] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

   - code refactoring

#### API Impact

No impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

 - Squash

#### Release Notes


### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.0, 3.5.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
