### PR TITLE
Stop Emitting BlackBoxResourceAnno

### DIFF
--- a/src/main/scala/chisel3/util/BlackBoxUtils.scala
+++ b/src/main/scala/chisel3/util/BlackBoxUtils.scala
@@ -6,7 +6,6 @@ import chisel3._
 import chisel3.experimental.{ChiselAnnotation, RunFirrtlTransform}
 import firrtl.transforms.{BlackBoxPathAnno, BlackBoxResourceAnno, BlackBoxInlineAnno, BlackBoxSourceHelper,
   BlackBoxNotFoundException}
-import java.io.{File, FileNotFoundException}
 
 trait HasBlackBoxResource extends BlackBox {
   self: BlackBox =>

--- a/src/main/scala/chisel3/util/BlackBoxUtils.scala
+++ b/src/main/scala/chisel3/util/BlackBoxUtils.scala
@@ -16,10 +16,12 @@ private[util] object BlackBoxHelpers {
     def fromResource(resourceName: String, moduleName: ModuleName) = try {
       val blackBoxFile = os.resource / os.RelPath(resourceName.dropWhile(_ == '/'))
       val contents = os.read(blackBoxFile)
-      if (contents.size > BigInt(2).pow(20))
-        logger.warn(s"Included black box resource $resourceName, which will be converted to an inline annotation, is greater than 1 MiB. This may affect compiler performance. Consider including this resource via a black box path.")
-
-
+      if (contents.size > BigInt(2).pow(20)) {
+        val message =
+          s"Black box resource $resourceName, which will be converted to an inline annotation, is greater than 1 MiB." +
+            "This may affect compiler performance. Consider including this resource via a black box path."
+        logger.warn(message)
+      }
       BlackBoxInlineAnno(moduleName, blackBoxFile.last, contents)
     } catch {
       case e: os.ResourceNotFoundException =>

--- a/src/main/scala/chisel3/util/BlackBoxUtils.scala
+++ b/src/main/scala/chisel3/util/BlackBoxUtils.scala
@@ -6,6 +6,29 @@ import chisel3._
 import chisel3.experimental.{ChiselAnnotation, RunFirrtlTransform}
 import firrtl.transforms.{BlackBoxPathAnno, BlackBoxResourceAnno, BlackBoxInlineAnno, BlackBoxSourceHelper,
   BlackBoxNotFoundException}
+import firrtl.annotations.ModuleName
+import logger.LazyLogging
+
+private[util] object BlackBoxHelpers {
+
+  implicit class BlackBoxInlineAnnoHelpers(anno: BlackBoxInlineAnno.type) extends LazyLogging {
+    /** Generate a BlackBoxInlineAnno from a Java Resource and a module name. */
+    def fromResource(resourceName: String, moduleName: ModuleName) = try {
+      val blackBoxFile = os.resource / os.RelPath(resourceName.dropWhile(_ == '/'))
+      val contents = os.read(blackBoxFile)
+      if (contents.size > BigInt(2).pow(20))
+        logger.warn(s"Included black box resource $resourceName, which will be converted to an inline annotation, is greater than 1 MiB. This may affect compiler performance. Consider including this resource via a black box path.")
+
+
+      BlackBoxInlineAnno(moduleName, blackBoxFile.last, contents)
+    } catch {
+      case e: os.ResourceNotFoundException =>
+        throw new BlackBoxNotFoundException(resourceName, e.getMessage)
+    }
+  }
+}
+
+import BlackBoxHelpers._
 
 trait HasBlackBoxResource extends BlackBox {
   self: BlackBox =>
@@ -21,13 +44,7 @@ trait HasBlackBoxResource extends BlackBox {
     */
   def addResource(blackBoxResource: String): Unit = {
     val anno = new ChiselAnnotation with RunFirrtlTransform {
-      def toFirrtl = try {
-        val blackBoxFile = os.resource / os.RelPath(blackBoxResource.dropWhile(_ == '/'))
-        BlackBoxInlineAnno(self.toNamed, blackBoxFile.last, os.read(blackBoxFile))
-      } catch {
-        case e: os.ResourceNotFoundException =>
-          throw new BlackBoxNotFoundException(blackBoxResource, e.getMessage)
-      }
+      def toFirrtl = BlackBoxInlineAnno.fromResource(blackBoxResource, self.toNamed)
       def transformClass = classOf[BlackBoxSourceHelper]
     }
     chisel3.experimental.annotate(anno)

--- a/src/main/scala/chisel3/util/ExtModuleUtils.scala
+++ b/src/main/scala/chisel3/util/ExtModuleUtils.scala
@@ -20,10 +20,12 @@ trait HasExtModuleResource extends ExtModule {
     */
   def addResource(blackBoxResource: String): Unit = {
     val anno = new ChiselAnnotation with RunFirrtlTransform {
-      def toFirrtl = {
-        ResourceHelpers.getResourceAsString(blackBoxResource) match {
-          case ResourceHelpers.ResourceResult(fileName, contents) => BlackBoxInlineAnno(self.toNamed, fileName, contents)
-        }
+      def toFirrtl = try {
+        val blackBoxFile = os.resource / os.RelPath(blackBoxResource.dropWhile(_ == '/'))
+        BlackBoxInlineAnno(self.toNamed, blackBoxFile.last, os.read(blackBoxFile))
+      } catch {
+        case e: os.ResourceNotFoundException =>
+          throw new BlackBoxNotFoundException(blackBoxResource, e.getMessage)
       }
       def transformClass = classOf[BlackBoxSourceHelper]
     }

--- a/src/main/scala/chisel3/util/ExtModuleUtils.scala
+++ b/src/main/scala/chisel3/util/ExtModuleUtils.scala
@@ -5,7 +5,6 @@ package chisel3.util
 import chisel3.experimental.{ChiselAnnotation, ExtModule, RunFirrtlTransform}
 import firrtl.transforms.{BlackBoxPathAnno, BlackBoxResourceAnno, BlackBoxInlineAnno, BlackBoxSourceHelper,
   BlackBoxNotFoundException}
-import java.io.{File, FileNotFoundException}
 
 trait HasExtModuleResource extends ExtModule {
   self: ExtModule =>

--- a/src/main/scala/chisel3/util/ExtModuleUtils.scala
+++ b/src/main/scala/chisel3/util/ExtModuleUtils.scala
@@ -3,7 +3,9 @@
 package chisel3.util
 
 import chisel3.experimental.{ChiselAnnotation, ExtModule, RunFirrtlTransform}
-import firrtl.transforms.{BlackBoxPathAnno, BlackBoxResourceAnno, BlackBoxInlineAnno, BlackBoxSourceHelper}
+import firrtl.transforms.{BlackBoxPathAnno, BlackBoxResourceAnno, BlackBoxInlineAnno, BlackBoxSourceHelper,
+  BlackBoxNotFoundException}
+import java.io.{File, FileNotFoundException}
 
 trait HasExtModuleResource extends ExtModule {
   self: ExtModule =>
@@ -18,7 +20,11 @@ trait HasExtModuleResource extends ExtModule {
     */
   def addResource(blackBoxResource: String): Unit = {
     val anno = new ChiselAnnotation with RunFirrtlTransform {
-      def toFirrtl = BlackBoxResourceAnno(self.toNamed, blackBoxResource)
+      def toFirrtl = {
+        ResourceHelpers.getResourceAsString(blackBoxResource) match {
+          case ResourceHelpers.ResourceResult(fileName, contents) => BlackBoxInlineAnno(self.toNamed, fileName, contents)
+        }
+      }
       def transformClass = classOf[BlackBoxSourceHelper]
     }
     chisel3.experimental.annotate(anno)

--- a/src/main/scala/chisel3/util/ExtModuleUtils.scala
+++ b/src/main/scala/chisel3/util/ExtModuleUtils.scala
@@ -6,6 +6,8 @@ import chisel3.experimental.{ChiselAnnotation, ExtModule, RunFirrtlTransform}
 import firrtl.transforms.{BlackBoxPathAnno, BlackBoxResourceAnno, BlackBoxInlineAnno, BlackBoxSourceHelper,
   BlackBoxNotFoundException}
 
+import BlackBoxHelpers._
+
 trait HasExtModuleResource extends ExtModule {
   self: ExtModule =>
 
@@ -19,13 +21,7 @@ trait HasExtModuleResource extends ExtModule {
     */
   def addResource(blackBoxResource: String): Unit = {
     val anno = new ChiselAnnotation with RunFirrtlTransform {
-      def toFirrtl = try {
-        val blackBoxFile = os.resource / os.RelPath(blackBoxResource.dropWhile(_ == '/'))
-        BlackBoxInlineAnno(self.toNamed, blackBoxFile.last, os.read(blackBoxFile))
-      } catch {
-        case e: os.ResourceNotFoundException =>
-          throw new BlackBoxNotFoundException(blackBoxResource, e.getMessage)
-      }
+      def toFirrtl = BlackBoxInlineAnno.fromResource(blackBoxResource, self.toNamed)
       def transformClass = classOf[BlackBoxSourceHelper]
     }
     chisel3.experimental.annotate(anno)


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

Other.

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

Change Chisel to never emit `BlackBoxResourceAnno`. This improves the separation between Chisel and a FIRRTL compiler. The semantics of locating the file associated with a `BlackBoxResourceAnno` is that of Java Resources. This is fine if a FIRRTL compiler is implemented on top of the JVM. However, if the FIRRTL compiler is _not_ implemented on the JVM, then it makes the Chisel classpath part of what is necessary to pass to the FIRRTL compiler (and that a FIRRTL compiler needs to handle Java resource finding).

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

No.

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
- Squash: The PR will be squashed and merged (choose this if you have no preference.
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.x, 3.5.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
