### PR TITLE
Fix incorrect comment in ScalaDoc

### DIFF
--- a/core/src/main/scala/chisel3/Reg.scala
+++ b/core/src/main/scala/chisel3/Reg.scala
@@ -127,7 +127,7 @@ object RegNext {
   * val x = Wire(UInt())
   * val y = Wire(UInt(8.W))
   * val r1 = RegInit(x) // width will be inferred
-  * val r2 = RegInit(y) // width is set to 8
+  * val r2 = RegInit(y) // width will be inferred
   * }}}
   *
   * 3. [[Aggregate]] initializer - width will be set to match the aggregate


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [NA] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

 - documentation

#### API Impact

No impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

 - Squash

#### Release Notes

Fix incorrect example in ScalaDoc for width behavior of RegInit

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [x] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.0, 3.5.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
