### PR TITLE
Add API for setting MultiClock in current Module scope

### DIFF
--- a/core/src/main/scala/chisel3/MultiClock.scala
+++ b/core/src/main/scala/chisel3/MultiClock.scala
@@ -6,6 +6,41 @@ import chisel3.internal._
 
 import scala.language.experimental.macros
 
+object setClockAndReset {
+ /** Creates a new Clock and Reset scope in current Module
+    *
+    * @param clock the new implicit Clock
+    * @param reset the new implicit Reset
+    * @return Unit, affect current Module
+    */
+  def apply(clock: Clock, reset: Reset): Unit = {
+    setClock(clock)
+    setReset(reset)
+  }
+}
+
+object setClock {
+  /** Creates a new Clock scope in current Module
+    *
+    * @param clock the new implicit Clock
+    * @return Unit, affect current Module
+    */
+  def apply[T](clock: Clock): Unit =  {
+    Builder.currentClock = Some(clock)
+  }
+}
+
+object setReset {
+  /** Creates a new Reset scope in current Module
+    *
+    * @param reset the new implicit Reset
+    * @return Unit, affect current Module
+    */
+  def apply[T](reset: Reset): Unit = {
+    Builder.currentReset = Some(reset)
+  }
+}
+
 object withClockAndReset {
   /** Creates a new Clock and Reset scope
     *

--- a/src/test/scala/chiselTests/Clock.scala
+++ b/src/test/scala/chiselTests/Clock.scala
@@ -24,6 +24,16 @@ class WithClockAndNoReset extends RawModule {
   out := a
 }
 
+class SetClockAndNoReset extends RawModule {
+  val clock1 = IO(Input(Clock()))
+  val clock2 = IO(Input(Clock()))
+  val in = IO(Input(Bool()))
+  val out = IO(Output(Bool()))
+  setClock(clock2)
+  val a = RegNext(in)
+
+  out := a
+}
 
 class ClockSpec extends ChiselPropSpec {
   property("Bool.asClock.asUInt should pass a signal through unaltered") {
@@ -34,4 +44,10 @@ class ClockSpec extends ChiselPropSpec {
     val circuit = ChiselStage.emitChirrtl(new WithClockAndNoReset)
     circuit.contains("reg a : UInt<1>, clock2") should be (true)
   }
+
+  property("Should be able to use setClock in a module with no reset") {
+    val circuit = ChiselStage.emitChirrtl(new SetClockAndNoReset)
+    circuit.contains("reg a : UInt<1>, clock2") should be (true)
+  }
+
 }

--- a/src/test/scala/chiselTests/SetClockAndResetSpec.scala
+++ b/src/test/scala/chiselTests/SetClockAndResetSpec.scala
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiselTests
+
+import chisel3._
+import chisel3.stage.ChiselStage
+import chisel3.util.{Counter, Queue}
+import chisel3.testers.BasicTester
+
+class UseSetClockAndResetModule extends RawModule {
+  val clk = IO(Input(Clock()))
+  val rst = IO(Input(Reset()))
+  val out = IO(Output(UInt(8.W)))
+
+  setClockAndReset(clk, rst)
+
+  val reg = RegInit(0.U(8.W))
+  reg := reg + 1.U
+  out := reg
+}
+
+class SetClockAndResetSpec extends ChiselFlatSpec with Utils {
+
+  behavior of "Reset"
+
+  it should "allow writing modules that are reset agnostic" in {
+    val sync = compile(new Module {
+      val io = IO(new Bundle {
+        val out = Output(UInt(8.W))
+      })
+      val inst = Module(new UseSetClockAndResetModule)
+      inst.clk := clock
+      inst.rst := reset
+      assert(inst.rst.isInstanceOf[chisel3.ResetType])
+      io.out := inst.out
+    })
+    sync should include ("always @(posedge clk)")
+
+    val async = compile(new Module {
+      val io = IO(new Bundle {
+        val out = Output(UInt(8.W))
+      })
+      val inst = Module(new UseSetClockAndResetModule)
+      inst.clk := clock
+      inst.rst := reset.asTypeOf(AsyncReset())
+      assert(inst.rst.isInstanceOf[chisel3.ResetType])
+      io.out := inst.out
+    })
+    async should include ("always @(posedge clk or posedge rst)")
+  }
+
+  behavior of "Users"
+
+  they should "be able to force implicit reset to be synchronous" in {
+    val fir = ChiselStage.emitChirrtl(new Module with RequireSyncReset {
+      reset shouldBe a [Bool]
+    })
+    fir should include ("input reset : UInt<1>")
+  }
+
+  they should "be able to force implicit reset to be asynchronous" in {
+    val fir = ChiselStage.emitChirrtl(new Module with RequireAsyncReset {
+      reset shouldBe an [AsyncReset]
+    })
+    fir should include ("input reset : AsyncReset")
+  }
+
+  "Chisel" should "error if sync and async modules are nested" in {
+    a [ChiselException] should be thrownBy extractCause[ChiselException] {
+      ChiselStage.elaborate(new Module with RequireAsyncReset {
+        val mod = Module(new Module with RequireSyncReset)
+      })
+    }
+  }
+}


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [ ] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
new feature/API

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

Not affect existing API, it does much like `withClockAndReset` `withClock` `withReset`,  but set Clock/Reset in current Module scope.

Because `Module(new xxx_module)`, the `Module()` would set `Builder.currentClock` to `None`,  `setClock`  does not need to set `None` again.

#### Backend Code Generation Impact

Not Change.
<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->
Squash

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.x, 3.5.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
