### PR TITLE
Expose AnnotationSeq to Module.

### DIFF
--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -14,6 +14,7 @@ import chisel3.internal.firrtl._
 import chisel3.internal.sourceinfo.{InstTransform, SourceInfo, UnlocatableSourceInfo}
 import chisel3.experimental.BaseModule
 import _root_.firrtl.annotations.{IsModule, ModuleName, ModuleTarget}
+import _root_.firrtl.AnnotationSeq
 
 object Module extends SourceInfoDoc {
   /** A wrapper method that all Module instantiations must be wrapped in
@@ -84,6 +85,8 @@ object Module extends SourceInfoDoc {
   def reset: Reset = Builder.forcedReset
   /** Returns the current Module */
   def currentModule: Option[BaseModule] = Builder.currentModule
+  /** Returns the global Annotations */
+  def annotationSeq: AnnotationSeq = Builder.annotationSeq
 }
 
 /** Abstract base class for Modules, which behave much like Verilog modules.

--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -85,8 +85,6 @@ object Module extends SourceInfoDoc {
   def reset: Reset = Builder.forcedReset
   /** Returns the current Module */
   def currentModule: Option[BaseModule] = Builder.currentModule
-  /** Returns the global Annotations */
-  def annotationSeq: AnnotationSeq = Builder.annotationSeq
 }
 
 /** Abstract base class for Modules, which behave much like Verilog modules.

--- a/core/src/main/scala/chisel3/aop/Aspect.scala
+++ b/core/src/main/scala/chisel3/aop/Aspect.scala
@@ -12,6 +12,7 @@ import firrtl.AnnotationSeq
   * @tparam T Type of top-level module
   */
 abstract class Aspect[T <: RawModule] extends Annotation with Unserializable with NoTargetAnnotation {
+  var annotations: AnnotationSeq = Seq()
   /** Convert this Aspect to a seq of FIRRTL annotation
     * @param top
     * @return
@@ -22,7 +23,8 @@ abstract class Aspect[T <: RawModule] extends Annotation with Unserializable wit
     * @param top
     * @return
     */
-  private[chisel3] def resolveAspect(top: RawModule): AnnotationSeq = {
+  private[chisel3] def resolveAspect(top: RawModule, remainingAnnotations: AnnotationSeq): AnnotationSeq = {
+    annotations = remainingAnnotations
     toAnnotation(top.asInstanceOf[T])
   }
 }

--- a/core/src/main/scala/chisel3/aop/Aspect.scala
+++ b/core/src/main/scala/chisel3/aop/Aspect.scala
@@ -12,7 +12,10 @@ import firrtl.AnnotationSeq
   * @tparam T Type of top-level module
   */
 abstract class Aspect[T <: RawModule] extends Annotation with Unserializable with NoTargetAnnotation {
-  var annotations: AnnotationSeq = Seq()
+  /** variable to save [[AnnotationSeq]] from [[chisel3.stage.phases.AspectPhase]]
+    * to be used at [[chisel3.aop.injecting.InjectorAspect]], exposes annotations to [[chisel3.internal.DynamicContext]]
+    */
+  private[aop] var annotationsInAspect: AnnotationSeq = Seq()
   /** Convert this Aspect to a seq of FIRRTL annotation
     * @param top
     * @return
@@ -24,7 +27,7 @@ abstract class Aspect[T <: RawModule] extends Annotation with Unserializable wit
     * @return
     */
   private[chisel3] def resolveAspect(top: RawModule, remainingAnnotations: AnnotationSeq): AnnotationSeq = {
-    annotations = remainingAnnotations
+    annotationsInAspect = remainingAnnotations
     toAnnotation(top.asInstanceOf[T])
   }
 }

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -9,7 +9,8 @@ import chisel3.experimental._
 import chisel3.internal.firrtl._
 import chisel3.internal.naming._
 import _root_.firrtl.annotations.{CircuitName, ComponentName, IsMember, ModuleName, Named, ReferenceTarget}
-import _root_.firrtl.annotations.AnnotationUtils.{validComponentName}
+import _root_.firrtl.annotations.AnnotationUtils.validComponentName
+import _root_.firrtl.AnnotationSeq
 import chisel3.internal.Builder.Prefix
 import logger.LazyLogging
 
@@ -305,7 +306,7 @@ private[chisel3] class ChiselContext() {
   var prefixStack: Prefix = Nil
 }
 
-private[chisel3] class DynamicContext() {
+private[chisel3] class DynamicContext(val annotationSeq: AnnotationSeq) {
   val globalNamespace = Namespace.empty
   val components = ArrayBuffer[Component]()
   val annotations = ArrayBuffer[ChiselAnnotation]()
@@ -364,6 +365,7 @@ private[chisel3] object Builder extends LazyLogging {
   def globalNamespace: Namespace = dynamicContext.globalNamespace
   def components: ArrayBuffer[Component] = dynamicContext.components
   def annotations: ArrayBuffer[ChiselAnnotation] = dynamicContext.annotations
+  def annotationSeq: AnnotationSeq = dynamicContext.annotationSeq
   def namingStack: NamingStack = dynamicContext.namingStack
 
   // Puts a prefix string onto the prefix stack
@@ -630,11 +632,6 @@ private[chisel3] object Builder extends LazyLogging {
                 s"Please upgrade to Scala 2.12. See $url"
       deprecated(msg, Some(""))
     }
-  }
-
-
-  def build[T <: RawModule](f: => T): (Circuit, T) = {
-    build(f, new DynamicContext())
   }
 
   private [chisel3] def build[T <: RawModule](f: => T, dynamicContext: DynamicContext): (Circuit, T) = {

--- a/src/main/scala/chisel3/aop/injecting/InjectingAspect.scala
+++ b/src/main/scala/chisel3/aop/injecting/InjectingAspect.scala
@@ -54,7 +54,7 @@ abstract class InjectorAspect[T <: RawModule, M <: RawModule](
     * @return
     */
   final def toAnnotation(modules: Iterable[M], circuit: String, moduleNames: Seq[String]): AnnotationSeq = {
-    val dynamicContext = new DynamicContext()
+    val dynamicContext = new DynamicContext(annotations)
     // Add existing module names into the namespace. If injection logic instantiates new modules
     //  which would share the same name, they will get uniquified accordingly
     moduleNames.foreach { n =>

--- a/src/main/scala/chisel3/aop/injecting/InjectingAspect.scala
+++ b/src/main/scala/chisel3/aop/injecting/InjectingAspect.scala
@@ -54,7 +54,7 @@ abstract class InjectorAspect[T <: RawModule, M <: RawModule](
     * @return
     */
   final def toAnnotation(modules: Iterable[M], circuit: String, moduleNames: Seq[String]): AnnotationSeq = {
-    val dynamicContext = new DynamicContext(annotations)
+    val dynamicContext = new DynamicContext(annotationsInAspect)
     // Add existing module names into the namespace. If injection logic instantiates new modules
     //  which would share the same name, they will get uniquified accordingly
     moduleNames.foreach { n =>

--- a/src/main/scala/chisel3/stage/ChiselAnnotations.scala
+++ b/src/main/scala/chisel3/stage/ChiselAnnotations.scala
@@ -56,11 +56,7 @@ case class ChiselGeneratorAnnotation(gen: () => RawModule) extends NoTargetAnnot
 
   /** Run elaboration on the Chisel module generator function stored by this [[firrtl.annotations.Annotation]]
     */
-  def elaborate: AnnotationSeq  = {
-    val (circuit, dut) = Builder.build(Module(gen()))
-    Seq(ChiselCircuitAnnotation(circuit), DesignAnnotation(dut))
-  }
-
+  def elaborate: AnnotationSeq = (new chisel3.stage.phases.Elaborate).transform(Seq(this))
 }
 
 object ChiselGeneratorAnnotation extends HasShellOptions {

--- a/src/main/scala/chisel3/stage/phases/AspectPhase.scala
+++ b/src/main/scala/chisel3/stage/phases/AspectPhase.scala
@@ -29,7 +29,7 @@ class AspectPhase extends Phase {
       case other => Seq(other)
     }
     if(dut.isDefined) {
-      val newAnnotations = aspects.flatMap { _.resolveAspect(dut.get) }
+      val newAnnotations = aspects.flatMap { _.resolveAspect(dut.get, remainingAnnotations) }
       remainingAnnotations ++ newAnnotations
     } else annotations
   }

--- a/src/main/scala/chisel3/util/experimental/getAnnotations.scala
+++ b/src/main/scala/chisel3/util/experimental/getAnnotations.scala
@@ -1,0 +1,9 @@
+package chisel3.util.experimental
+
+import chisel3.internal.Builder
+import firrtl.AnnotationSeq
+
+object getAnnotations {
+  /** Returns the global Annotations */
+  def apply(): AnnotationSeq = Builder.annotationSeq
+}

--- a/src/test/scala/chiselTests/Module.scala
+++ b/src/test/scala/chiselTests/Module.scala
@@ -3,8 +3,10 @@
 package chiselTests
 
 import chisel3._
-import chisel3.stage.ChiselStage
 import chisel3.experimental.DataMirror
+import chisel3.stage.{ChiselGeneratorAnnotation, ChiselStage, NoRunFirrtlCompilerAnnotation}
+import firrtl.annotations.NoTargetAnnotation
+import firrtl.options.Unserializable
 
 class SimpleIO extends Bundle {
   val in  = Input(UInt(32.W))
@@ -140,6 +142,17 @@ class ModuleSpec extends ChiselPropSpec with Utils {
       assert(checkModule(this))
     })
   }
+
+  property("object chisel3.util.experimental.getAnnotations should return current annotations.") {
+    case class DummyAnnotation() extends NoTargetAnnotation with Unserializable
+    (new ChiselStage).transform(Seq(
+      ChiselGeneratorAnnotation(() => new RawModule {
+        assert(chisel3.util.experimental.getAnnotations().contains(DummyAnnotation()))
+      }),
+      DummyAnnotation(),
+      NoRunFirrtlCompilerAnnotation))
+  }
+
   property("DataMirror.modulePorts should work") {
     ChiselStage.elaborate(new Module {
       val io = IO(new Bundle { })


### PR DESCRIPTION
Resolve #1729
depends on #1730
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement
- new feature/API

#### API Impact

add API `chisel3.util.experimental.getAnnotations` to get `AnnotationSeq` in current phase.

#### Backend Code Generation Impact

None
#### Desired Merge Strategy
- Rebase: You will rebase the PR onto master and it will be merged with a merge commit.

#### Release Notes
Expose AnnotationSeq to Module.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.0, 3.5.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
