### PR TITLE
Relax upper type bound on doNotDedup

### DIFF
--- a/core/src/main/scala/chisel3/Annotation.scala
+++ b/core/src/main/scala/chisel3/Annotation.scala
@@ -3,8 +3,8 @@
 package chisel3.experimental
 
 import scala.language.existentials
-import chisel3.internal.{Builder, InstanceId, LegacyModule}
-import chisel3.{CompileOptions, Data}
+import chisel3.internal.{Builder, InstanceId}
+import chisel3.{CompileOptions, Data, RawModule}
 import firrtl.Transform
 import firrtl.annotations._
 import firrtl.options.Unserializable
@@ -78,7 +78,7 @@ object doNotDedup {
     * @param module The module to be marked
     * @return Unmodified signal `module`
     */
-   def apply[T <: LegacyModule](module: T)(implicit compileOptions: CompileOptions): Unit = {
+   def apply[T <: RawModule](module: T)(implicit compileOptions: CompileOptions): Unit = {
     annotate(new ChiselAnnotation { def toFirrtl = NoDedupAnnotation(module.toNamed) })
   }
 }


### PR DESCRIPTION
Change the upper type bound on the doNotDedup type parameter to
RawModule from LegacyModule (which is Module). This enables the
utility to be used on both MultiIOModule and RawModule.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>

### Contributor Checklist

- [n/a] Did you add Scaladoc to every public function/method?
- [n/a] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [n/a] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
- new feature/API

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

This extends the API for `doNotDedup` to work on more types of modules.

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

None.

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
- Squash: The PR will be squashed and merged (choose this if you have no preference.
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

- Change doNotDedup to work on RawModule and MultiIOModule

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.0, 3.5.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
