### PR TITLE
VecLiterals First Pass

### DIFF
--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -174,9 +174,6 @@ trait VecFactory extends SourceInfoDoc {
 sealed class Vec[T <: Data] private[chisel3] (gen: => T, val length: Int)
     extends Aggregate with VecLike[T] {
 
-  //TODO: what to do when lit widths are different than gen's width
-  //TODO: fix ordering problems with lits
-
   override def toString: String = {
     val bindingString = topBindingOpt match {
       case Some(VecLitBinding(vecLitBinding)) =>

--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -520,7 +520,7 @@ sealed class Vec[T <: Data] private[chisel3] (gen: => T, val length: Int)
       }
     } // don't convert to a Map yet to preserve duplicate keys
 
-    clone.bind(VecLitBinding(vecLitLinkedMap))
+    clone.bind(VecLitBinding(ListMap(vecLitLinkedMap.toSeq:_*)))
     clone
   }
 }

--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -5,7 +5,7 @@ package chisel3
 import scala.collection.immutable.ListMap
 import scala.collection.mutable.{HashSet, LinkedHashMap}
 import scala.language.experimental.macros
-import chisel3.experimental.{BaseModule, BundleLiteralException, EnumType, VecLiteralException}
+import chisel3.experimental.{BaseModule, BundleLiteralException, ChiselEnum, EnumType, VecLiteralException}
 import chisel3.internal._
 import chisel3.internal.Builder.pushCommand
 import chisel3.internal.firrtl._
@@ -171,8 +171,8 @@ sealed class Vec[T <: Data] private[chisel3] (gen: => T, val length: Int)
   override def toString: String = {
     val bindingString = topBindingOpt match {
       case Some(VecLitBinding(vecLitBinding)) =>
-        val contents = vecLitBinding.map { case (data, lit) =>
-          s"$data=$lit"
+        val contents = vecLitBinding.zipWithIndex.map { case ((data, lit), index) =>
+          s"$index=$lit"
         }.mkString(", ")
         s"($contents"
       case _ => bindingToString

--- a/core/src/main/scala/chisel3/Data.scala
+++ b/core/src/main/scala/chisel3/Data.scala
@@ -391,6 +391,7 @@ abstract class Data extends HasId with NamedComponent with SourceInfoDoc {
     case Some(DontCareBinding()) => s"(DontCare)"
     case Some(ElementLitBinding(litArg)) => s"(unhandled literal)"
     case Some(BundleLitBinding(litMap)) => s"(unhandled bundle literal)"
+    case Some(VecLitBinding(litMap)) => s"(unhandled vec literal)"
   }).getOrElse("")
 
   // Return ALL elements at root of this type.
@@ -489,6 +490,11 @@ abstract class Data extends HasId with NamedComponent with SourceInfoDoc {
         litMap.get(this) match {
           case Some(litArg) => litArg
           case _ => materializeWire() // FIXME FIRRTL doesn't have Bundle literal expressions
+        }
+      case Some(VecLitBinding(litMap)) =>
+        litMap.get(this) match {
+          case Some(litArg) => litArg
+          case _ => materializeWire() // FIXME FIRRTL doesn't have Vec literal expressions
         }
       case Some(DontCareBinding()) =>
         materializeWire() // FIXME FIRRTL doesn't have a DontCare expression so materialize a Wire

--- a/core/src/main/scala/chisel3/Element.scala
+++ b/core/src/main/scala/chisel3/Element.scala
@@ -41,16 +41,6 @@ abstract class Element extends Data {
     case _ => None
   }
 
- //TODO: Delete this, looked like it might be necessary at some point but tests run fine without this.
-//  private[chisel3] def litArgOption: Option[LitArg] = {
-//    topBindingOpt match {
-//      case Some(ElementLitBinding(litArg)) => Some(litArg)
-//      case Some(VecLitBinding(vecLitBinding)) =>
-//        vecLitBinding.get(this)
-//      case _ => None
-//    }
-//  }
-
   override def litOption: Option[BigInt] = litArgOption.map(_.num)
   private[chisel3] def litIsForcedWidth: Option[Boolean] = litArgOption.map(_.forcedWidth)
 

--- a/core/src/main/scala/chisel3/Element.scala
+++ b/core/src/main/scala/chisel3/Element.scala
@@ -29,6 +29,10 @@ abstract class Element extends Data {
       case Some(litArg) => Some(ElementLitBinding(litArg))
       case _ => Some(DontCareBinding())
     }
+    case Some(VecLitBinding(litMap)) => litMap.get(this) match {
+      case Some(litArg) => Some(ElementLitBinding(litArg))
+      case _ => Some(DontCareBinding())
+    }
     case topBindingOpt => topBindingOpt
   }
 
@@ -36,6 +40,16 @@ abstract class Element extends Data {
     case Some(ElementLitBinding(litArg)) => Some(litArg)
     case _ => None
   }
+
+ //TODO: Delete this, looked like it might be necessary at some point but tests run fine without this.
+//  private[chisel3] def litArgOption: Option[LitArg] = {
+//    topBindingOpt match {
+//      case Some(ElementLitBinding(litArg)) => Some(litArg)
+//      case Some(VecLitBinding(vecLitBinding)) =>
+//        vecLitBinding.get(this)
+//      case _ => None
+//    }
+//  }
 
   override def litOption: Option[BigInt] = litArgOption.map(_.num)
   private[chisel3] def litIsForcedWidth: Option[Boolean] = litArgOption.map(_.forcedWidth)

--- a/core/src/main/scala/chisel3/experimental/package.scala
+++ b/core/src/main/scala/chisel3/experimental/package.scala
@@ -130,6 +130,14 @@ package object experimental {
     }
   }
 
+  object VecLiterals {
+    implicit class AddVecLiteralConstructor[T <: Vec[_]](x: T) {
+      def Lit(elems: (Int, Data)*): T = {
+        x._makeLit(elems: _*)
+      }
+    }
+  }
+
   // Use to add a prefix to any component generated in input scope
   val prefix = chisel3.internal.prefix
   // Use to remove prefixes not in provided scope

--- a/core/src/main/scala/chisel3/experimental/package.scala
+++ b/core/src/main/scala/chisel3/experimental/package.scala
@@ -130,8 +130,16 @@ package object experimental {
     }
   }
 
