### PR TITLE
Add toString method to BitPat

### DIFF
--- a/src/main/scala/chisel3/util/BitPat.scala
+++ b/src/main/scala/chisel3/util/BitPat.scala
@@ -119,4 +119,11 @@ sealed class BitPat(val value: BigInt, val mask: BigInt, width: Int) extends Sou
     !(this === that)
   }
 
+  override def toString = {
+    "BitPat(" +
+      (0 until width).map(i =>
+        if (((mask >> i) & 1) == 1) if (((value >> i) & 1) == 1)  "1" else "0" else "?"
+      ).reverse.reduce(_ + _) +
+    ")"
+  }
 }

--- a/src/test/scala/chiselTests/util/BitPatSpec.scala
+++ b/src/test/scala/chiselTests/util/BitPatSpec.scala
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiselTests.util
+
+import chisel3.util.BitPat
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+
+class BitPatSpec extends AnyFlatSpec with Matchers {
+  behavior of classOf[BitPat].toString
+
+  it should "convert a BitPat to readable form" in {
+    val testPattern = "0" * 32 + "1" * 32 + "?" * 32 + "?01" * 32
+    BitPat("b" + testPattern).toString should be (s"BitPat($testPattern)")
+  }
+}


### PR DESCRIPTION
Required by `util.experimental.decoder` (WIP, new name is `util.experimental.minimizer`). Use the string representation of BitPat as key of the cache map to provide reusability when generating minimized logic.
And also useful for normal usages.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method? N/A
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`? N/A
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
- new feature

#### API Impact
Add `toString` method to `BitPat`
<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

#### Backend Code Generation Impact
No
<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
- Squash: The PR will be squashed and merged.
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
BitPat can now produce meaningful string representation.
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.0, 3.5.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
