### PR TITLE
Bump SNAPSHOT and SNAPSHOT dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,8 +29,8 @@ def javacOptionsVersion(scalaVersion: String): Seq[String] = {
 }
 
 val defaultVersions = Map(
-  "firrtl" -> "edu.berkeley.cs" %% "firrtl" % "1.4-SNAPSHOT",
-  "treadle" -> "edu.berkeley.cs" %% "treadle" % "1.3-SNAPSHOT"
+  "firrtl" -> "edu.berkeley.cs" %% "firrtl" % "1.5-SNAPSHOT",
+  "treadle" -> "edu.berkeley.cs" %% "treadle" % "1.5-SNAPSHOT"
 )
 
 lazy val commonSettings = Seq (
@@ -39,7 +39,7 @@ lazy val commonSettings = Seq (
     Resolver.sonatypeRepo("releases")
   ),
   organization := "edu.berkeley.cs",
-  version := "3.4-SNAPSHOT",
+  version := "3.5-SNAPSHOT",
   autoAPIMappings := true,
   scalaVersion := "2.12.12",
   crossScalaVersions := Seq("2.12.12", "2.11.12"),

--- a/build.sc
+++ b/build.sc
@@ -11,11 +11,11 @@ object chisel3 extends mill.Cross[chisel3CrossModule]("2.11.12", "2.12.12")
 // Please retain it.
 // Provide a managed dependency on X if -DXVersion="" is supplied on the command line.
 val defaultVersions = Map(
-  "firrtl" -> "1.4-SNAPSHOT"
+  "firrtl" -> "1.5-SNAPSHOT"
 )
 
 val testDefaultVersions = Map(
-  "treadle" -> "1.3-SNAPSHOT"
+  "treadle" -> "1.5-SNAPSHOT"
 )
 
 def getVersion(dep: String, org: String = "edu.berkeley.cs") = {
@@ -46,7 +46,7 @@ trait CommonModule extends CrossSbtModule with PublishModule {
 
   override def ivyDeps = super.ivyDeps() ++ firrtlIvyDeps
 
-  def publishVersion = "3.4-SNAPSHOT"
+  def publishVersion = "3.5-SNAPSHOT"
 
   // 2.12.10 -> Array("2", "12", "10") -> "12" -> 12
   protected def majorVersion = crossScalaVersion.split('.')(1).toInt


### PR DESCRIPTION
### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [NA] Did you add at least one test demonstrating the PR?
- [NA] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [NA] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [NA] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
- version bumping

#### API Impact

This ensures that master is now `3.5-SNAPSHOT` so that `3.4.x` can publish `3.4-SNAPSHOT`

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

 - Squash

#### Release Notes


### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.0, 3.5.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
