### PR TITLE
Remove a buggy type conversion in decoder

### DIFF
--- a/src/main/scala/chisel3/util/experimental/decoder/QMCDecoder.scala
+++ b/src/main/scala/chisel3/util/experimental/decoder/QMCDecoder.scala
@@ -184,7 +184,7 @@ class QMCDecoder extends Decoder {
           if (((defaultTerm.mask >> i) & 1) != 0) {
             logic(addr, addrWidth, cache, simplifyDC(mint, maxt, addrWidth))
           } else {
-            val defbit = (defaultTerm.value.toInt >> i) & 1
+            val defbit = (defaultTerm.value >> i) & 1
             val t = if (defbit == 0) mint else maxt
             val bit = logic(addr, addrWidth, cache, simplify(t, dc, addrWidth))
             if (defbit == 0) bit else ~bit

--- a/src/test/scala/chiselTests/util/experimental/decoder/QMCDecoderSpec.scala
+++ b/src/test/scala/chiselTests/util/experimental/decoder/QMCDecoderSpec.scala
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiselTests.util.experimental.decoder
+
+import chisel3._
+import chisel3.util._
+
+import chisel3.testers.BasicTester
+import chisel3.util.experimental.decoder.QMCDecoder
+import chiselTests.ChiselFlatSpec
+
+
+class QMCDecoderSpec extends ChiselFlatSpec {
+  "Function with more than 32 outputs" should "be simplified correctly" in {
+    assertTesterPasses(new BasicTester {
+      val out = WireDefault(
+        QMCDecoder().decode(
+          addr = WireDefault(1.U(1.W)),
+          default = BitPat("b" + "1" + "0" * 32),
+          mapping = Seq(BitPat("b?") -> BitPat("b" + "?" * 33))
+        )
+      )
+      chisel3.assert(out(32) === 1.U(1.W))
+      stop()
+    })
+  }
+}


### PR DESCRIPTION
Remove a meaningless `toInt` type conversion in `QMCDecoder` which causes a limitation of 32 on the number of output values.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
- bug fix
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact
None.
<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

#### Backend Code Generation Impact
None.
<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
- Squash: The PR will be squashed and merged (choose this if you have no preference.
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.0, 3.5.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
