### PR TITLE
add ShiftRegisters to expose register inside ShiftRegister.

### DIFF
--- a/src/main/scala/chisel3/util/Reg.scala
+++ b/src/main/scala/chisel3/util/Reg.scala
@@ -64,45 +64,21 @@ object ShiftRegisters
   /** Returns a sequence of delayed input signal registers from 1 to n.
     *
     * @param in input to delay
-    * @param n number of cycles to delay
+    * @param n  number of cycles to delay
     * @param en enable the shift
     *
     */
-  def apply[T <: Data](in: T, n: Int, en: Bool = true.B): Seq[T] = {
-    if (n != 0) {
-      val rs = Seq.fill(n)(Reg(chiselTypeOf(in)))
-      when(en) {
-        rs.foldLeft(in)((in, out) => {
-          out := in
-          out
-        })
-      }
-      rs
-    } else {
-      Seq(in)
-    }
-  }
+  def apply[T <: Data](in: T, n: Int, en: Bool = true.B): Seq[T] =
+    Seq.iterate(in, n + 1)(util.RegEnable(_, en)).drop(1)
 
   /** Returns delayed input signal registers with reset initialization from 1 to n.
     *
-    * @param in input to delay
-    * @param n number of cycles to delay
+    * @param in        input to delay
+    * @param n         number of cycles to delay
     * @param resetData reset value for each register in the shift
-    * @param en enable the shift
+    * @param en        enable the shift
     *
     */
-  def apply[T <: Data](in: T, n: Int, resetData: T, en: Bool): Seq[T] = {
-    if (n != 0) {
-      val rs = Seq.fill(n)(RegInit(chiselTypeOf(in), resetData))
-      when(en) {
-        rs.foldLeft(in)((in, out) => {
-          out := in
-          out
-        })
-      }
-      rs
-    } else {
-      Seq(in)
-    }
-  }
+  def apply[T <: Data](in: T, n: Int, resetData: T, en: Bool): Seq[T] =
+    Seq.iterate(in, n + 1)(util.RegEnable(_, resetData, en)).drop(1)
 }

--- a/src/test/scala/chiselTests/Reg.scala
+++ b/src/test/scala/chiselTests/Reg.scala
@@ -69,3 +69,21 @@ class ShiftRegisterSpec extends ChiselPropSpec {
     forAll(smallPosInts) { (shift: Int) => assertTesterPasses{ new ShiftResetTester(shift) } }
   }
 }
+
+class ShiftsTester(n: Int) extends BasicTester {
+  val (cntVal, done) = Counter(true.B, n)
+  val start = 23.U
+  val srs = ShiftRegisters(cntVal + start, n)
+  when(RegNext(done)) {
+    srs.zipWithIndex.foreach{ case (data, index) =>
+      assert(data === (23 + n - 1 - index).U)
+    }
+    stop()
+  }
+}
+
+class ShiftRegistersSpec extends ChiselPropSpec {
+  property("ShiftRegisters should shift") {
+    forAll(smallPosInts) { (shift: Int) => assertTesterPasses{ new ShiftsTester(shift) } }
+  }
+}


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement
 - bug fix
 - new feature/API

#### API Impact
This PR adds API `ShiftRegisters` to expose each register inside the original ShiftRegister, which only return the last instance of register.
This PR enable rename, annotate internal registers for a `ShiftRegister`.  

#### Backend Code Generation Impact
Fix bug #1722 

#### Desired Merge Strategy

 - Rebase: You will rebase the PR onto master and it will be merged with a merge commit.

#### Release Notes
API addition: add `ShiftRegisters`, return the sequence of shift register

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.0, 3.5.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
