### PR TITLE
Don't toggle top.cpp clock and reset on same cycle

### DIFF
--- a/src/main/resources/chisel3/top.cpp
+++ b/src/main/resources/chisel3/top.cpp
@@ -47,8 +47,15 @@ int main(int argc, char** argv) {
   cout << "Starting simulation!\n";
 
   while (!Verilated::gotFinish() && main_time < timeout) {
-    if (main_time > 10) {
-      top->reset = 0;   // Deassert reset
+    // Deassert reset on timestep 10.  This needs to occur before the clock
+    // asserts on timestep 11 because there is a single call to top->eval() in
+    // this loop.  Verilator evaluates sequential logic (always blocks) before
+    // combinational logic during top->eval().  Staggering the reset update is
+    // necessary to produce the same simulation behavior independent of whether
+    // or not the generated Verilog puts synchronous reset logic inside or
+    // outside its associated always block.
+    if (main_time == 10) {
+      top->reset = 0;
     }
     if ((main_time % 10) == 1) {
       top->clock = 1;       // Toggle clock
@@ -92,4 +99,3 @@ int main(int argc, char** argv) {
     if (tfp) tfp->close();
 #endif
 }
-


### PR DESCRIPTION
Change top.cpp to deassert reset one time unit before the clock
asserts.  This avoids a simultation race condition if Chisel and a
FIRRTL compiler emit Verilog where a synchronous reset is not inside
the always block even though the Verilog is formally equivalent.

Reset now deasserts on time unit 10 and the clock ticks on time unit
11.

Concretely, the previous formulation of `top.cpp` is sensitive to changes in the Verilog emission that cropped up when trying to use `llvm/circt` purely for the Low -> Verilog path. This would result in things like the following two formally equivalent circuits resulting in simulation mismatches.

The Scala FIRRTL Compiler produces something like:
```verilog
module A(input clock, reset);
  reg [1:0] count;
  wire [1:0] _wrap_value_T_1 = count + 2'h1;
  always @(posedge clock) begin
    if (reset)
      count <= 2'h0;
    else
      count <= _wrap_value_T_1;
  end
endmodule
```

The MLIR FIRRTL Compiler (`llvm/circt`) produces something like:
```verilog
module B(input clock, reset);
  reg  [1:0] count;
  wire [1:0] _T;
  assign _T = count;
  wire [2:0] _T_2 = {1'h0, _T} + 3'h1;
  wire [1:0] _T_6 = ~{2{reset}} & _T_2[1:0];
  always_ff @(posedge clock)
    count <= _T_6;
endmodule
```

Both Yosys and Formality said these were equivalent.

As far as I can tell, the problem is that the `_T_6 = ~{2{reset}} & _T_2[1:0]` and the `posedge clock` blocks can execute in any order. One order is "correct" and one order is "incorrect". By moving the reset before the clock, `top.cpp` is then invariant to changes in however the backend decides to generate Verilog.

### Contributor Checklist

- [x] Did you add ~Scaladoc~ _C++ inline comments_ to every public function/method?
- [n/a] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
- bug fix                        
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

None.

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

#### Backend Code Generation Impact

None.

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
- Squash: The PR will be squashed and merged (choose this if you have no preference.
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.0, 3.5.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
