### PR TITLE
throw exception if BitPat width is 0 

### DIFF
--- a/src/main/scala/chisel3/util/BitPat.scala
+++ b/src/main/scala/chisel3/util/BitPat.scala
@@ -23,6 +23,7 @@ object BitPat {
     // If ? parsing is to be exposed, the return API needs further scrutiny
     // (especially with things like mask polarity).
     require(x.head == 'b', "BitPats must be in binary and be prefixed with 'b'")
+    require(x.length > 1, "BitPat width cannot be 0.")
     var bits = BigInt(0)
     var mask = BigInt(0)
     var count = 0

--- a/src/test/scala/chiselTests/util/BitPatSpec.scala
+++ b/src/test/scala/chiselTests/util/BitPatSpec.scala
@@ -16,6 +16,6 @@ class BitPatSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "not fail if BitPat width is 0" in {
-    BitPat("b").toString
+    intercept[IllegalArgumentException]{BitPat("b")}
   }
 }

--- a/src/test/scala/chiselTests/util/BitPatSpec.scala
+++ b/src/test/scala/chiselTests/util/BitPatSpec.scala
@@ -14,4 +14,8 @@ class BitPatSpec extends AnyFlatSpec with Matchers {
     val testPattern = "0" * 32 + "1" * 32 + "?" * 32 + "?01" * 32
     BitPat("b" + testPattern).toString should be (s"BitPat($testPattern)")
   }
+
+  it should "not fail if BitPat width is 0" in {
+    BitPat("b").toString
+  }
 }


### PR DESCRIPTION
fix #1919 
### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement
- bug fix

#### API Impact
None

#### Backend Code Generation Impact
None

#### Desired Merge Strategy
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->

#### Release Notes

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.x, 3.5.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
