### PR TITLE
Bump to Scala 2.12.13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        scala: [2.12.12]
+        scala: [2.12.13]
     container:
       image: ucbbar/chisel3-tools
       options: --user github --entrypoint /bin/bash
@@ -32,7 +32,7 @@ jobs:
       - name: Cache Scala
         uses: coursier/cache-action@v5
       - name: Documentation (Scala 2.12 only)
-        if: matrix.scala == '2.12.12'
+        if: matrix.scala == '2.12.13'
         run: sbt ++${{ matrix.scala }} docs/mdoc
       - name: Test
         run: sbt ++${{ matrix.scala }} test

--- a/build.sbt
+++ b/build.sbt
@@ -15,8 +15,8 @@ lazy val commonSettings = Seq (
   organization := "edu.berkeley.cs",
   version := "3.5-SNAPSHOT",
   autoAPIMappings := true,
-  scalaVersion := "2.12.12",
-  crossScalaVersions := Seq("2.12.12"),
+  scalaVersion := "2.12.13",
+  crossScalaVersions := Seq("2.12.13"),
   scalacOptions := Seq("-deprecation", "-feature",
   ),
   libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value,
@@ -92,6 +92,7 @@ lazy val pluginScalaVersions = Seq(
   "2.12.10",
   "2.12.11",
   "2.12.12",
+  "2.12.13",
 )
 
 lazy val plugin = (project in file("plugin")).

--- a/build.sc
+++ b/build.sc
@@ -5,7 +5,7 @@ import coursier.maven.MavenRepository
 import $ivy.`com.lihaoyi::mill-contrib-buildinfo:$MILL_VERSION`
 import mill.contrib.buildinfo.BuildInfo
 
-object chisel3 extends mill.Cross[chisel3CrossModule]("2.12.12")
+object chisel3 extends mill.Cross[chisel3CrossModule]("2.12.13")
 
 // The following stanza is searched for and used when preparing releases.
 // Please retain it.

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -16,7 +16,7 @@ addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.15")
 
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.0")
 
-addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.2.5" )
+addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.2.16" )
 
 addSbtPlugin("com.eed3si9n" % "sbt-sriracha" % "0.1.0")
 


### PR DESCRIPTION
### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [NA] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

   - new feature/API 

#### API Impact

This allows users of the Chisel plugin to use Scala 2.12.13 (plugins require publishing for each minor version)

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

- Squash
- 
#### Release Notes

Bump to Scala 2.12.13, publish chisel3-plugin for 2.12.13.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.0, 3.5.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
