### PR TITLE
Cookbook: clean up desiredName example

### DIFF
--- a/docs/src/cookbooks/cookbook.md
+++ b/docs/src/cookbooks/cookbook.md
@@ -447,16 +447,16 @@ class Salt extends Module {
 }
 ```
 
-Elaborating the Chisel module `Salt` yields our "desire name" for `Salt` and `Coffee` in the output Verilog:
-```scala mdoc:passthrough
-import chisel3.stage.{ChiselStage, ChiselGeneratorAnnotation}
-import firrtl.annotations.DeletedAnnotation
-import firrtl.EmittedVerilogCircuitAnnotation
+Elaborating the Chisel module `Salt` yields our "desired names" for `Salt` and `Coffee` in the output Verilog:
+```scala mdoc:silent
+import chisel3.stage.ChiselStage
 
-(new ChiselStage)
-  .execute(Array("-X", "verilog"), Seq(ChiselGeneratorAnnotation(() => new Salt)))
-  .collectFirst{ case DeletedAnnotation(_, a: EmittedVerilogCircuitAnnotation) => a.value.value }
-  .foreach(a => println(s"""|```verilog
-                            |$a
-                            |```""".stripMargin))
+(ChiselStage).emitVerilog(new Salt)
+```
+
+```scala mdoc:passthrough
+val a = (ChiselStage).emitVerilog(new Salt)
+println(s"""|```verilog
+            |$a
+            |```""".stripMargin)
 ```

--- a/docs/src/cookbooks/cookbook.md
+++ b/docs/src/cookbooks/cookbook.md
@@ -451,12 +451,9 @@ Elaborating the Chisel module `Salt` yields our "desired names" for `Salt` and `
 ```scala mdoc:silent
 import chisel3.stage.ChiselStage
 
-(ChiselStage).emitVerilog(new Salt)
+ChiselStage.emitVerilog(new Salt)
 ```
 
-```scala mdoc:passthrough
-val a = (ChiselStage).emitVerilog(new Salt)
-println(s"""|```verilog
-            |$a
-            |```""".stripMargin)
+```scala mdoc:verilog
+ChiselStage.emitVerilog(new Salt)
 ```


### PR DESCRIPTION
### Contributor Checklist

- [N/A] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Old:

Elaborating the Chisel module Salt yields our “desire name” for Salt and Coffee in the output Verilog: Elaborating design… [[34mdeprecated[0m] class repl.MdocSession$App12$Salt\(anonfun$80\)anonfun$apply$38\(anon$7 (1 calls): chisel3.1 autoclonetype failed, falling back to 3.0 behavior using null as the outer instance. Autoclonetype failure reason: Unable to determine instance of outer class class repl.MdocSession$App12$Salt\)anonfun$80\(anonfun$apply$38, no candidates assignable to outer class types; examined List(repl.MdocSession$App12$Salt@2b5e67c4) [[34mdeprecated[0m] class repl.MdocSession$App12$Coffee\)anonfun$77\(anonfun$apply$37\)anon$6 (1 calls): chisel3.1 autoclonetype failed, falling back to 3.0 behavior using null as the outer instance. Autoclonetype failure reason: Unable to determine instance of outer class class repl.MdocSession$App12$Coffee\(anonfun$77\)anonfun$apply$37, no candidates assignable to outer class types; examined List(repl.MdocSession$App12$Coffee@1ffbbd46) [[33mwarn[0m] [33mThere were 2 deprecated function(s) used. These may stop compiling in a future release - you are encouraged to fix these issues.[0m [[33mwarn[0m] Line numbers for deprecations reported by Chisel may be inaccurate; enable scalac compiler deprecation warnings via either of the following methods: [[33mwarn[0m] In the sbt interactive console, enter: [[33mwarn[0m] set scalacOptions in ThisBuild ++= Seq(“-unchecked”, “-deprecation”) [[33mwarn[0m] or, in your build.sbt, add the line: [[33mwarn[0m] scalacOptions := Seq(“-unchecked”, “-deprecation”) Done elaborating.

#### This PR:

Elaborating the Chisel module `Salt` yields our "desired names" for `Salt` and `Coffee` in the output Verilog:
```scala
import chisel3.stage.ChiselStage

(ChiselStage).emitVerilog(new Salt)
```

```verilog
module SodiumMonochloride(
  input   clock,
  input   reset
);
  wire [31:0] drink_I; // @[cookbook.md 377:23]
  wire [31:0] drink_O; // @[cookbook.md 377:23]
  Tea drink ( // @[cookbook.md 377:23]
    .I(drink_I),
    .O(drink_O)
  );
  assign drink_I = 32'h0;
endmodule

```

#### Type of Improvement

<!-- Choose one or more from the following: -->
- bug fix 
- documentation 
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

No impact

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->
No Impact
#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
- Squash: The PR will be squashed and merged (choose this if you have no preference.
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

Clean up cookbook example of desiredName 

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.x, 3.5.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
