### PR TITLE
Get rid of Docker.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,21 +16,19 @@ jobs:
     strategy:
       matrix:
         scala: [2.13.6, 2.12.13]
-    container:
-      image: ucbbar/chisel3-tools
-      options: --user github --entrypoint /bin/bash
-    env:
-      CONTAINER_HOME: /home/github
+    container: archlinux/archlinux:latest
 
     steps:
+      - name: Install dependencies
+        run: |
+          echo -e '[archlinuxcn]\nServer = https://repo.archlinuxcn.org/$arch' >> /etc/pacman.conf
+          pacman-key --init
+          pacman -Syu --noconfirm archlinuxcn-keyring
+          pacman -Syu --noconfirm jdk11-graalvm-bin
+          pacman -Syu --noconfirm git sbt mill verilator z3 make clang
+          archlinux-java set java-11-graalvm
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Setup Scala
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: adopt@1.8
-      - name: Cache Scala
-        uses: coursier/cache-action@v5
       - name: Documentation (Scala 2.12 only)
         if: matrix.scala == '2.12.13'
         run: sbt ++${{ matrix.scala }} docs/mdoc
@@ -55,19 +53,14 @@ jobs:
   publish:
     needs: [all_tests_passed]
     runs-on: ubuntu-latest
+    container: archlinux/archlinux:latest
     if: github.event_name == 'push'
 
     steps:
+      - name: Install dependencies
+        run: pacman -Syu --noconfirm git sbt gnupg
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Setup Scala
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: adopt@1.8
-      - name: Cache Scala
-        uses: coursier/cache-action@v5
-      - name: Setup GPG (for Publish)
-        uses: olafurpg/setup-gpg@v3
       - name: Publish
         run: sbt ci-release
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,12 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
+          echo -e '[archlinuxcn]\nServer = https://repo.archlinuxcn.org/$arch' >> /etc/pacman.conf
+          pacman-key --init
+          pacman -Syu --noconfirm archlinuxcn-keyring
+          pacman -Syu --noconfirm jdk11-graalvm-bin
           pacman -Syu --noconfirm git sbt mill verilator z3 make clang
+          archlinux-java set java-11-graalvm
       - name: Checkout
         uses: actions/checkout@v2
       - name: Documentation (Scala 2.12 only)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,12 +21,7 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
-          echo -e '[archlinuxcn]\nServer = https://repo.archlinuxcn.org/$arch' >> /etc/pacman.conf
-          pacman-key --init
-          pacman -Syu --noconfirm archlinuxcn-keyring
-          pacman -Syu --noconfirm jdk11-graalvm-bin
           pacman -Syu --noconfirm git sbt mill verilator z3 make clang
-          archlinux-java set java-11-graalvm
       - name: Checkout
         uses: actions/checkout@v2
       - name: Documentation (Scala 2.12 only)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
           pacman-key --init
           pacman -Syu --noconfirm archlinuxcn-keyring
           pacman -Syu --noconfirm jdk11-graalvm-bin
-          pacman -Syu --noconfirm git sbt mill verilator z3 make clang
+          pacman -Syu --noconfirm git sbt mill verilator z3 make gcc
           archlinux-java set java-11-graalvm
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
This patch changes CI from self-maintained docker to Arch Linux, which provides all binary dependency from its upstream repository.
This makes possible to automatically check our publish is compatible to upstream stable version, and ease the maintenance burden of chisel-tools docker image.
It also switch to the graalvm to speed up our test.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement
- new feature/API

#### API Impact
None

#### Backend Code Generation Impact
None

#### Desired Merge Strategy
- Squash

#### Release Notes
Switch CI to Arch Linux

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.x, 3.5.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
