### PR TITLE
deprecate Bits

### DIFF
--- a/core/src/main/scala/chisel3/package.scala
+++ b/core/src/main/scala/chisel3/package.scala
@@ -160,7 +160,7 @@ package object chisel3 {
   // (UInt|SInt)\(([_a-zA-Z][_0-9a-zA-Z]*),\s*(?:width\s*=)?\s*(\d+|[_a-zA-Z][_0-9a-zA-Z]*)\)
   //  => $2.as$1($3.W)
 
-  @deprecated("Bits() will return UInt, which is not type-safe, will be removed in 3.5", "Chisel 3.5")
+  @deprecated("Bits() returning UInt is not type-safe; to be removed in 3.5", "Chisel 3.5")
   object Bits extends UIntFactory
   object UInt extends UIntFactory
   object SInt extends SIntFactory

--- a/core/src/main/scala/chisel3/package.scala
+++ b/core/src/main/scala/chisel3/package.scala
@@ -160,6 +160,7 @@ package object chisel3 {
   // (UInt|SInt)\(([_a-zA-Z][_0-9a-zA-Z]*),\s*(?:width\s*=)?\s*(\d+|[_a-zA-Z][_0-9a-zA-Z]*)\)
   //  => $2.as$1($3.W)
 
+  @deprecated("Bits() will return UInt, which is not type-safe, will be removed in 3.5", "Chisel 3.5")
   object Bits extends UIntFactory
   object UInt extends UIntFactory
   object SInt extends SIntFactory


### PR DESCRIPTION
Based on the disscussion on the dev-meeting.
Bits will return UInt, which is a strange API, I think we need to remove this API. Then adding it back after making `abstract class Bits` concrete.
### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [ ] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [ ] Did you state the API impact?
- [ ] Did you specify the code generation impact?
- [ ] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement
- code cleanup 

#### API Impact

deprecate API

#### Backend Code Generation Impact

None

#### Desired Merge Strategy

  - Rebase: You will rebase the PR onto master and it will be merged with a merge commit.

#### Release Notes
  Bits(???) is deprecated.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.0, 3.5.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?