### PR TITLE
Fix ShiftRegister with 0 delay. 

### DIFF
--- a/src/main/scala/chisel3/util/Reg.scala
+++ b/src/main/scala/chisel3/util/Reg.scala
@@ -42,7 +42,7 @@ object ShiftRegister
     * val regDelayTwo = ShiftRegister(nextVal, 2, ena)
     * }}}
     */
-  def apply[T <: Data](in: T, n: Int, en: Bool = true.B): T = ShiftRegisters(in, n, en).last
+  def apply[T <: Data](in: T, n: Int, en: Bool = true.B): T = ShiftRegisters(in, n, en).lastOption.getOrElse(in)
 
   /** Returns the n-cycle delayed version of the input signal with reset initialization.
     *
@@ -55,7 +55,7 @@ object ShiftRegister
     * val regDelayTwoReset = ShiftRegister(nextVal, 2, 0.U, ena)
     * }}}
     */
-  def apply[T <: Data](in: T, n: Int, resetData: T, en: Bool): T = ShiftRegisters(in, n, resetData, en).last
+  def apply[T <: Data](in: T, n: Int, resetData: T, en: Bool): T = ShiftRegisters(in, n, resetData, en).lastOption.getOrElse(in)
 }
 
 

--- a/src/test/scala/chiselTests/Reg.scala
+++ b/src/test/scala/chiselTests/Reg.scala
@@ -7,6 +7,7 @@ import chisel3.util._
 import chisel3.experimental.DataMirror
 import chisel3.stage.ChiselStage
 import chisel3.testers.BasicTester
+import org.scalacheck.Gen
 
 class RegSpec extends ChiselFlatSpec {
   "Reg" should "be of the same type and width as t" in {
@@ -55,18 +56,18 @@ class ShiftResetTester(n: Int) extends BasicTester {
   val start = 23.U
   val sr = ShiftRegister(cntVal + 23.U, n, 1.U, true.B)
   when(done) {
-    assert(sr === 1.U)
+    assert(sr === (if(n == 0) cntVal + 23.U else 1.U))
     stop()
   }
 }
 
 class ShiftRegisterSpec extends ChiselPropSpec {
   property("ShiftRegister should shift") {
-    forAll(smallPosInts) { (shift: Int) => assertTesterPasses{ new ShiftTester(shift) } }
+    forAll(Gen.choose(0, 4)) { (shift: Int) => assertTesterPasses{ new ShiftTester(shift) } }
   }
 
   property("ShiftRegister should reset all values inside") {
-    forAll(smallPosInts) { (shift: Int) => assertTesterPasses{ new ShiftResetTester(shift) } }
+    forAll(Gen.choose(0, 4)) { (shift: Int) => assertTesterPasses{ new ShiftResetTester(shift) } }
   }
 }
 
@@ -84,6 +85,6 @@ class ShiftsTester(n: Int) extends BasicTester {
 
 class ShiftRegistersSpec extends ChiselPropSpec {
   property("ShiftRegisters should shift") {
-    forAll(smallPosInts) { (shift: Int) => assertTesterPasses{ new ShiftsTester(shift) } }
+    forAll(Gen.choose(0, 4)) { (shift: Int) => assertTesterPasses{ new ShiftsTester(shift) } }
   }
 }


### PR DESCRIPTION
if ShiftRegisters is empty, scala will complain:
```
  java.util.NoSuchElementException
    scala.collection.LinearSeqOptimized.last(LinearSeqOptimized.scala:150)
```
This PR:
1. fix this issue and return `in` directly when ShiftRegister size is 0.
1. Add test to check ShiftRegister(s) with delay is 0. 

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement
- bug fix

#### API Impact
None

#### Backend Code Generation Impact
No

#### Desired Merge Strategy
- Rebase: You will rebase the PR onto master and it will be merged with a merge commit.

#### Release Notes

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.x, 3.5.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
