### PR TITLE
Import memory files inline for Verilog generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ test_run_dir
 *~
 \#*\#
 .\#*
+.metals
+.bloop
+metals.sbt

--- a/src/main/scala/chisel3/util/experimental/LoadMemoryTransform.scala
+++ b/src/main/scala/chisel3/util/experimental/LoadMemoryTransform.scala
@@ -40,7 +40,7 @@ case class ChiselLoadMemoryAnnotation[T <: Data](
 }
 
 
-/** [[loadMemoryFromFile]] is an annotation generator that helps with loading a memory from a text file. This relies on
+/** [[loadMemoryFromFile]] is an annotation generator that helps with loading a memory from a text file as a bind module. This relies on
   * Verilator and Verilog's `\$readmemh` or `\$readmemb`. The [[https://github.com/freechipsproject/treadle Treadle
   * backend]] can also recognize this annotation and load memory at run-time.
   *
@@ -113,6 +113,86 @@ object loadMemoryFromFile {
     hexOrBinary: MemoryLoadFileType.FileType = MemoryLoadFileType.Hex
   ): Unit = {
     annotate(ChiselLoadMemoryAnnotation(memory, fileName, hexOrBinary))
+  }
+}
+
+
+/** [[loadMemoryFromFileInline]] is an annotation generator that helps with loading a memory from a text file inlined in
+  * the Verilog module. This relies on Verilator and Verilog's `\$readmemh` or `\$readmemb`.
+  * The [[https://github.com/freechipsproject/treadle Treadlebackend]] can also recognize this annotation and load memory at run-time.
+  *
+  * This annotation, when the FIRRTL compiler runs, triggers the [[MemoryFileInlineAnnotation]] that will add Verilog
+  * directives inlined to the module enabling the specified memories to be initialized from files.
+  * The module supports both `hex` and `bin` files by passing the appropriate [[MemoryLoadFileType.FileType]] argument with
+  * [[MemoryLoadFileType.Hex]] or [[MemoryLoadFileType.Binary]]. Hex is the default.
+  *
+  * ==Example module==
+  *
+  * Consider a simple Module containing a memory:
+  * {{{
+  * import chisel3._
+  * class UsesMem(memoryDepth: Int, memoryType: Data) extends Module {
+  *   val io = IO(new Bundle {
+  *     val address = Input(UInt(memoryType.getWidth.W))
+  *     val value   = Output(memoryType)
+  *   })
+  *   val memory = Mem(memoryDepth, memoryType)
+  *   io.value := memory(io.address)
+  * }
+  * }}}
+  *
+  * ==Above module with annotation==
+  *
+  * To load this memory from the file `/workspace/workdir/mem1.hex.txt` just add an import and annotate the memory:
+  * {{{
+  * import chisel3._
+  * import chisel3.util.experimental.loadMemoryFromFileInline   // <<-- new import here
+  * class UsesMem(memoryDepth: Int, memoryType: Data) extends Module {
+  *   val io = IO(new Bundle {
+  *     val address = Input(UInt(memoryType.getWidth.W))
+  *     val value   = Output(memoryType)
+  *   })
+  *   val memory = Mem(memoryDepth, memoryType)
+  *   io.value := memory(io.address)
+  *   loadMemoryFromFileInline(memory, "/workspace/workdir/mem1.hex.txt")  // <<-- Note the annotation here
+  * }
+  * }}}
+  *
+  * ==Example file format==
+  *
+  * A memory file should consist of ASCII text in either hex or binary format. The following example shows such a
+  * file formatted to use hex:
+  * {{{
+  *   0
+  *   7
+  *   d
+  *  15
+  * }}}
+  *
+  * A binary file can be similarly constructed.
+  * Chisel does not validate the file format or existence. It is supposed to be in a path accessible by the synthesis
+  * tool together with the generated Verilog.
+  *
+  * @see Chisel3 Wiki entry on
+  * [[https://github.com/freechipsproject/chisel3/wiki/Chisel-Memories#loading-memories-in-simulation "Loading Memories
+  * in Simulation"]]
+  */
+object loadMemoryFromFileInline {
+
+
+  /** Annotate a memory such that it can be initialized inline using a file
+    * @param memory the memory
+    * @param fileName the file used for initialization
+    * @param hexOrBinary whether the file uses a hex or binary number representation
+    */
+  def apply[T <: Data](
+    memory: MemBase[T],
+    fileName: String,
+    hexOrBinary: MemoryLoadFileType.FileType = MemoryLoadFileType.Hex
+  ): Unit = {
+    annotate(new ChiselAnnotation {
+      override def toFirrtl = MemoryFileInlineAnnotation(memory.toTarget, fileName, hexOrBinary)
+    })
   }
 }
 


### PR DESCRIPTION
This annotation adds memory import with inline generation for the
emmiter.
Supports both readmemh and readmemb statements based on argument.

This PR depends on FIRRTL version with merged PR https://github.com/chipsalliance/firrtl/pull/2107.

Example code:

```scala
package utils

import chisel3._
import chisel3.util.experimental.loadMemoryFromFileInline

class DualPortRAM(words: Int = 1, width: Int = 32, memoryFile: String = "")
    extends Module {
  val addrWidth = chiselTypeOf((words * 1024).U)
  val io = IO(new Bundle {
    // Port 1
    val addr1 = Input(addrWidth)
    val addr2 = Input(addrWidth)
    val dataIn1 = Input(UInt(width.W))
    val we1 = Input(Bool())
    val dataOut1 = Output(UInt(width.W))
    val dataOut2 = Output(UInt(width.W))
  })
  val mem = SyncReadMem(words, UInt(width.W))
  loadMemoryFromFileInline(mem, memoryFile)

  // Port 1
  io.dataOut1 := mem.read(io.addr1)
  when(io.we1) {
    mem.write(io.addr1, io.dataIn1)
  }
  // Port 2
  io.dataOut2 := mem.read(io.addr2)
}

object DualPortRAMObj extends App {
  (new chisel3.stage.ChiselStage).emitVerilog(
    new DualPortRAM(16, width = 64, memoryFile = "sample.hex"),
    Array("-X", "verilog") ++ args
  )
}
```