+  /** This class provides the `Lit` method needed to define a `Vec` literal
+    */
   object VecLiterals {
     implicit class AddVecLiteralConstructor[T <: Vec[_]](x: T) {
+      /** Given a generator of a list tuples of the form [Int, Data]
+        * constructs a Vec literal, parallel concept to `BundleLiteral`
+        *
+        * @param elems generates a lit of `(Int, Data)` where the I
+        * @return
+        */
       def Lit(elems: (Int, Data)*): T = {
         x._makeLit(elems: _*)
       }

--- a/core/src/main/scala/chisel3/internal/Binding.scala
+++ b/core/src/main/scala/chisel3/internal/Binding.scala
@@ -6,7 +6,7 @@ import chisel3._
 import chisel3.experimental.BaseModule
 import chisel3.internal.firrtl.LitArg
 
-import scala.collection.mutable
+import scala.collection.immutable.ListMap
 
 /** Requires that a node is hardware ("bound")
   */
@@ -126,4 +126,4 @@ case class ElementLitBinding(litArg: LitArg) extends LitBinding
 // Literal binding attached to the root of a Bundle, containing literal values of its children.
 case class BundleLitBinding(litMap: Map[Data, LitArg]) extends LitBinding
 // Literal binding attached to the root of a Vec, containing literal values of its children.
-case class VecLitBinding(litMap: mutable.LinkedHashMap[Data, LitArg]) extends LitBinding
+case class VecLitBinding(litMap: ListMap[Data, LitArg]) extends LitBinding

--- a/core/src/main/scala/chisel3/internal/Binding.scala
+++ b/core/src/main/scala/chisel3/internal/Binding.scala
@@ -6,6 +6,9 @@ import chisel3._
 import chisel3.experimental.BaseModule
 import chisel3.internal.firrtl.LitArg
 
+import scala.collection.immutable.ListMap
+import scala.collection.mutable
+
 /** Requires that a node is hardware ("bound")
   */
 object requireIsHardware {
@@ -119,3 +122,4 @@ sealed trait LitBinding extends UnconstrainedBinding with ReadOnlyBinding
 case class ElementLitBinding(litArg: LitArg) extends LitBinding
 // Literal binding attached to the root of a Bundle, containing literal values of its children.
 case class BundleLitBinding(litMap: Map[Data, LitArg]) extends LitBinding
+case class VecLitBinding(litMap: mutable.LinkedHashMap[Data, LitArg]) extends LitBinding

--- a/core/src/main/scala/chisel3/internal/Binding.scala
+++ b/core/src/main/scala/chisel3/internal/Binding.scala
@@ -6,7 +6,6 @@ import chisel3._
 import chisel3.experimental.BaseModule
 import chisel3.internal.firrtl.LitArg
 
-import scala.collection.immutable.ListMap
 import scala.collection.mutable
 
 /** Requires that a node is hardware ("bound")
@@ -122,4 +121,5 @@ sealed trait LitBinding extends UnconstrainedBinding with ReadOnlyBinding
 case class ElementLitBinding(litArg: LitArg) extends LitBinding
 // Literal binding attached to the root of a Bundle, containing literal values of its children.
 case class BundleLitBinding(litMap: Map[Data, LitArg]) extends LitBinding
+// Literal binding attached to the root of a Vec, containing literal values of its children.
 case class VecLitBinding(litMap: mutable.LinkedHashMap[Data, LitArg]) extends LitBinding

--- a/core/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -91,6 +91,12 @@ abstract class LitArg(val num: BigInt, widthArg: Width) extends Arg {
     elem
   }
 
+  /** Provides a mechanism that LitArgs can have their width adjusted
+    * to match other members of a VecLiteral
+    *
+    * @param newWidth the new width for this
+    * @return
+    */
   def cloneWithWidth(newWidth: Width): this.type
 
   protected def minWidth: Int

--- a/core/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -91,6 +91,8 @@ abstract class LitArg(val num: BigInt, widthArg: Width) extends Arg {
     elem
   }
 
+  def cloneWithWidth(newWidth: Width): this.type
+
   protected def minWidth: Int
   if (forcedWidth) {
     require(widthArg.get >= minWidth,
@@ -106,6 +108,10 @@ case class ULit(n: BigInt, w: Width) extends LitArg(n, w) {
   def name: String = "UInt" + width + "(\"h0" + num.toString(16) + "\")"
   def minWidth: Int = 1 max n.bitLength
 
+  def cloneWithWidth(newWidth: Width): this.type = {
+    ULit(n, newWidth).asInstanceOf[this.type]
+  }
+
   require(n >= 0, s"UInt literal ${n} is negative")
 }
 
@@ -115,6 +121,10 @@ case class SLit(n: BigInt, w: Width) extends LitArg(n, w) {
     s"asSInt(${ULit(unsigned, width).name})"
   }
   def minWidth: Int = 1 + n.bitLength
+
+  def cloneWithWidth(newWidth: Width): this.type = {
+    SLit(n, newWidth).asInstanceOf[this.type]
+  }
 }
 
 case class FPLit(n: BigInt, w: Width, binaryPoint: BinaryPoint) extends LitArg(n, w) {
@@ -123,6 +133,10 @@ case class FPLit(n: BigInt, w: Width, binaryPoint: BinaryPoint) extends LitArg(n
     s"asFixedPoint(${ULit(unsigned, width).name}, ${binaryPoint.asInstanceOf[KnownBinaryPoint].value})"
   }
   def minWidth: Int = 1 + n.bitLength
+
+  def cloneWithWidth(newWidth: Width): this.type = {
+    FPLit(n, newWidth, binaryPoint).asInstanceOf[this.type]
+  }
 }
 
 case class IntervalLit(n: BigInt, w: Width, binaryPoint: BinaryPoint) extends LitArg(n, w) {
@@ -135,6 +149,10 @@ case class IntervalLit(n: BigInt, w: Width, binaryPoint: BinaryPoint) extends Li
       IntervalRange.getBound(isClosed = true, BigDecimal(n)), IntervalRange.getRangeWidth(binaryPoint))
   }
   def minWidth: Int = 1 + n.bitLength
+
+  def cloneWithWidth(newWidth: Width): this.type = {
+    IntervalLit(n, newWidth, binaryPoint).asInstanceOf[this.type]
+  }
 }
 
 case class Ref(name: String) extends Arg

--- a/docs/src/appendix/experimental-features.md
+++ b/docs/src/appendix/experimental-features.md
@@ -79,7 +79,55 @@ class Example3 extends RawModule {
 chisel3.stage.ChiselStage.emitVerilog(new Example3)
 ```
 
-Vec literals are not yet supported.
+### Vec Literals
+
+Vec literals can be constructed via an experimental import:
+
+```scala mdoc
+import chisel3._
+import chisel3.experimental.VecLiterals._
+
+class Example extends RawModule {
+  val out = IO(Output(new Vec(2, UInt(4.W)))
+  out := Vec(2, UInt(4.W)).Lit(0 -> 1.U, 1 -> 2.U)
+}
+```
+
+```scala mdoc:verilog
+chisel3.stage.ChiselStage.emitVerilog(new Example)
+```
+
+Partial specification is allowed, defaulting any unconnected fields to 0 (regardless of type).
+
+```scala mdoc
+class Example2 extends RawModule {
+  val out = Vec(4, UInt(4.W))
+  out := Vec(4, UInt(4.W)).Lit(0 -> 1.U, 3 -> 7.U)
+}
+```
+
+```scala mdoc:verilog
+chisel3.stage.ChiselStage.emitVerilog(new Example2)
+```
+
+Bundle literals can also be nested arbitrarily.
+
+```scala mdoc
+class ChildBundle extends Bundle {
+  val foo = UInt(8.W)
+}
+
+class Example3 extends RawModule {
+  val out = IO(Output(Vec(2, new ChildBundle)))
+  out := Vec(2, new ChildBundle)).Lit(
+    0 -> (new ChildBundle).Lit(_.foo -> 42.U))
+    1 -> (new ChildBundle).Lit(_.foo -> 7.U))
+}
+```
+
+```scala mdoc:verilog
+chisel3.stage.ChiselStage.emitVerilog(new Example3)
+```
 
 ### Interval Type
 

--- a/docs/src/appendix/experimental-features.md
+++ b/docs/src/appendix/experimental-features.md
@@ -87,58 +87,44 @@ Vec literals can be constructed via an experimental import:
 import chisel3._
 import chisel3.experimental.VecLiterals._
 
-class Example extends RawModule {
-  val out = IO(Output(new Vec(2, UInt(4.W)))
+class VecExample1 extends Module {
+  val out = IO(Output(Vec(2, UInt(4.W))))
   out := Vec(2, UInt(4.W)).Lit(0 -> 1.U, 1 -> 2.U)
 }
 ```
 
 ```scala mdoc:verilog
-chisel3.stage.ChiselStage.emitVerilog(new Example)
+chisel3.stage.ChiselStage.emitVerilog(new VecExample1)
 ```
 
 Partial specification is allowed, defaulting any unconnected fields to 0 (regardless of type).
 
 ```scala mdoc
-class Example2 extends RawModule {
+class VecExample2 extends RawModule {
   val out = Vec(4, UInt(4.W))
   out := Vec(4, UInt(4.W)).Lit(0 -> 1.U, 3 -> 7.U)
 }
 ```
 
 ```scala mdoc:verilog
-chisel3.stage.ChiselStage.emitVerilog(new Example2)
+chisel3.stage.ChiselStage.emitVerilog(new VecExample2)
 ```
 
 Registers can be initialized from Vec literals
 
 ```scala mdoc
-class Example3 extends RawModule {
+class VecExample3 extends Module {
+  val out = IO(Output(Vec(4, UInt(8.W))))
   val y = RegInit(
     Vec(4, UInt(8.W)).Lit(0 -> 0xAB.U(8.W), 1 -> 0xCD.U(8.W), 2 -> 0xEF.U(8.W), 3 -> 0xFF.U(8.W))
   )
+  out := y
 }
 ```
 
 ```scala mdoc:verilog
-chisel3.stage.ChiselStage.emitVerilog(new Example3)
+chisel3.stage.ChiselStage.emitVerilog(new VecExample3)
 ```
-
-Registers can be partially initialized from Vec literals. Only specified elements will be assigned.
-
-```scala mdoc
-class Example4 extends RawModule {
-  val y = RegInit(
-    Vec(4, UInt(8.W)).Lit(0 -> 0xAB.U(8.W), 2 -> 0xEF.U(8.W))
-  )
-}
-```
-
-```scala mdoc:verilog
-chisel3.stage.ChiselStage.emitVerilog(new Example4)
-```
-
-
 
 Vec literals can also be nested arbitrarily.
 

--- a/docs/src/appendix/experimental-features.md
+++ b/docs/src/appendix/experimental-features.md
@@ -124,10 +124,10 @@ class Example3 extends RawModule {
 chisel3.stage.ChiselStage.emitVerilog(new Example3)
 ```
 
-Registers can be partialy initialized from Vec literals. Only specified elements will be assigned.
+Registers can be partially initialized from Vec literals. Only specified elements will be assigned.
 
 ```scala mdoc
-class 4 extends RawModule {
+class Example4 extends RawModule {
   val y = RegInit(
     Vec(4, UInt(8.W)).Lit(0 -> 0xAB.U(8.W), 2 -> 0xEF.U(8.W))
   )
@@ -135,7 +135,7 @@ class 4 extends RawModule {
 ```
 
 ```scala mdoc:verilog
-chisel3.stage.ChiselStage.emitVerilog(new 4)
+chisel3.stage.ChiselStage.emitVerilog(new Example4)
 ```
 
 

--- a/docs/src/appendix/experimental-features.md
+++ b/docs/src/appendix/experimental-features.md
@@ -110,14 +110,44 @@ class Example2 extends RawModule {
 chisel3.stage.ChiselStage.emitVerilog(new Example2)
 ```
 
-Bundle literals can also be nested arbitrarily.
+Registers can be initialized from Vec literals
+
+```scala mdoc
+class Example3 extends RawModule {
+  val y = RegInit(
+    Vec(4, UInt(8.W)).Lit(0 -> 0xAB.U(8.W), 1 -> 0xCD.U(8.W), 2 -> 0xEF.U(8.W), 3 -> 0xFF.U(8.W))
+  )
+}
+```
+
+```scala mdoc:verilog
+chisel3.stage.ChiselStage.emitVerilog(new Example3)
+```
+
+Registers can be partialy initialized from Vec literals. Only specified elements will be assigned.
+
+```scala mdoc
+class 4 extends RawModule {
+  val y = RegInit(
+    Vec(4, UInt(8.W)).Lit(0 -> 0xAB.U(8.W), 2 -> 0xEF.U(8.W))
+  )
+}
+```
+
+```scala mdoc:verilog
+chisel3.stage.ChiselStage.emitVerilog(new 4)
+```
+
+
+
+Vec literals can also be nested arbitrarily.
 
 ```scala mdoc
 class ChildBundle extends Bundle {
   val foo = UInt(8.W)
 }
 
-class Example3 extends RawModule {
+class Example5 extends RawModule {
   val out = IO(Output(Vec(2, new ChildBundle)))
   out := Vec(2, new ChildBundle)).Lit(
     0 -> (new ChildBundle).Lit(_.foo -> 42.U))
@@ -126,7 +156,7 @@ class Example3 extends RawModule {
 ```
 
 ```scala mdoc:verilog
-chisel3.stage.ChiselStage.emitVerilog(new Example3)
+chisel3.stage.ChiselStage.emitVerilog(new Example5)
 ```
 
 ### Interval Type

--- a/docs/src/appendix/experimental-features.md
+++ b/docs/src/appendix/experimental-features.md
@@ -133,16 +133,17 @@ class ChildBundle extends Bundle {
   val foo = UInt(8.W)
 }
 
-class Example5 extends RawModule {
+class VecExample5 extends RawModule {
   val out = IO(Output(Vec(2, new ChildBundle)))
-  out := Vec(2, new ChildBundle)).Lit(
-    0 -> (new ChildBundle).Lit(_.foo -> 42.U))
-    1 -> (new ChildBundle).Lit(_.foo -> 7.U))
+  out := Vec(2, new ChildBundle).Lit(
+    0 -> (new ChildBundle).Lit(_.foo -> 42.U),
+    1 -> (new ChildBundle).Lit(_.foo -> 7.U)
+  )
 }
 ```
 
 ```scala mdoc:verilog
-chisel3.stage.ChiselStage.emitVerilog(new Example5)
+chisel3.stage.ChiselStage.emitVerilog(new VecExample5)
 ```
 
 ### Interval Type

--- a/src/test/scala/chiselTests/BundleLiteralSpec.scala
+++ b/src/test/scala/chiselTests/BundleLiteralSpec.scala
@@ -46,24 +46,6 @@ class BundleLiteralSpec extends ChiselFlatSpec with Utils {
     } }
   }
 
-  "bundle literals" should "not pack when sparsely specified" in {
-    intercept[NoSuchElementException] {
-      assertTesterPasses {
-        new BasicTester {
-          val bundleLit = (new MyBundle).Lit(_.a -> 42.U, _.c -> MyEnum.sB)
-          bundleLit.litOption should equal(None) // packed as 42 (8-bit), false=0 (1-bit), sB=1 (1-bit)
-          chisel3.assert(bundleLit.asUInt() === bundleLit.litOption.get.U) // sanity-check consistency with runtime
-
-          val longBundleLit = (new LongBundle).Lit(
-            _.a -> 0xDEADDEADBEEFL.U, _.c -> 4.5.F(16.W, 4.BP))
-          longBundleLit.litOption should be(None)
-          chisel3.assert(longBundleLit.asUInt() === longBundleLit.litOption.get.U)
-          stop()
-        }
-      }
-    }
-  }
-
   "bundle literals" should "work in RTL" in {
     val outsideBundleLit = (new MyBundle).Lit(_.a -> 42.U, _.b -> true.B, _.c -> MyEnum.sB)
     assertTesterPasses{ new BasicTester{

--- a/src/test/scala/chiselTests/BundleLiteralSpec.scala
+++ b/src/test/scala/chiselTests/BundleLiteralSpec.scala
@@ -47,7 +47,7 @@ class BundleLiteralSpec extends ChiselFlatSpec with Utils {
   }
 
   "bundle literals" should "not pack when sparsely specified" in {
-    intercept[ChiselException] {
+    intercept[NoSuchElementException] {
       assertTesterPasses {
         new BasicTester {
           val bundleLit = (new MyBundle).Lit(_.a -> 42.U, _.c -> MyEnum.sB)

--- a/src/test/scala/chiselTests/ChiselSpec.scala
+++ b/src/test/scala/chiselTests/ChiselSpec.scala
@@ -2,22 +2,22 @@
 
 package chiselTests
 
-import org.scalatest._
-import org.scalatest.prop._
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalacheck._
 import chisel3._
-import chisel3.stage.{ChiselGeneratorAnnotation, ChiselStage}
-import chisel3.testers._
-import firrtl.{AnnotationSeq, CommonOptions, EmittedVerilogCircuitAnnotation, ExecutionOptionsManager, FirrtlExecutionFailure, FirrtlExecutionSuccess, HasFirrtlOptions}
-import firrtl.annotations.{Annotation, DeletedAnnotation}
-import firrtl.util.BackendCompilationUtilities
-import java.io.ByteArrayOutputStream
-import java.security.Permission
-
 import chisel3.aop.Aspect
 import chisel3.stage.{ChiselGeneratorAnnotation, ChiselStage, NoRunFirrtlCompilerAnnotation, PrintFullStackTraceAnnotation}
+import chisel3.testers._
+import firrtl.annotations.Annotation
+import firrtl.util.BackendCompilationUtilities
+import firrtl.{AnnotationSeq, EmittedVerilogCircuitAnnotation}
+import org.scalacheck._
+import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should._
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+
+import java.io.ByteArrayOutputStream
+import java.security.Permission
 import scala.reflect.ClassTag
 
 /** Common utility functions for Chisel unit tests. */
@@ -89,6 +89,9 @@ trait ChiselRunners extends Assertions with BackendCompilationUtilities {
 
 /** Spec base class for BDD-style testers. */
 abstract class ChiselFlatSpec extends AnyFlatSpec with ChiselRunners with Matchers
+
+/** Spec base class for BDD-style testers. */
+abstract class ChiselFreeSpec extends AnyFreeSpec with ChiselRunners with Matchers
 
 class ChiselTestUtilitiesSpec extends ChiselFlatSpec {
   import org.scalatest.exceptions.TestFailedException

--- a/src/test/scala/chiselTests/ChiselSpec.scala
+++ b/src/test/scala/chiselTests/ChiselSpec.scala
@@ -93,60 +93,6 @@ abstract class ChiselFlatSpec extends AnyFlatSpec with ChiselRunners with Matche
 /** Spec base class for BDD-style testers. */
 abstract class ChiselFreeSpec extends AnyFreeSpec with ChiselRunners with Matchers
 
-class ChiselTestUtilitiesSpec extends ChiselFlatSpec {
-  import org.scalatest.exceptions.TestFailedException
-  // Who tests the testers?
-  "assertKnownWidth" should "error when the expected width is wrong" in {
-    val caught = intercept[ChiselException] {
-      assertKnownWidth(7) {
-        Wire(UInt(8.W))
-      }
-    }
-    assert(caught.getCause.isInstanceOf[TestFailedException])
-  }
-
-  it should "error when the width is unknown" in {
-    a [ChiselException] shouldBe thrownBy {
-      assertKnownWidth(7) {
-        Wire(UInt())
-      }
-    }
-  }
-
-  it should "work if the width is correct" in {
-    assertKnownWidth(8) {
-      Wire(UInt(8.W))
-    }
-  }
-
-  "assertInferredWidth" should "error if the width is known" in {
-    val caught = intercept[ChiselException] {
-      assertInferredWidth(8) {
-        Wire(UInt(8.W))
-      }
-    }
-    assert(caught.getCause.isInstanceOf[TestFailedException])
-  }
-
-  it should "error if the expected width is wrong" in {
-    a [TestFailedException] shouldBe thrownBy {
-      assertInferredWidth(8) {
-        val w = Wire(UInt())
-        w := 2.U(2.W)
-        w
-      }
-    }
-  }
-
-  it should "pass if the width is correct" in {
-    assertInferredWidth(4) {
-      val w = Wire(UInt())
-      w := 2.U(4.W)
-      w
-    }
-  }
-}
-
 /** Spec base class for property-based testers. */
 class ChiselPropSpec extends PropSpec with ChiselRunners with ScalaCheckPropertyChecks with Matchers {
 

--- a/src/test/scala/chiselTests/VecLiteralSpec.scala
+++ b/src/test/scala/chiselTests/VecLiteralSpec.scala
@@ -33,7 +33,7 @@ class VecLiteralSpec extends ChiselFreeSpec with Utils {
       )
     }
 
-    "indices in vec literals myst not be repeated" in {
+    "indices in vec literals must not be repeated" in {
       val e = intercept[VecLiteralException] {
         Vec(2, UInt(4.W)).Lit(0 -> 1.U, 1 -> 2.U, 2 -> 3.U, 2 -> 3.U, 2 -> 3.U, 3 -> 4.U)
       }
@@ -56,11 +56,14 @@ class VecLiteralSpec extends ChiselFreeSpec with Utils {
         "VecLit: Literal specified at index 0 (UInt<1>(1)) does not match Vec type SInt<4>"
       )
     }
+
     "all lits must be the same type but width can be equal or smaller than the Vec's element width" in {
       val v = Vec(2, SInt(4.W)).Lit(0 -> 1.S, 1 -> -2.S)
       v(0).toString should include(1.S(4.W).toString)
       v(1).toString should include(-2.S(4.W).toString)
+      v.toString should include ("SInt<4>[2](0=SLit(1,<4>), 1=SLit(-2,<4>)")
     }
+
     "all lits must be the same type but width cannot be greater than Vec's element width" in {
       val e = intercept[VecLiteralException] {
         val v = Vec(2, SInt(4.W)).Lit(0 -> 11.S, 1 -> -0xffff.S)

--- a/src/test/scala/chiselTests/VecLiteralSpec.scala
+++ b/src/test/scala/chiselTests/VecLiteralSpec.scala
@@ -1,0 +1,444 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiselTests
+
+import chisel3._
+import chisel3.experimental.VecLiterals._
+import chisel3.experimental.{ChiselEnum, FixedPoint, VecLiteralException}
+import chisel3.stage.ChiselStage
+import chisel3.testers.BasicTester
+
+class VecLiteralSpec extends ChiselFreeSpec with Utils {
+  object MyEnum extends ChiselEnum {
+    val sA, sB, sC = Value
+  }
+  object MyEnumB extends ChiselEnum {
+    val sA, sB = Value
+  }
+
+  "Vec literals should work with chisel Enums" in {
+    val enumVec = Vec(3, MyEnum()).Lit(0 -> MyEnum.sA, 1 -> MyEnum.sB, 2-> MyEnum.sC)
+    enumVec(0).toString should include (MyEnum.sA.toString)
+    enumVec(1).toString should include (MyEnum.sB.toString)
+    enumVec(2).toString should include (MyEnum.sC.toString)
+  }
+
+  "improperly constructed vec literals should be detected" - {
+    "indices in vec literal muse be greater than zero and less than length" in {
+      val e = intercept[VecLiteralException] {
+        Vec(2, UInt(4.W)).Lit(0 -> 1.U, 1 -> 2.U, 2 -> 3.U, 3 -> 4.U, -2 -> 7.U)
+      }
+      e.getMessage should include (
+        "VecLiteral: The following indices (2,3,-2) are less than zero or greater or equal to than Vec length"
+      )
+    }
+
+    "indices in vec literals myst not be repeated" in {
+      val e = intercept[VecLiteralException] {
+        Vec(2, UInt(4.W)).Lit(0 -> 1.U, 1 -> 2.U, 2 -> 3.U, 2 -> 3.U, 2 -> 3.U, 3 -> 4.U)
+      }
+      e.getMessage should include("VecLiteral: has duplicated indices 2(3 times)")
+    }
+    "lits must fit in vec element width" in {
+      val e = intercept[VecLiteralException] {
+        Vec(2, SInt(4.W)).Lit(0 -> 0xab.U, 1 -> 0xbc.U)
+      }
+      e.getMessage should include(
+        "VecLiteral: Vec[SInt<4>] has the following incorrectly typed or sized initializers: " +
+          "0 -> UInt<8>(171),1 -> UInt<8>(188)"
+      )
+    }
+    "all lits must be the same type" in {
+      val e = intercept[VecLiteralException] {
+        Vec(2, SInt(4.W)).Lit(0 -> 1.U, 1 -> 2.U)
+      }
+      e.getMessage should include(
+        "VecLit: Literal specified at index 0 (UInt<1>(1)) does not match Vec type SInt<4>"
+      )
+    }
+    "all lits must be the same type but width can be equal or smaller than the Vec's element width" in {
+      val v = Vec(2, SInt(4.W)).Lit(0 -> 1.S, 1 -> -2.S)
+      v(0).toString should include(1.S(4.W).toString)
+      v(1).toString should include(-2.S(4.W).toString)
+    }
+    "all lits must be the same type but width cannot be greater than Vec's element width" in {
+      val e = intercept[VecLiteralException] {
+        val v = Vec(2, SInt(4.W)).Lit(0 -> 11.S, 1 -> -0xffff.S)
+      }
+      e.getMessage should include(
+        "VecLit: Literal specified at index 0 (SInt<5>(11)) is too wide for Vec type SInt<4>"
+      )
+    }
+  }
+
+  "Vec literals should elaborate" in {
+    class HasVecInit extends Module {
+      val y = RegInit(
+        Vec(4, UInt(8.W)).Lit(0 -> 0xAB.U(8.W), 1 -> 0xCD.U(8.W), 2 -> 0xEF.U(8.W), 3 -> 0xFF.U(8.W))
+      )
+      printf(s"y.asUInt = %x\n", y.asUInt)
+    }
+
+    val firrtl = ChiselStage.emitFirrtl(new HasVecInit)
+    firrtl should include("""_y_WIRE[0] <= UInt<8>("hab")""")
+    firrtl should include("""_y_WIRE[1] <= UInt<8>("hcd")""")
+    firrtl should include("""_y_WIRE[2] <= UInt<8>("hef")""")
+    firrtl should include("""_y_WIRE[3] <= UInt<8>("hff")""")
+    firrtl should include("""      reset => (reset, _y_WIRE)""".stripMargin)
+  }
+
+  "lowest of vec literal contains least significant bits and " in {
+    val y = Vec(4, UInt(8.W)).Lit(0 -> 0xAB.U(8.W), 1 -> 0xCD.U(8.W), 2 -> 0xEF.U(8.W), 3 -> 0xFF.U(8.W))
+    // println(s"y: ${y.litValue().toString(16)}")
+    y.litValue() should be(BigInt("FFEFCDAB", 16))
+  }
+
+  "the order lits are specified does not matter" in {
+    val y = Vec(4, UInt(8.W)).Lit(3 -> 0xFF.U(8.W), 2 -> 0xEF.U(8.W), 1 -> 0xCD.U(8.W), 0 -> 0xAB.U(8.W))
+    // println(s"y: ${y.litValue().toString(16)}")
+    y.litValue() should be(BigInt("FFEFCDAB", 16))
+  }
+
+  "regardless of the literals widths, packing should be done based on the width of the Vec's gen" in {
+    val z = Vec(4, UInt(8.W)).Lit(0 -> 0x2.U, 1 -> 0x2.U, 2 -> 0x2.U, 3 -> 0x3.U)
+    // println(s"z: ${z.litValue().toString(16)}")
+    z.litValue() should be(BigInt("03020202", 16))
+  }
+
+  "packing sparse vec lits should not pack, litOption returns None" in {
+    // missing sub-listeral for index 2
+    val z = Vec(4, UInt(8.W)).Lit(0 -> 0x2.U, 1 -> 0x2.U, 3 -> 0x3.U)
+
+    println(s"sparse z: ${z.litOption}")
+    z.litOption should be(None)
+  }
+
+  "registers can be initialized with a Vec literal" in {
+    assertTesterPasses(new BasicTester {
+      val y = RegInit(Vec(4, UInt(8.W)).Lit(0 -> 0xAB.U(8.W), 1 -> 0xCD.U(8.W), 2 -> 0xEF.U(8.W), 3 -> 0xFF.U(8.W)))
+      //printf("y = %x\n", y.asUInt)
+      chisel3.assert(y.asUInt === BigInt("FFEFCDAB", 16).U)
+      stop()
+    })
+  }
+
+  "vec lits should work" in {
+    val y = Vec(4, UInt(8.W)).Lit(0 -> 0xAB.U(8.W), 1 -> 0xCD.U(8.W), 2 -> 0xEF.U(8.W), 3 -> 0xAB.U(8.W))
+    println(s"y(0).litOption: ${y(0).litOption}")
+    println(s"y(0).toString: ${y(0).toString}")
+
+    println(s"y.toString: ${y.toString}")
+    println(s"y.litOption: ${y.litOption}")
+    println(s"y.litOption: ${y.litOption.get.toString(16)}")
+
+    println(s"y(0).litOption: ${y(0).litOption}")
+    println(s"y.litValue: ${y.litValue()}")
+  }
+
+  "how does asUInt work" in {
+    assertTesterPasses(new BasicTester {
+      val vec1 = Vec(4, UInt(16.W)).Lit(0 -> 0xDD.U, 1 -> 0xCC.U, 2 -> 0xBB.U, 3 -> 0xAA.U)
+
+      val vec2 = VecInit(Seq(0xDD.U, 0xCC.U, 0xBB.U, 0xAA.U))
+      printf("vec1 %x\n", vec1.asUInt())
+      printf("vec2 %x\n", vec2.asUInt())
+      stop()
+    })
+  }
+
+  "Vec literals uint conversion" in {
+    class M1 extends Module {
+      val out1 = IO(Output(UInt(64.W)))
+      val out2 = IO(Output(UInt(64.W)))
+
+      val v1 = Vec(4, UInt(16.W)).Lit(0 -> 0xDD.U, 1 -> 0xCC.U, 2 -> 0xBB.U, 3 -> 0xAA.U)
+      printf("v1 %x\n", v1.asUInt)
+      out1 := v1.asUInt
+
+      val v2 = VecInit(0xDD.U(16.W), 0xCC.U, 0xBB.U, 0xAA.U)
+      printf("v2 %x\n", v1.asUInt)
+      out2 := v2.asUInt
+    }
+    println(ChiselStage.emitFirrtl(new M1))
+
+    assertTesterPasses(new BasicTester {
+      val m = Module(new M1)
+      printf("m.out1 %x  m.out2 %x\n", m.out1, m.out2)
+      chisel3.assert(m.out1 === m.out2)
+      stop()
+    })
+  }
+
+  "VecLits should work properly with .asUInt" in {
+    val outsideVecLit = Vec(4, UInt(16.W)).Lit(0 -> 0xDD.U, 1 -> 0xCC.U, 2 -> 0xBB.U, 3 -> 0xAA.U)
+    println(s"outsideVecLit ${outsideVecLit.litValue().toString(16)}")
+
+    assertTesterPasses {
+      new BasicTester {
+        // TODO: add direct bundle compare operations, when that feature is added
+        chisel3.assert(outsideVecLit(0) === 0xDD.U, s"v(0)")
+        printf("VecList.litValue: %x\n", outsideVecLit.litValue().U)
+        val x = outsideVecLit.asUInt
+        printf("VecList.asUInt: %x\n", x)
+        stop()
+      }
+    }
+  }
+
+  "VecLits should work properly with .asUInt elaborated" in {
+    class M extends Module {
+      val outsideVecLit = Vec(4, UInt(16.W)).Lit(0 -> 0xDD.U, 1 -> 0xCC.U, 2 -> 0xBB.U, 3 -> 0xAA.U)
+      printf(s"outsideVecLit %x\n", outsideVecLit.asUInt)
+    }
+
+    println(ChiselStage.emitFirrtl(new M))
+  }
+
+  "bundle literals should work in RTL" in {
+    val outsideVecLit = Vec(4, UInt(16.W)).Lit(0 -> 0xDD.U, 1 -> 0xCC.U, 2 -> 0xBB.U, 3 -> 0xAA.U)
+    println(s"outsideVecLit ${outsideVecLit.litValue().toString(16)}")
+
+    assertTesterPasses {
+      new BasicTester {
+        // TODO: add direct bundle compare operations, when that feature is added
+        chisel3.assert(outsideVecLit(0) === 0xDD.U, s"v(0)")
+        chisel3.assert(outsideVecLit(1) === 0xCC.U)
+        chisel3.assert(outsideVecLit(2) === 0xBB.U)
+      chisel3.assert(outsideVecLit(3) === 0xAA.U)
+
+      chisel3.printf("outsideVecLit.litValue() = %x outsideVecLit.asUInt() = %x\n",
+        outsideVecLit.litValue().U, outsideVecLit.asUInt)
+      chisel3.assert(outsideVecLit.litValue().U === outsideVecLit.asUInt())
+
+      val insideVecLit = Vec(4, UInt(16.W)).Lit(0 -> 0xDD.U, 1 -> 0xCC.U, 2 -> 0xBB.U, 3 -> 0xAA.U)
+      chisel3.assert(insideVecLit(0) === 0xDD.U)
+      chisel3.assert(insideVecLit(1) === 0xCC.U)
+      chisel3.assert(insideVecLit(2) === 0xBB.U)
+      chisel3.assert(insideVecLit(3) === 0xAA.U)
+
+      chisel3.assert(insideVecLit(0) === outsideVecLit(0))
+      chisel3.assert(insideVecLit(1) === outsideVecLit(1))
+      chisel3.assert(insideVecLit(2) === outsideVecLit(2))
+      chisel3.assert(insideVecLit(3) === outsideVecLit(3))
+
+      val vecWire1 = Wire(Vec(4, UInt(16.W)))
+      vecWire1 := outsideVecLit
+
+      chisel3.assert(vecWire1(0) === 0xDD.U)
+      chisel3.assert(vecWire1(1) === 0xCC.U)
+      chisel3.assert(vecWire1(2) === 0xBB.U)
+      chisel3.assert(vecWire1(3) === 0xAA.U)
+
+      val vecWire2 = Wire(Vec(4, UInt(16.W)))
+      vecWire2 := insideVecLit
+
+      chisel3.assert(vecWire2(0) === 0xDD.U)
+      chisel3.assert(vecWire2(1) === 0xCC.U)
+      chisel3.assert(vecWire2(2) === 0xBB.U)
+      chisel3.assert(vecWire2(3) === 0xAA.U)
+
+      stop()
+    }}
+  }
+
+  "partial vec literals should work in RTL" in {
+    assertTesterPasses{ new BasicTester{
+      val vecLit = Vec(4, UInt(8.W)).Lit(0 -> 42.U, 2 -> 5.U)
+      chisel3.assert(vecLit(0) === 42.U)
+      chisel3.assert(vecLit(2) === 5.U)
+
+      val vecWire = Wire(Vec(4, UInt(8.W)))
+      vecWire := vecLit
+
+      chisel3.assert(vecWire(0) === 42.U)
+      chisel3.assert(vecWire(2) === 5.U)
+
+      stop()
+    }}
+  }
+
+  "nested vec literals should be constructable" in {
+    val outerVec = Vec(2, Vec(3, UInt(4.W))).Lit(
+      0 -> Vec(3, UInt(4.W)).Lit(0 -> 1.U, 1 -> 2.U, 2 -> 3.U),
+      1 -> Vec(3, UInt(4.W)).Lit(0 -> 4.U, 1 -> 5.U, 2 -> 6.U)
+    )
+    outerVec(0)(0).litValue() should be (BigInt(1))
+    outerVec(0)(1).litValue() should be (BigInt(2))
+    outerVec(0)(2).litValue() should be (BigInt(3))
+    outerVec(1)(0).litValue() should be (BigInt(4))
+    outerVec(1)(1).litValue() should be (BigInt(5))
+    outerVec(1)(2).litValue() should be (BigInt(6))
+  }
+
+  "contained vecs should work" in {
+    assertTesterPasses{ new BasicTester {
+      val outerVec = Vec(2, Vec(3, UInt(4.W))).Lit(
+        0 -> Vec(3, UInt(4.W)).Lit(0 -> 1.U, 1 -> 2.U, 2 -> 3.U),
+        1 -> Vec(3, UInt(4.W)).Lit(0 -> 4.U, 1 -> 5.U, 2 -> 6.U)
+      )
+
+      chisel3.assert(outerVec(0)(0) === 1.U)
+      chisel3.assert(outerVec(0)(1) === 2.U)
+      chisel3.assert(outerVec(0)(2) === 3.U)
+      chisel3.assert(outerVec(1)(0) === 4.U)
+      chisel3.assert(outerVec(1)(1) === 5.U)
+      chisel3.assert(outerVec(1)(2) === 6.U)
+
+      val v0 = outerVec(0)
+      val v1 = outerVec(1)
+      chisel3.assert(v0(0) === 1.U)
+      chisel3.assert(v0(1) === 2.U)
+      chisel3.assert(v0(2) === 3.U)
+      chisel3.assert(v1(0) === 4.U)
+      chisel3.assert(v1(1) === 5.U)
+      chisel3.assert(v1(2) === 6.U)
+
+      stop()
+    }
+    }
+  }
+
+  "test this" in {
+    class M extends Module {
+      def vecFactory = Vec(2, FixedPoint(8.W, 4.BP))
+
+      val vecWire1 = Wire(Output(vecFactory))
+      val vecWire2 = Wire(Output(vecFactory))
+      //      vecWire1 := DontCare
+      val vecLit1 = vecFactory.Lit(0 -> (1.5).F(8.W, 4.BP))
+      val vecLit2 = vecFactory.Lit(1 -> (3.25).F(8.W, 4.BP))
+
+      vecWire1 := vecLit1
+      vecWire2 := vecLit2
+      printf("vw1(0) %x  vw1(1) %x\n", vecWire1(0).asUInt(), vecWire1(1).asUInt())
+    }
+    println(ChiselStage.emitFirrtl(new M))
+  }
+
+  //TODO: decide what behavior here should be
+  "This doesn't work should it" ignore {
+    assertTesterPasses {
+      new BasicTester {
+        def vecFactory = Vec(2, FixedPoint(8.W, 4.BP))
+
+        val vecWire1 = Wire(Output(vecFactory))
+        val vecLit1 = vecFactory.Lit(0 -> (1.5).F(8.W, 4.BP))
+        val vecLit2 = vecFactory.Lit(1 -> (3.25).F(8.W, 4.BP))
+
+        vecWire1 := vecLit1
+        vecWire1 := vecLit2
+        printf("vw1(0) %x  vw1(1) %x\n", vecWire1(0).asUInt(), vecWire1(1).asUInt())
+        chisel3.assert(vecWire1(0) === (1.5).F(8.W, 4.BP))
+        chisel3.assert(vecWire1(1) === (3.25).F(8.W, 4.BP))
+        stop()
+      }
+    }
+  }
+
+  "partially initialized Vec literals should assign" in {
+    assertTesterPasses {
+      new BasicTester {
+        def vecFactory = Vec(2, FixedPoint(8.W, 4.BP))
+
+        val vecWire1 = Wire(Output(vecFactory))
+        val vecWire2 = Wire(Output(vecFactory))
+        val vecLit1 = vecFactory.Lit(0 -> (1.5).F(8.W, 4.BP))
+        val vecLit2 = vecFactory.Lit(1 -> (3.25).F(8.W, 4.BP))
+
+        vecWire1 := vecLit1
+        vecWire2 := vecLit2
+        printf("vw1(0) %x  vw1(1) %x\n", vecWire1(0).asUInt(), vecWire1(1).asUInt())
+        chisel3.assert(vecWire1(0) === (1.5).F(8.W, 4.BP))
+        chisel3.assert(vecWire2(1) === (3.25).F(8.W, 4.BP))
+        stop()
+      }
+    }
+  }
+
+  "Vec literals should work as register reset values" in {
+    assertTesterPasses {
+      new BasicTester {
+        val r = RegInit(Vec(3, UInt(11.W)).Lit(0 -> 0xA.U, 1 -> 0xB.U, 2 -> 0xC.U))
+        r := (r.asUInt + 1.U).asTypeOf(Vec(3, UInt(11.W))) // prevent constprop
+
+        // check reset values on first cycle out of reset
+        chisel3.assert(r(0) === 0xA.U)
+        chisel3.assert(r(1) === 0xB.U)
+        chisel3.assert(r(2) === 0xC.U)
+        stop()
+      }
+    }
+  }
+
+  "partially initialized Vec literals should work as register reset values" in {
+    assertTesterPasses {
+      new BasicTester {
+        val r = RegInit(Vec(3, UInt(11.W)).Lit(0 -> 0xA.U, 2 -> 0xC.U))
+        r := (r.asUInt + 1.U).asTypeOf(Vec(3, UInt(11.W))) // prevent constprop
+
+        // check reset values on first cycle out of reset
+        chisel3.assert(r(0) === 0xA.U)
+        chisel3.assert(r(2) === 0xC.U)
+        stop()
+      }
+    }
+  }
+
+  "Fields extracted from Vec Literals should work as register reset values" in {
+    assertTesterPasses {
+      new BasicTester {
+        val r = RegInit(Vec(3, UInt(11.W)).Lit(0 -> 0xA.U, 2 -> 0xC.U)(0))
+        r := r + 1.U // prevent const prop
+        chisel3.assert(r === 0xA.U) // coming out of reset
+        stop()
+      }
+    }
+  }
+
+  "DontCare fields extracted from Vec Literals should work as register reset values" in {
+    assertTesterPasses {
+      new BasicTester {
+        val r = RegInit(Vec(3, Bool()).Lit(0 -> true.B)(2))
+        r := reset.asBool
+        printf(p"r = $r\n") // Can't assert because reset value is DontCare
+        stop()
+      }
+    }
+  }
+
+  "DontCare fields extracted from Vec Literals should work in other Expressions" in {
+    assertTesterPasses {
+      new BasicTester {
+        val x = Vec(3, Bool()).Lit(0 -> true.B)(2) || true.B
+        chisel3.assert(x === true.B)
+        stop()
+      }
+    }
+  }
+
+  "vec literals with non-literal values should fail" in {
+    val exc = intercept[VecLiteralException] {
+      extractCause[VecLiteralException] {
+        ChiselStage.elaborate {
+          new RawModule {
+            (Vec(3, UInt(11.W)).Lit(0 -> UInt()))
+          }
+        }
+      }
+    }
+    exc.getMessage should include("field 0 specified with non-literal value UInt")
+  }
+
+  "vec literals with non-type-equivalent element fields should fail" in {
+    val exc = intercept[VecLiteralException] {
+      extractCause[VecLiteralException] {
+        ChiselStage.elaborate {
+          new RawModule {
+            (Vec(3, UInt(11.W)).Lit(0 -> true.B))
+          }
+        }
+      }
+    }
+    exc.getMessage should include("(Bool(true)) does not match Vec type UInt<11>")
+  }
+}

--- a/src/test/scala/chiselTests/VecLiteralSpec.scala
+++ b/src/test/scala/chiselTests/VecLiteralSpec.scala
@@ -89,19 +89,16 @@ class VecLiteralSpec extends ChiselFreeSpec with Utils {
 
   "lowest of vec literal contains least significant bits and " in {
     val y = Vec(4, UInt(8.W)).Lit(0 -> 0xAB.U(8.W), 1 -> 0xCD.U(8.W), 2 -> 0xEF.U(8.W), 3 -> 0xFF.U(8.W))
-    // println(s"y: ${y.litValue().toString(16)}")
     y.litValue() should be(BigInt("FFEFCDAB", 16))
   }
 
   "the order lits are specified does not matter" in {
     val y = Vec(4, UInt(8.W)).Lit(3 -> 0xFF.U(8.W), 2 -> 0xEF.U(8.W), 1 -> 0xCD.U(8.W), 0 -> 0xAB.U(8.W))
-    // println(s"y: ${y.litValue().toString(16)}")
     y.litValue() should be(BigInt("FFEFCDAB", 16))
   }
 
   "regardless of the literals widths, packing should be done based on the width of the Vec's gen" in {
     val z = Vec(4, UInt(8.W)).Lit(0 -> 0x2.U, 1 -> 0x2.U, 2 -> 0x2.U, 3 -> 0x3.U)
-    // println(s"z: ${z.litValue().toString(16)}")
     z.litValue() should be(BigInt("03020202", 16))
   }
 
@@ -109,30 +106,15 @@ class VecLiteralSpec extends ChiselFreeSpec with Utils {
     // missing sub-listeral for index 2
     val z = Vec(4, UInt(8.W)).Lit(0 -> 0x2.U, 1 -> 0x2.U, 3 -> 0x3.U)
 
-    println(s"sparse z: ${z.litOption}")
     z.litOption should be(None)
   }
 
   "registers can be initialized with a Vec literal" in {
     assertTesterPasses(new BasicTester {
       val y = RegInit(Vec(4, UInt(8.W)).Lit(0 -> 0xAB.U(8.W), 1 -> 0xCD.U(8.W), 2 -> 0xEF.U(8.W), 3 -> 0xFF.U(8.W)))
-      //printf("y = %x\n", y.asUInt)
       chisel3.assert(y.asUInt === BigInt("FFEFCDAB", 16).U)
       stop()
     })
-  }
-
-  "vec lits should work" in {
-    val y = Vec(4, UInt(8.W)).Lit(0 -> 0xAB.U(8.W), 1 -> 0xCD.U(8.W), 2 -> 0xEF.U(8.W), 3 -> 0xAB.U(8.W))
-    println(s"y(0).litOption: ${y(0).litOption}")
-    println(s"y(0).toString: ${y(0).toString}")
-
-    println(s"y.toString: ${y.toString}")
-    println(s"y.litOption: ${y.litOption}")
-    println(s"y.litOption: ${y.litOption.get.toString(16)}")
-
-    println(s"y(0).litOption: ${y(0).litOption}")
-    println(s"y.litValue: ${y.litValue()}")
   }
 
   "how does asUInt work" in {
@@ -152,18 +134,14 @@ class VecLiteralSpec extends ChiselFreeSpec with Utils {
       val out2 = IO(Output(UInt(64.W)))
 
       val v1 = Vec(4, UInt(16.W)).Lit(0 -> 0xDD.U, 1 -> 0xCC.U, 2 -> 0xBB.U, 3 -> 0xAA.U)
-      printf("v1 %x\n", v1.asUInt)
       out1 := v1.asUInt
 
       val v2 = VecInit(0xDD.U(16.W), 0xCC.U, 0xBB.U, 0xAA.U)
-      printf("v2 %x\n", v1.asUInt)
       out2 := v2.asUInt
     }
-    println(ChiselStage.emitFirrtl(new M1))
 
     assertTesterPasses(new BasicTester {
       val m = Module(new M1)
-      printf("m.out1 %x  m.out2 %x\n", m.out1, m.out2)
       chisel3.assert(m.out1 === m.out2)
       stop()
     })
@@ -171,74 +149,57 @@ class VecLiteralSpec extends ChiselFreeSpec with Utils {
 
   "VecLits should work properly with .asUInt" in {
     val outsideVecLit = Vec(4, UInt(16.W)).Lit(0 -> 0xDD.U, 1 -> 0xCC.U, 2 -> 0xBB.U, 3 -> 0xAA.U)
-    println(s"outsideVecLit ${outsideVecLit.litValue().toString(16)}")
 
     assertTesterPasses {
       new BasicTester {
-        // TODO: add direct bundle compare operations, when that feature is added
         chisel3.assert(outsideVecLit(0) === 0xDD.U, s"v(0)")
-        printf("VecList.litValue: %x\n", outsideVecLit.litValue().U)
-        val x = outsideVecLit.asUInt
-        printf("VecList.asUInt: %x\n", x)
         stop()
       }
     }
   }
 
-  "VecLits should work properly with .asUInt elaborated" in {
-    class M extends Module {
-      val outsideVecLit = Vec(4, UInt(16.W)).Lit(0 -> 0xDD.U, 1 -> 0xCC.U, 2 -> 0xBB.U, 3 -> 0xAA.U)
-      printf(s"outsideVecLit %x\n", outsideVecLit.asUInt)
-    }
-
-    println(ChiselStage.emitFirrtl(new M))
-  }
-
   "bundle literals should work in RTL" in {
     val outsideVecLit = Vec(4, UInt(16.W)).Lit(0 -> 0xDD.U, 1 -> 0xCC.U, 2 -> 0xBB.U, 3 -> 0xAA.U)
-    println(s"outsideVecLit ${outsideVecLit.litValue().toString(16)}")
 
     assertTesterPasses {
       new BasicTester {
-        // TODO: add direct bundle compare operations, when that feature is added
         chisel3.assert(outsideVecLit(0) === 0xDD.U, s"v(0)")
         chisel3.assert(outsideVecLit(1) === 0xCC.U)
         chisel3.assert(outsideVecLit(2) === 0xBB.U)
-      chisel3.assert(outsideVecLit(3) === 0xAA.U)
+        chisel3.assert(outsideVecLit(3) === 0xAA.U)
 
-      chisel3.printf("outsideVecLit.litValue() = %x outsideVecLit.asUInt() = %x\n",
-        outsideVecLit.litValue().U, outsideVecLit.asUInt)
-      chisel3.assert(outsideVecLit.litValue().U === outsideVecLit.asUInt())
+        chisel3.assert(outsideVecLit.litValue().U === outsideVecLit.asUInt())
 
-      val insideVecLit = Vec(4, UInt(16.W)).Lit(0 -> 0xDD.U, 1 -> 0xCC.U, 2 -> 0xBB.U, 3 -> 0xAA.U)
-      chisel3.assert(insideVecLit(0) === 0xDD.U)
-      chisel3.assert(insideVecLit(1) === 0xCC.U)
-      chisel3.assert(insideVecLit(2) === 0xBB.U)
-      chisel3.assert(insideVecLit(3) === 0xAA.U)
+        val insideVecLit = Vec(4, UInt(16.W)).Lit(0 -> 0xDD.U, 1 -> 0xCC.U, 2 -> 0xBB.U, 3 -> 0xAA.U)
+        chisel3.assert(insideVecLit(0) === 0xDD.U)
+        chisel3.assert(insideVecLit(1) === 0xCC.U)
+        chisel3.assert(insideVecLit(2) === 0xBB.U)
+        chisel3.assert(insideVecLit(3) === 0xAA.U)
 
-      chisel3.assert(insideVecLit(0) === outsideVecLit(0))
-      chisel3.assert(insideVecLit(1) === outsideVecLit(1))
-      chisel3.assert(insideVecLit(2) === outsideVecLit(2))
-      chisel3.assert(insideVecLit(3) === outsideVecLit(3))
+        chisel3.assert(insideVecLit(0) === outsideVecLit(0))
+        chisel3.assert(insideVecLit(1) === outsideVecLit(1))
+        chisel3.assert(insideVecLit(2) === outsideVecLit(2))
+        chisel3.assert(insideVecLit(3) === outsideVecLit(3))
 
-      val vecWire1 = Wire(Vec(4, UInt(16.W)))
-      vecWire1 := outsideVecLit
+        val vecWire1 = Wire(Vec(4, UInt(16.W)))
+        vecWire1 := outsideVecLit
 
-      chisel3.assert(vecWire1(0) === 0xDD.U)
-      chisel3.assert(vecWire1(1) === 0xCC.U)
-      chisel3.assert(vecWire1(2) === 0xBB.U)
-      chisel3.assert(vecWire1(3) === 0xAA.U)
+        chisel3.assert(vecWire1(0) === 0xDD.U)
+        chisel3.assert(vecWire1(1) === 0xCC.U)
+        chisel3.assert(vecWire1(2) === 0xBB.U)
+        chisel3.assert(vecWire1(3) === 0xAA.U)
 
-      val vecWire2 = Wire(Vec(4, UInt(16.W)))
-      vecWire2 := insideVecLit
+        val vecWire2 = Wire(Vec(4, UInt(16.W)))
+        vecWire2 := insideVecLit
 
-      chisel3.assert(vecWire2(0) === 0xDD.U)
-      chisel3.assert(vecWire2(1) === 0xCC.U)
-      chisel3.assert(vecWire2(2) === 0xBB.U)
-      chisel3.assert(vecWire2(3) === 0xAA.U)
+        chisel3.assert(vecWire2(0) === 0xDD.U)
+        chisel3.assert(vecWire2(1) === 0xCC.U)
+        chisel3.assert(vecWire2(2) === 0xBB.U)
+        chisel3.assert(vecWire2(3) === 0xAA.U)
 
-      stop()
-    }}
+        stop()
+      }
+    }
   }
 
   "partial vec literals should work in RTL" in {
@@ -296,23 +257,6 @@ class VecLiteralSpec extends ChiselFreeSpec with Utils {
       stop()
     }
     }
-  }
-
-  "test this" in {
-    class M extends Module {
-      def vecFactory = Vec(2, FixedPoint(8.W, 4.BP))
-
-      val vecWire1 = Wire(Output(vecFactory))
-      val vecWire2 = Wire(Output(vecFactory))
-      //      vecWire1 := DontCare
-      val vecLit1 = vecFactory.Lit(0 -> (1.5).F(8.W, 4.BP))
-      val vecLit2 = vecFactory.Lit(1 -> (3.25).F(8.W, 4.BP))
-
-      vecWire1 := vecLit1
-      vecWire2 := vecLit2
-      printf("vw1(0) %x  vw1(1) %x\n", vecWire1(0).asUInt(), vecWire1(1).asUInt())
-    }
-    println(ChiselStage.emitFirrtl(new M))
   }
 
   //TODO: decide what behavior here should be

--- a/src/test/scala/chiselTests/VecLiteralSpec.scala
+++ b/src/test/scala/chiselTests/VecLiteralSpec.scala
@@ -60,7 +60,7 @@ class VecLiteralSpec extends ChiselFreeSpec with Utils {
     "all lits must be the same type but width can be equal or smaller than the Vec's element width" in {
       val v = Vec(2, SInt(4.W)).Lit(0 -> 1.S, 1 -> -2.S)
       v(0).toString should include(1.S(4.W).toString)
-      v(1).toString should include(-2.S(4.W).toString)
+      v(1).toString should include((-2).S(4.W).toString)
       v.toString should include ("SInt<4>[2](0=SLit(1,<4>), 1=SLit(-2,<4>)")
     }
 


### PR DESCRIPTION
Introduces a requested feature `Vec` literals. Much like `Bundle` literals, this allows
developers to specify a `Vec` aggregate literal in a convenient (relatively) compact form
e.g.
```
  val vecLiteral = Vec(2, UInt(4.W)).Lit(0 -> 0xA.U, 1 -> 0xB.U)
```
Features
- Can be defined outside of module (enables use with chiseltest library)
- Can be sparsely specified (with the effect that top level `litOption` returns None)
- litOption behaves like to UInt in bit ordering
- works as `Reg` initializer
- Decent error exceptions for
  - duplicate keys are found
  - wrong data types employed
  - width of individual element exceeds the basic `Vec` width

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

New feature

#### API Impact

This is an API addition. the `Vec` type now has a `Lit` method creates a `Vec` literal.

#### Backend Code Generation Impact

This should not impact generated verilog

#### Desired Merge Strategy

Squash: The PR will be squashed and merged

#### Release Notes
Introduces Vec literals which are similar to Bundle Literals. Simple example:
```scala
  val vecLiteral = Vec(2, UInt(8.W)).Lit(0 -> 0xA.U, 1 -> 0xB.U)
```

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.0, 3.5.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
