### PR TITLE
Fix incorrect usage of emitFirrtl in test

### DIFF
--- a/src/test/scala/chiselTests/experimental/verification/VerificationSpec.scala
+++ b/src/test/scala/chiselTests/experimental/verification/VerificationSpec.scala
@@ -28,7 +28,7 @@ class VerificationSpec extends ChiselPropSpec {
   }
 
   property("basic equality check should work") {
-    val fir = ChiselStage.emitFirrtl(new VerificationModule)
+    val fir = ChiselStage.emitChirrtl(new VerificationModule)
     val lines = fir.split("\n").map(_.trim)
     assertContains(lines, "cover(clock, _T, UInt<1>(\"h1\"), \"\") @[VerificationSpec.scala 16:15]")
     assertContains(lines, "assume(clock, _T_2, UInt<1>(\"h1\"), \"\") @[VerificationSpec.scala 18:18]")


### PR DESCRIPTION
Change a test to use emitChirrtl instead of emitFirrtl. This test
isn't supposed to be running the Scala FIRRTL Compiler, but the latter
method causes this to happen.

This fixes a mistake I introduced in b0389cc905eb19103cc4bc55e9ec9666c9939dca.

### Contributor Checklist

- [n/a] Did you add Scaladoc to every public function/method?
- [n/a] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
- code cleanup
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

None.

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

None.

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
- Squash: The PR will be squashed and merged (choose this if you have no preference.
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.0, 3.5.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
