### PR TITLE
allowReflectiveAutoCloneType must work outside of Builder context

### DIFF
--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -532,8 +532,12 @@ private[chisel3] object Builder extends LazyLogging {
     dynamicContext.currentReset = newReset
   }
 
-  // This should only be used for testing
-  def allowReflectiveAutoCloneType: Boolean = dynamicContext.allowReflectiveAutoCloneType
+  // This should only be used for testing, must be true outside of Builder context
+  def allowReflectiveAutoCloneType: Boolean = {
+    dynamicContextVar.value
+                     .map(_.allowReflectiveAutoCloneType)
+                     .getOrElse(true)
+  }
   def allowReflectiveAutoCloneType_=(value: Boolean): Unit = {
     dynamicContext.allowReflectiveAutoCloneType = value
   }

--- a/src/test/scala/chiselTests/AutoClonetypeSpec.scala
+++ b/src/test/scala/chiselTests/AutoClonetypeSpec.scala
@@ -127,6 +127,10 @@ class AutoClonetypeSpec extends ChiselFlatSpec with Utils {
     } }
   }
 
+  "Autoclonetype" should "work outside of a builder context" in {
+    new BundleWithIntArg(8).cloneType
+  }
+
   def checkSubBundleInvalid() = {
     elaborate { new Module {
       val io = IO(new Bundle{}).suggestName("io")


### PR DESCRIPTION
Some 2.11 tests caught this issue in https://github.com/chipsalliance/chisel3/pull/1810 since they don't run with the plugin.
Because this is already fixed there, this PR doesn't need backporting.

Basically, the problem is that the check I added in https://github.com/chipsalliance/chisel3/pull/1804 for disabling reflective autoclonetype triggers if reflective autoclonetype happens outside of a Builder context. This changes makes `Builder.allowReflectiveAutoCloneType` succeed if there is no `DynamicContext`. Because `allowReflectiveAutoCloneType` is only used in testing, this is the correct thing to do.

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [NA] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [NA] Did you add text to be included in the Release Notes for this change?

As a bug fix to a not-yet-released feature, no release notes for this particular PR

#### Type of Improvement

  - bug fix    

#### API Impact

No impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

   - Squash

#### Release Notes


### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.0, 3.5.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
