### PR TITLE
Replace hard coded line separators with system specific ones in SMT checker

### DIFF
--- a/src/test/scala/chiselTests/SMTModelCheckingSpec.scala
+++ b/src/test/scala/chiselTests/SMTModelCheckingSpec.scala
@@ -9,6 +9,7 @@ import firrtl.util.BackendCompilationUtilities.timeStamp
 import logger.{LazyLogging, LogLevel, LogLevelAnnotation}
 import org.scalatest.flatspec.AnyFlatSpec
 import os._
+import scala.util.Properties
 
 /** [[SMTModelCheckingSpec]] use z3 and [[firrtl.backends.experimental.smt]] library
   * to solve `assert/assume` in [[chisel3.experimental.verification]],
@@ -64,8 +65,8 @@ private object Z3ModelChecker extends LazyLogging {
   private def executeStep(path: Path): Boolean = {
     val (out, ret) = executeCmd(path.toString)
     assert(ret == 0, s"expected success (0), not $ret: `$out`\nz3 ${path.toString}")
-    assert(out == "sat\n" || out == "unsat\n", s"Unexpected output: $out")
-    out == "unsat\n"
+    assert(out == "sat" + Properties.lineSeparator || out == "unsat" + Properties.lineSeparator, s"Unexpected output: $out")
+    out == "unsat" + Properties.lineSeparator
   }
 
   private def executeCmd(cmd: String): (String, Int) = {


### PR DESCRIPTION
Hard coded `\n` results in false-positive assertion failures and confusing error messages in SMT checker when using Z3 on Windows.

The output log was: `java.lang.AssertionError: assertion failed: Unexpected output: unsat` but `unsat` is actually an acceptable output.


### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
- bug fix
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact
No.
<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

#### Backend Code Generation Impact
No.
<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
- Squash: The PR will be squashed and merged (choose this if you have no preference.
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.x, 3.5.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
