### PR TITLE
Bump scalatest to 3.2.9

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -70,7 +70,7 @@ lazy val chiselSettings = Seq (
   name := "chisel3",
 
   libraryDependencies ++= Seq(
-    "org.scalatest" %% "scalatest" % "3.1.2" % "test",
+    "org.scalatest" %% "scalatest" % "3.2.9" % "test",
     "org.scalatestplus" %% "scalacheck-1-14" % "3.2.2.0" % "test",
     "com.lihaoyi" %% "os-lib" % "0.7.8",
   ),

--- a/build.sc
+++ b/build.sc
@@ -107,7 +107,7 @@ class chisel3CrossModule(val crossScalaVersion: String) extends CommonModule wit
     override def scalacPluginClasspath = m.scalacPluginClasspath
 
     override def ivyDeps = m.ivyDeps() ++ Agg(
-      ivy"org.scalatest::scalatest:3.1.2",
+      ivy"org.scalatest::scalatest:3.2.9",
       ivy"org.scalatestplus::scalacheck-1-14:3.2.2.0",
     ) ++ m.treadleIvyDeps
 

--- a/src/test/scala/chiselTests/ChiselSpec.scala
+++ b/src/test/scala/chiselTests/ChiselSpec.scala
@@ -13,7 +13,8 @@ import org.scalacheck._
 import org.scalatest._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should._
+import org.scalatest.propspec.AnyPropSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
 import java.io.ByteArrayOutputStream
@@ -94,7 +95,7 @@ abstract class ChiselFlatSpec extends AnyFlatSpec with ChiselRunners with Matche
 abstract class ChiselFreeSpec extends AnyFreeSpec with ChiselRunners with Matchers
 
 /** Spec base class for property-based testers. */
-abstract class ChiselPropSpec extends PropSpec with ChiselRunners with ScalaCheckPropertyChecks with Matchers {
+abstract class ChiselPropSpec extends AnyPropSpec with ChiselRunners with ScalaCheckPropertyChecks with Matchers {
 
   // Constrain the default number of instances generated for every use of forAll.
   implicit override val generatorDrivenConfig: PropertyCheckConfiguration =

--- a/src/test/scala/chiselTests/ExtModuleImpl.scala
+++ b/src/test/scala/chiselTests/ExtModuleImpl.scala
@@ -8,12 +8,11 @@ import chisel3._
 import chisel3.experimental.ExtModule
 import chisel3.stage.{ChiselGeneratorAnnotation, ChiselStage}
 import chisel3.util.{HasExtModuleInline, HasExtModulePath, HasExtModuleResource}
-import firrtl.FirrtlExecutionSuccess
 import firrtl.options.TargetDirAnnotation
 import firrtl.stage.FirrtlCircuitAnnotation
 import firrtl.transforms.BlackBoxNotFoundException
-import org.scalacheck.Test.Failed
-import org.scalatest.{FreeSpec, Matchers, Succeeded}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
 //scalastyle:off magic.number
 
@@ -102,7 +101,7 @@ class UsesMissingExtModuleResource extends RawModule {
   val foo = Module(new ExtModuleResourceNotFound)
 }
 
-class ExtModuleImplSpec extends FreeSpec with Matchers {
+class ExtModuleImplSpec extends AnyFreeSpec with Matchers {
   "ExtModule can have verilator source implementation" - {
 
     "Implementations can be contained in-line" in {


### PR DESCRIPTION
I sometimes run into issues where the build is trying to use scalatest 3.2.2 even though we still have it set for 3.1.2. I think this is due to https://github.com/chipsalliance/chisel3/pull/1908 which itself depends on scalatest 3.2.2 so there might be inconsistency between different dependency resolvers (whether one uses Ivy or Coursier) that causes some builds to fail.

Easiest way to fix this issue is to just go ahead and bump.

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [NA] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [NA] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
- test dependency bump
- 
#### API Impact

No impact, but in our tests we have to use the `Any*spec` style now

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

- Squash

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.x, 3.5.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
