### PR TITLE
Make plugin autoclonetype always on

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -179,8 +179,6 @@ lazy val chisel = (project in file(".")).
     mimaPreviousArtifacts := Set(),
     libraryDependencies += defaultVersions("treadle") % "test",
     scalacOptions in Test ++= Seq("-language:reflectiveCalls"),
-    // Only used in Test for 3.4.x, used in Compile in 3.5
-    scalacOptions in Test += "-P:chiselplugin:useBundlePlugin",
     scalacOptions in Compile in doc ++= Seq(
       "-diagrams",
       "-groups",

--- a/plugin/src/main/scala-2.12/chisel3/internal/plugin/ChiselPlugin.scala
+++ b/plugin/src/main/scala-2.12/chisel3/internal/plugin/ChiselPlugin.scala
@@ -5,8 +5,9 @@ package chisel3.internal.plugin
 import scala.tools.nsc
 import nsc.Global
 import nsc.plugins.{Plugin, PluginComponent}
+import scala.reflect.internal.util.NoPosition
 
-private[plugin] case class ChiselPluginArguments(var useBundlePlugin: Boolean = false) {
+private[plugin] case class ChiselPluginArguments(var useBundlePlugin: Boolean = true) {
   def useBundlePluginOpt = "useBundlePlugin"
   def useBundlePluginFullOpt = s"-P:chiselplugin:$useBundlePluginOpt"
 }
@@ -24,7 +25,8 @@ class ChiselPlugin(val global: Global) extends Plugin {
   override def init(options: List[String], error: String => Unit): Boolean = {
     for (option <- options) {
       if (option == arguments.useBundlePluginOpt) {
-        arguments.useBundlePlugin = true
+        val msg = s"'${arguments.useBundlePluginFullOpt}' is now default behavior, you can stop using the scalacOption."
+        global.reporter.warning(NoPosition, msg)
       } else {
         error(s"Option not understood: '$option'")
       }

--- a/src/test/scala/chiselTests/AutoClonetypeSpec.scala
+++ b/src/test/scala/chiselTests/AutoClonetypeSpec.scala
@@ -265,19 +265,18 @@ class AutoClonetypeSpec extends ChiselFlatSpec with Utils {
 
   behavior of "Compiler Plugin Autoclonetype"
 
-  // Necessary test for 3.4.x, but we will break this (for non-plugin users) in 3.5
-  it should "NOT break code that extends chisel3.util Bundles (whether they use the plugin or not)" in {
-    class MyModule extends MultiIOModule {
-      val io = IO(new InheritingBundle)
-      io.deq <> io.enq
-      io.count := 0.U
-      io.error := true.B
-    }
-    elaborate(new MyModule)
-  }
-
   // New tests from the plugin
   if (usingPlugin) {
+    it should "NOT break code that extends chisel3.util Bundles if they use the plugin" in {
+      class MyModule extends MultiIOModule {
+        val io = IO(new InheritingBundle)
+        io.deq <> io.enq
+        io.count := 0.U
+        io.error := true.B
+      }
+      elaborate(new MyModule)
+    }
+
     it should "support Bundles with non-val parameters" in {
       class MyBundle(i: Int) extends Bundle {
         val foo = UInt(i.W)


### PR DESCRIPTION
Follow on to https://github.com/chipsalliance/chisel3/pull/1804, make the compiler plugin autoclonetype be always on and thus used in chisel3 itself.

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

- performance improvement 
 - new feature/API  

#### API Impact

As described in the release notes in https://github.com/chipsalliance/chisel3/pull/1804 and reflected in the test change, this will cause issues for any Bundle that inherits from a Bundle in `chisel3.util` if the code is not also compiled using the compiler plugin. Thus, this change can only occur on the major version bump.

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

#### Desired Merge Strategy

- Squash

#### Release Notes

Always generate `cloneType` methods for Bundles using the compiler plugin. This causes a binary and source incompatible change for any Chisel code that does not use the compiler plugin but extends a `Bundle` in other code that does. All Chisel users should use the compiler plugin.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.0, 3.5.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
