### PR TITLE
Verilog

### DIFF
--- a/src/main/scala/chisel3/verilog.scala
+++ b/src/main/scala/chisel3/verilog.scala
@@ -1,0 +1,15 @@
+package chisel3
+
+import chisel3.stage.ChiselStage
+import firrtl.AnnotationSeq
+
+object getVerilogString {
+  def apply(gen: => RawModule): String = ChiselStage.emitVerilog(gen)
+}
+
+object emitVerilog {
+  def apply(gen: => RawModule, args: Array[String] = Array.empty,
+                  annotations: AnnotationSeq = Seq.empty): Unit = {
+    (new ChiselStage).emitVerilog(gen, args, annotations)
+  }
+}

--- a/src/test/scala/chiselTests/Module.scala
+++ b/src/test/scala/chiselTests/Module.scala
@@ -8,6 +8,8 @@ import chisel3.stage.{ChiselGeneratorAnnotation, ChiselStage, NoRunFirrtlCompile
 import firrtl.annotations.NoTargetAnnotation
 import firrtl.options.Unserializable
 
+import scala.io.Source
+
 class SimpleIO extends Bundle {
   val in  = Input(UInt(32.W))
   val out = Output(UInt(32.W))
@@ -186,5 +188,16 @@ class ModuleSpec extends ChiselPropSpec with Utils {
       assert(name.contains("_Anon"))
     }
     ChiselStage.elaborate(new RawModule with Foo)
+  }
+
+  property("getVerilogString(new PlusOne() should produce a valid Verilog string") {
+    val s = getVerilogString(new PlusOne())
+    assert(s.contains("assign io_out = io_in + 32'h1"))
+  }
+
+  property("emitVerilog((new PlusOne()..) shall produce a valid Verilog file in a subfolder") {
+   emitVerilog(new PlusOne(), Array("--target-dir", "generated"))
+    val s = Source.fromFile("generated/PlusOne.v").mkString("")
+    assert(s.contains("assign io_out = io_in + 32'h1"))
   }
 }


### PR DESCRIPTION
### Contributor Checklist

This is just a start for a discussion to resolve  #1715. Not intended to merge now, before we finished the discussion.

This is a quick fix to add Verilog emission to a Chisel3 object, instead of ChiselStage or new ChiselStage. However, I would prefer to have this functionality on ```Module```, like this:

```
(new Hello()).emitVerilog
```

where ```Hello()``` is a Chisel Module.
