### PR TITLE
remove scopt dependency.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -72,7 +72,6 @@ lazy val chiselSettings = Seq (
   libraryDependencies ++= Seq(
     "org.scalatest" %% "scalatest" % "3.1.2" % "test",
     "org.scalatestplus" %% "scalacheck-1-14" % "3.2.2.0" % "test",
-    "com.github.scopt" %% "scopt" % "4.0.1"
   ),
 ) ++ (
   // Tests from other projects may still run concurrently

--- a/build.sc
+++ b/build.sc
@@ -107,7 +107,6 @@ class chisel3CrossModule(val crossScalaVersion: String) extends CommonModule wit
     override def ivyDeps = m.ivyDeps() ++ Agg(
       ivy"org.scalatest::scalatest:3.1.2",
       ivy"org.scalatestplus::scalacheck-1-14:3.2.2.0",
-      ivy"com.github.scopt::scopt:4.0.1"
     ) ++ m.treadleIvyDeps
 
     override def moduleDeps = super.moduleDeps ++ treadleModule


### PR DESCRIPTION
ChiselStage -> Stage(from firrtl) -> scopt, Chisel no longer explicitly depends on scopt. 
I forgot to remove this in #1730
### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement
- code cleanup

#### API Impact
None

#### Backend Code Generation Impact
None

#### Desired Merge Strategy
- Rebase: You will rebase the PR onto master and it will be merged with a merge commit. 

#### Release Notes
None

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.x, 3.5.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
