### PR TITLE
Add redirect for Scala 2.11 upgrade page

### DIFF
--- a/docs/src/wiki-deprecated/upgrading-from-scala-2-11.md
+++ b/docs/src/wiki-deprecated/upgrading-from-scala-2-11.md
@@ -2,6 +2,8 @@
 layout: docs
 title:  "Upgrading From Scala 2.11"
 section: "chisel3"
+redirect_from:
+  - /chisel3/upgrading-from-scala-2-11.html
 ---
 
 <!-- Prelude -->


### PR DESCRIPTION
The Scala 2.11 deprecation warning in FIRRTL has a link that has been broken for a while: https://github.com/chipsalliance/firrtl/blob/031fe1382660867750e6eeebea5665c137dbccbe/src/main/scala/firrtl/stage/transforms/CheckScalaVersion.scala#L10

This provides a redirect so the link will remain alive.

I've verified this works by building the website locally. I don't know all the details of how Jekyll works, but I figured it out from the documentation on the `jekyll-redirect-from` plugin which just so happens to be part of the website build: https://github.com/jekyll/jekyll-redirect-from

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [NA] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

   - bug fix    

#### API Impact

No impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

   - Squash

#### Release Notes

Fix broken link on website for Scala 2.11 upgrade instructions

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [x] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.0, 3.5.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
