### PR TITLE
Fix doc formatting and generation

### DIFF
--- a/docs/src/explanations/memories.md
+++ b/docs/src/explanations/memories.md
@@ -15,31 +15,30 @@ Users can define read only memories with a `Vec`:
 ```scala mdoc:invisible
 import chisel3._
 ```
-
 ``` scala mdoc:compile-only
-    VecInit(inits: Seq[T])
-    VecInit(elt0: T, elts: T*)
+VecInit(inits: Seq[T])
+VecInit(elt0: T, elts: T*)
 ```
 
 where `inits` is a sequence of initial `Data` literals that initialize the ROM. For example,  users cancreate a small ROM initialized to 1, 2, 4, 8 and loop through all values using a counter as an address generator as follows:
 
 ``` scala mdoc:compile-only
-    val m = VecInit(Array(1.U, 2.U, 4.U, 8.U))
-    val r = m(counter(m.length.U))
+val m = VecInit(Array(1.U, 2.U, 4.U, 8.U))
+val r = m(counter(m.length.U))
 ```
 
 We can create an *n* value sine lookup table using a ROM initialized as follows:
 
 ``` scala mdoc:silent
-    def sinTable(amp: Double, n: Int) = {
-      val times =
-        (0 until n).map(i => (i*2*Pi)/(n.toDouble-1) - Pi)
-      val inits =
-        times.map(t => round(amp * sin(t)).asSInt(32.W))
-      VecInit(inits)
-    }
-    def sinWave(amp: Double, n: Int) =
-      sinTable(amp, n)(counter(n.U))
+def sinTable(amp: Double, n: Int) = {
+  val times =
+    (0 until n).map(i => (i*2*Pi)/(n.toDouble-1) - Pi)
+  val inits =
+    times.map(t => round(amp * sin(t)).asSInt(32.W))
+  VecInit(inits)
+}
+def sinWave(amp: Double, n: Int) =
+  sinTable(amp, n)(counter(n.U))
 ```
 
 where `amp` is used to scale the fixpoint values stored in the ROM.

--- a/docs/src/explanations/memories.md
+++ b/docs/src/explanations/memories.md
@@ -15,21 +15,21 @@ Users can define read only memories with a `Vec`:
 ```scala mdoc:invisible
 import chisel3._
 ```
-``` scala mdoc:compile-only
+```scala mdoc:compile-only
 VecInit(inits: Seq[T])
 VecInit(elt0: T, elts: T*)
 ```
 
 where `inits` is a sequence of initial `Data` literals that initialize the ROM. For example,  users cancreate a small ROM initialized to 1, 2, 4, 8 and loop through all values using a counter as an address generator as follows:
 
-``` scala mdoc:compile-only
+```scala mdoc:compile-only
 val m = VecInit(Array(1.U, 2.U, 4.U, 8.U))
 val r = m(counter(m.length.U))
 ```
 
 We can create an *n* value sine lookup table using a ROM initialized as follows:
 
-``` scala mdoc:silent
+```scala mdoc:silent
 def sinTable(amp: Double, n: Int) = {
   val times =
     (0 until n).map(i => (i*2*Pi)/(n.toDouble-1) - Pi)

--- a/docs/src/explanations/memories.md
+++ b/docs/src/explanations/memories.md
@@ -10,31 +10,32 @@ Chisel provides facilities for creating both read only and read/write memories.
 
 ## ROM
 
-Users can define read only memories with a `Vec`:
+Users can define read-only memories by constructing a `Vec` with `VecInit`.
+`VecInit` can except either a variable-argument number of `Data` literals or a `Seq[Data]` literals that initialize the ROM.
 
 ```scala mdoc:invisible
 import chisel3._
-```
-```scala mdoc:compile-only
-VecInit(inits: Seq[T])
-VecInit(elt0: T, elts: T*)
+// This is bad, don't do this, use a val
+def counter = util.Counter(true.B, 4)._1
+val Pi = 3.14
+def sin(t: Double): Double = t // What should this be?
 ```
 
-where `inits` is a sequence of initial `Data` literals that initialize the ROM. For example,  users cancreate a small ROM initialized to 1, 2, 4, 8 and loop through all values using a counter as an address generator as follows:
+For example, users can create a small ROM initialized to 1, 2, 4, 8 and loop through all values using a counter as an address generator as follows:
 
 ```scala mdoc:compile-only
-val m = VecInit(Array(1.U, 2.U, 4.U, 8.U))
+val m = VecInit(1.U, 2.U, 4.U, 8.U)
 val r = m(counter(m.length.U))
 ```
 
 We can create an *n* value sine lookup table using a ROM initialized as follows:
 
-```scala mdoc:silent
+```scala mdoc:compile-only
 def sinTable(amp: Double, n: Int) = {
   val times =
     (0 until n).map(i => (i*2*Pi)/(n.toDouble-1) - Pi)
   val inits =
-    times.map(t => round(amp * sin(t)).asSInt(32.W))
+    times.map(t => Math.round(amp * sin(t)).asSInt(32.W))
   VecInit(inits)
 }
 def sinWave(amp: Double, n: Int) =

--- a/docs/src/explanations/polymorphism-and-parameterization.md
+++ b/docs/src/explanations/polymorphism-and-parameterization.md
@@ -231,7 +231,10 @@ class X[T <: BaseModule with MyAdder](genT: => T) extends Module {
 println(ChiselStage.emitVerilog(new X(new Mod1)))
 println(ChiselStage.emitVerilog(new X(new Mod2)))
 ```
-```scala mdoc:passthrough
-println(ChiselStage.emitVerilog(new X(new Mod1)))
-println(ChiselStage.emitVerilog(new X(new Mod2)))
+
+Output:
+
+```scala mdoc:verilog
+ChiselStage.emitVerilog(new X(new Mod1))
+ChiselStage.emitVerilog(new X(new Mod2))
 ```

--- a/docs/src/explanations/sequential-circuits.md
+++ b/docs/src/explanations/sequential-circuits.md
@@ -11,7 +11,7 @@ import chisel3._
 val in = Bool()
 ```
 The simplest form of state element supported by Chisel is a positive edge-triggered register, which can be instantiated as:
-``` scala mdoc:compile-only
+```scala mdoc:compile-only
 val reg = RegNext(in)
 ```
 This circuit has an output that is a copy of the input signal `in` delayed by one clock cycle. Note that we do not have to specify the type of Reg as it will be automatically inferred from its input when instantiated in this way. In the current version of Chisel, clock and reset are global signals that are implicitly included where needed.


### PR DESCRIPTION
### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

- documentation

#### API Impact

No API impact. Just fix for documentation generation.

#### Backend Code Generation Impact

No impact.

#### Desired Merge Strategy

- Squash: The PR will be squashed and merged (choose this if you have no preference.

#### Release Notes

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.x, 3.5.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
