### PR TITLE
Make Maven show chisel3 as apache-2.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -57,8 +57,8 @@ lazy val publishSettings = Seq (
   pomExtra := <url>http://chisel.eecs.berkeley.edu/</url>
     <licenses>
       <license>
-        <name>BSD-style</name>
-        <url>http://www.opensource.org/licenses/bsd-license.php</url>
+        <name>apache-v2</name>
+        <url>https://opensource.org/licenses/Apache-2.0</url>
         <distribution>repo</distribution>
       </license>
     </licenses>

--- a/build.sc
+++ b/build.sc
@@ -87,7 +87,7 @@ trait CommonModule extends CrossSbtModule with PublishModule {
     description = artifactName(),
     organization = "edu.berkeley.cs",
     url = "https://www.chisel-lang.org",
-    licenses = Seq(License.`BSD-3-Clause`),
+    licenses = Seq(License.`Apache-2.0`),
     versionControl = VersionControl.github("freechipsproject", "chisel3"),
     developers = Seq(
       Developer("jackbackrack", "Jonathan Bachrach", "https://eecs.berkeley.edu/~jrb/")


### PR DESCRIPTION
Fix settings so maven will show license as apache 2.0
- fix build.sbt
- fix build.sc

### Contributor Checklist

- [-] Did you add Scaladoc to every public function/method?
- [-] Did you add at least one test demonstrating the PR?
- [-] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [-] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [-] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [ x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

License Issue

#### API Impact

None

#### Backend Code Generation Impact

No code gen implications

#### Desired Merge Strategy

Squash

#### Release Notes

This fixes the problem where Maven says that chisel3 is bsd license, when it actually is apache-2.0

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.0, 3.5.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