Generated Verilog:

```verilog
module DualPortRAM(
  input         clock,
  input         reset,
  input  [14:0] io_addr1,
  input  [14:0] io_addr2,
  input  [63:0] io_dataIn1,
  input         io_we1,
  output [63:0] io_dataOut1,
  output [63:0] io_dataOut2
);
`ifdef RANDOMIZE_REG_INIT
  reg [31:0] _RAND_0;
  reg [31:0] _RAND_1;
`endif // RANDOMIZE_REG_INIT
  reg [63:0] mem [0:15]; // @[DualportRAM.scala 26:24]
  wire [63:0] mem_MPORT_data; // @[DualportRAM.scala 26:24]
  wire [3:0] mem_MPORT_addr; // @[DualportRAM.scala 26:24]
  wire [63:0] mem_MPORT_2_data; // @[DualportRAM.scala 26:24]
  wire [3:0] mem_MPORT_2_addr; // @[DualportRAM.scala 26:24]
  wire [63:0] mem_MPORT_1_data; // @[DualportRAM.scala 26:24]
  wire [3:0] mem_MPORT_1_addr; // @[DualportRAM.scala 26:24]
  wire  mem_MPORT_1_mask; // @[DualportRAM.scala 26:24]
  wire  mem_MPORT_1_en; // @[DualportRAM.scala 26:24]
  reg [3:0] mem_MPORT_addr_pipe_0;
  reg [3:0] mem_MPORT_2_addr_pipe_0;
  assign mem_MPORT_addr = mem_MPORT_addr_pipe_0;
  assign mem_MPORT_data = mem[mem_MPORT_addr]; // @[DualportRAM.scala 26:24]
  assign mem_MPORT_2_addr = mem_MPORT_2_addr_pipe_0;
  assign mem_MPORT_2_data = mem[mem_MPORT_2_addr]; // @[DualportRAM.scala 26:24]
  assign mem_MPORT_1_data = io_dataIn1;
  assign mem_MPORT_1_addr = io_addr1[3:0];
  assign mem_MPORT_1_mask = 1'h1;
  assign mem_MPORT_1_en = io_we1;
  assign io_dataOut1 = mem_MPORT_data; // @[DualportRAM.scala 33:15]
  assign io_dataOut2 = mem_MPORT_2_data; // @[DualportRAM.scala 38:15]
  always @(posedge clock) begin
    if (mem_MPORT_1_en & mem_MPORT_1_mask) begin
      mem[mem_MPORT_1_addr] <= mem_MPORT_1_data; // @[DualportRAM.scala 26:24]
    end
    mem_MPORT_addr_pipe_0 <= io_addr1[3:0];
    mem_MPORT_2_addr_pipe_0 <= io_addr2[3:0];
  end
// Register and memory initialization
`ifdef RANDOMIZE_GARBAGE_ASSIGN
`define RANDOMIZE
`endif
`ifdef RANDOMIZE_INVALID_ASSIGN
`define RANDOMIZE
`endif
`ifdef RANDOMIZE_REG_INIT
`define RANDOMIZE
`endif
`ifdef RANDOMIZE_MEM_INIT
`define RANDOMIZE
`endif
`ifndef RANDOM
`define RANDOM $random
`endif
  integer initvar;
`ifndef SYNTHESIS
`ifdef FIRRTL_BEFORE_INITIAL
`FIRRTL_BEFORE_INITIAL
`endif
initial begin
  `ifdef RANDOMIZE
    `ifdef INIT_RANDOM
      `INIT_RANDOM
    `endif
    `ifndef VERILATOR
      `ifdef RANDOMIZE_DELAY
        #`RANDOMIZE_DELAY begin end
      `else
        #0.002 begin end
      `endif
    `endif
`ifdef RANDOMIZE_REG_INIT
  _RAND_0 = {1{`RANDOM}};
  mem_MPORT_addr_pipe_0 = _RAND_0[3:0];
  _RAND_1 = {1{`RANDOM}};
  mem_MPORT_2_addr_pipe_0 = _RAND_1[3:0];
`endif // RANDOMIZE_REG_INIT
  `endif // RANDOMIZE

initial begin
  $readmemh("sample.hex", mem);
end
end // initial
`ifdef FIRRTL_AFTER_INITIAL
`FIRRTL_AFTER_INITIAL
`endif
`endif // SYNTHESIS
endmodule
```

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
- new feature/API

#### API Impact

This change adds a new annotation method supporting load memory files inline in generated Verilog code. No impacts to existing methods or API.

#### Backend Code Generation Impact

The change adds inline memory read statements to generated Verilog backend.

#### Desired Merge Strategy

- Squash: The PR will be squashed and merged

#### Release Notes

(addition) Added `loadMemoryFromFileInline` annotation in `chisel3.util.experimental` to allow loading hex and bin memory files inline in Verilog emitter backend(#1805)

### Reviewer Checklist (only modified by reviewer)
- [x] Did you add the appropriate labels?
- [x] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.0, 3.5.0) ?
- [x] Did you review?
- [x] Did you check whether all relevant Contributor checkboxes have been checked?
- [x] Did you mark as `Please Merge`?
