### PR TITLE
Add file line to source link from scaladoc

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -196,7 +196,7 @@ lazy val chisel = (project in file(".")).
           } else {
             s"v${version.value}"
           }
-        s"https://github.com/freechipsproject/chisel3/tree/$branch/€{FILE_PATH}.scala"
+        s"https://github.com/chipsalliance/chisel3/tree/$branch€{FILE_PATH_EXT}#L€{FILE_LINE}"
       }
     )
   )


### PR DESCRIPTION
Very simple change but very helpful when navigating from scaladoc to github.
Also update repo path renaming and use the more universal `€{FILE_PATH_EXT}` rather than `€{FILE_PATH}.scala`

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement
documentation

#### API Impact
None

#### Backend Code Generation Impact
None

#### Desired Merge Strategy
squash

#### Release Notes
Add file line to source link from scaladoc

### Reviewer Checklist (only modified by reviewer)
- [x] Did you add the appropriate labels?
- [x] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.0, 3.5.0) ?
- [x] Did you review?
- [x] Did you check whether all relevant Contributor checkboxes have been checked?
- [x] Did you mark as `Please Merge`?
