### PR TITLE
Fix CloneModuleAsRecord support for .toTarget

### DIFF
--- a/core/src/main/scala/chisel3/BlackBox.scala
+++ b/core/src/main/scala/chisel3/BlackBox.scala
@@ -62,7 +62,7 @@ package experimental {
     * @note The parameters API is experimental and may change
     */
   abstract class ExtModule(val params: Map[String, Param] = Map.empty[String, Param]) extends BaseBlackBox {
-    private[chisel3] override def generateComponent(): Component = {
+    private[chisel3] override def generateComponent(): Option[Component] = {
       require(!_closed, "Can't generate module more than once")
       _closed = true
 
@@ -86,7 +86,7 @@ package experimental {
       val firrtlPorts = getModulePorts map {port => Port(port, port.specifiedDirection)}
       val component = DefBlackBox(this, name, firrtlPorts, SpecifiedDirection.Unspecified, params)
       _component = Some(component)
-      component
+      _component
     }
 
     private[chisel3] def initializeInParent(parentCompileOptions: CompileOptions): Unit = {
@@ -145,7 +145,7 @@ abstract class BlackBox(val params: Map[String, Param] = Map.empty[String, Param
   // Allow access to bindings from the compatibility package
   protected def _compatIoPortBound() = portsContains(_io)
 
-  private[chisel3] override def generateComponent(): Component = {
+  private[chisel3] override def generateComponent(): Option[Component] = {
     _compatAutoWrapPorts()  // pre-IO(...) compatibility hack
 
     // Restrict IO to just io, clock, and reset
@@ -178,7 +178,7 @@ abstract class BlackBox(val params: Map[String, Param] = Map.empty[String, Param
     val firrtlPorts = namedPorts map {namedPort => Port(namedPort._2, namedPort._2.specifiedDirection)}
     val component = DefBlackBox(this, name, firrtlPorts, _io.specifiedDirection, params)
     _component = Some(component)
-    component
+    _component
   }
 
   private[chisel3] def initializeInParent(parentCompileOptions: CompileOptions): Unit = {

--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -64,13 +64,18 @@ object Module extends SourceInfoDoc {
     Builder.currentClock = saveClock   // Back to clock and reset scope
     Builder.currentReset = saveReset
 
-    val component = module.generateComponent()
-    Builder.components += component
+    // Only add the component if the module generates one
+    val componentOpt = module.generateComponent()
+    for (component <- componentOpt) {
+      Builder.components += component
+    }
 
     Builder.setPrefix(savePrefix)
 
     // Handle connections at enclosing scope
-    if(!Builder.currentModule.isEmpty) {
+    // We use _component because Modules that don't generate them may still have one
+    if (Builder.currentModule.isDefined && module._component.isDefined) {
+      val component = module._component.get
       pushCommand(DefInstance(sourceInfo, module, component.ports))
       module.initializeInParent(compileOptions)
     }
@@ -178,20 +183,73 @@ package internal {
   import chisel3.experimental.BaseModule
 
   object BaseModule {
-    private[chisel3] class ClonePorts (elts: Data*)(implicit compileOptions: CompileOptions) extends Record {
+    // Private internal class to serve as a _parent for Data in cloned ports
+    private[chisel3] class ModuleClone(proto: BaseModule) extends BaseModule {
+      // Don't generate a component, but point to the one for the cloned Module
+      private[chisel3] def generateComponent(): Option[Component] = {
+        _component = proto._component
+        None
+      }
+      // This module doesn't acutally exist in the FIRRTL so no initialization to do
+      private[chisel3] def initializeInParent(parentCompileOptions: CompileOptions): Unit = ()
+
+      override def desiredName: String = proto.name
+    }
+
+    /** Record type returned by CloneModuleAsRecord
+      *
+      * @note These are not true Data (the Record doesn't correspond to anything in the emitted
+      * FIRRTL yet its elements *do*) so have some very specialized behavior.
+      * @param proto Optional pointer to the Module we are a clone of. Set for first instance, unset
+      *              for clones
+      */
+    private[chisel3] class ClonePorts (proto: Option[BaseModule], elts: Data*)(implicit compileOptions: CompileOptions) extends Record {
       val elements = ListMap(elts.map(d => d.instanceName -> d.cloneTypeFull): _*)
       def apply(field: String) = elements(field)
-      override def cloneType = (new ClonePorts(elts: _*)).asInstanceOf[this.type]
+      override def cloneType = (new ClonePorts(None, elts: _*)).asInstanceOf[this.type]
+
+      // Because ClonePorts instances are *not* created inside of their parent module, but rather,
+      // their parent's parent, we have to intercept the standard setRef and replace it with our own
+      // special Ref type.
+      // This only applies to ClonePorts created in cloneIORecord, any clones of these Records have
+      // normal behavior.
+      // Also, the name of ClonePorts Records needs to be propagated to their parent ModuleClone
+      // since we have no other way of setting the instance name for those.
+      private[chisel3] override def setRef(imm: Arg, force: Boolean): Unit = {
+        val immx = (proto, imm) match {
+          case (Some(mod), Ref(name)) =>
+            // Our _parent is a ModuleClone that needs its ref to match ours for .toAbsoluteTarget
+            _parent.foreach(_.setRef(Ref(name), force=true))
+            // Return a specialize-ref that will do the right thing
+            ModuleCloneIO(mod, name)
+          case _ => imm
+        }
+        super.setRef(immx, force)
+      }
+    }
+
+    // Recursively set the parent of the start Data and any children (eg. in an Aggregate)
+    private def setAllParents(start: Data, parent: Option[BaseModule]): Unit = {
+      def rec(data: Data): Unit = {
+        data._parent = parent
+        data match {
+        case _: Element =>
+        case agg: Aggregate =>
+          agg.getElements.foreach(rec)
+        }
+      }
+      rec(start)
     }
 
     private[chisel3] def cloneIORecord(proto: BaseModule)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): ClonePorts = {
       require(proto.isClosed, "Can't clone a module before module close")
-      val clonePorts = new ClonePorts(proto.getModulePorts: _*)
-      clonePorts.bind(WireBinding(Builder.forcedUserModule, Builder.currentWhen()))
-      val cloneInstance = new DefInstance(sourceInfo, proto, proto._component.get.ports) {
-        override def name = clonePorts.getRef.name
-      }
-      pushCommand(cloneInstance)
+      // We don't create this inside the ModuleClone because we need the ref to be set by the
+      // currentModule (and not clonePorts)
+      val clonePorts = new ClonePorts(Some(proto), proto.getModulePorts: _*)
+      val cloneParent = Module(new ModuleClone(proto))
+      clonePorts.bind(PortBinding(cloneParent))
+      setAllParents(clonePorts, Some(cloneParent))
+      // Normally handled during Module construction but ClonePorts really lives in its parent's parent
       if (!compileOptions.explicitInvalidate) {
         pushCommand(DefInvalid(sourceInfo, clonePorts.ref))
       }
@@ -270,7 +328,7 @@ package experimental {
     /** Generates the FIRRTL Component (Module or Blackbox) of this Module.
       * Also closes the module so no more construction can happen inside.
       */
-    private[chisel3] def generateComponent(): Component
+    private[chisel3] def generateComponent(): Option[Component]
 
     /** Sets up this module in the parent context
       */
@@ -308,9 +366,12 @@ package experimental {
 
     /** Legalized name of this module. */
     final lazy val name = try {
-      // If this is a module aspect, it should share the same name as the original module
-      // Thus, the desired name should be returned without uniquification
-      if(this.isInstanceOf[ModuleAspect]) desiredName else Builder.globalNamespace.name(desiredName)
+      // ModuleAspects and ModuleClones are not "true modules" and thus should share
+      // their original modules names without uniquification
+      this match {
+        case (_: ModuleAspect | _: internal.BaseModule.ModuleClone) => desiredName
+        case _ => Builder.globalNamespace.name(desiredName)
+      }
     } catch {
       case e: NullPointerException => throwException(
         s"Error: desiredName of ${this.getClass.getName} is null. Did you evaluate 'name' before all values needed by desiredName were available?", e)

--- a/core/src/main/scala/chisel3/RawModule.scala
+++ b/core/src/main/scala/chisel3/RawModule.scala
@@ -7,6 +7,7 @@ import scala.util.Try
 import scala.language.experimental.macros
 import chisel3.experimental.{BaseModule, BaseSim}
 import chisel3.internal._
+import chisel3.internal.BaseModule.ModuleClone
 import chisel3.internal.Builder._
 import chisel3.internal.firrtl._
 import chisel3.internal.sourceinfo.UnlocatableSourceInfo
@@ -74,6 +75,7 @@ abstract class RawModule(implicit moduleCompileOptions: CompileOptions)
     // All suggestions are in, force names to every node.
     for (id <- getIds) {
       id match {
+        case id: ModuleClone => id.setRefAndPortsRef(_namespace) // special handling
         case id: BaseModule => id.forceName(None, default=id.desiredName, _namespace)
         case id: MemBase[_] => id.forceName(None, default="MEM", _namespace)
         case id: BaseSim => id.forceName(None, default="SIM", _namespace)

--- a/core/src/main/scala/chisel3/RawModule.scala
+++ b/core/src/main/scala/chisel3/RawModule.scala
@@ -57,7 +57,7 @@ abstract class RawModule(implicit moduleCompileOptions: CompileOptions)
   }
 
 
-  private[chisel3] override def generateComponent(): Component = {
+  private[chisel3] override def generateComponent(): Option[Component] = {
     require(!_closed, "Can't generate module more than once")
     _closed = true
 
@@ -130,7 +130,7 @@ abstract class RawModule(implicit moduleCompileOptions: CompileOptions)
     }
     val component = DefModule(this, name, firrtlPorts, invalidateCommands ++ getCommands)
     _component = Some(component)
-    component
+    _component
   }
 
   private[chisel3] def initializeInParent(parentCompileOptions: CompileOptions): Unit = {
@@ -221,7 +221,7 @@ package object internal {
     // Allow access to bindings from the compatibility package
     protected def _compatIoPortBound() = portsContains(_io)
 
-    private[chisel3] override def generateComponent(): Component = {
+    private[chisel3] override def generateComponent(): Option[Component] = {
       _compatAutoWrapPorts()  // pre-IO(...) compatibility hack
 
       // Restrict IO to just io, clock, and reset

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -84,7 +84,7 @@ trait InstanceId {
 
 private[chisel3] trait HasId extends InstanceId {
   private[chisel3] def _onModuleClose: Unit = {}
-  private[chisel3] val _parent: Option[BaseModule] = Builder.currentModule
+  private[chisel3] var _parent: Option[BaseModule] = Builder.currentModule
 
   private[chisel3] val _id: Long = Builder.idGen.next
 

--- a/core/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -161,15 +161,21 @@ case class IntervalLit(n: BigInt, w: Width, binaryPoint: BinaryPoint) extends Li
 }
 
 case class Ref(name: String) extends Arg
+/** Arg for ports of Modules
+  * @param mod the module this port belongs to
+  * @param name the name of the port
+  */
 case class ModuleIO(mod: BaseModule, name: String) extends Arg {
   override def fullName(ctx: Component): String =
     if (mod eq ctx.id) name else s"${mod.getRef.name}.$name"
 }
-// For use with CloneModuleAsRecord
-// Note that `name` is the name of the module instance whereas in ModuleIO it's the name of the port
-// The names of ports inside of a ModuleCloneIO are the names of the Slots
+/** Ports of cloned modules (CloneModuleAsRecord)
+  * @param mod The original module for which these ports are a clone
+  * @param name the name of the module instance
+  */
 case class ModuleCloneIO(mod: BaseModule, name: String) extends Arg {
   override def fullName(ctx: Component): String =
+    // NOTE: mod eq ctx.id only occurs in Target and Named-related APIs
     if (mod eq ctx.id) "" else name
 }
 case class Slot(imm: Node, name: String) extends Arg {

--- a/core/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -165,9 +165,18 @@ case class ModuleIO(mod: BaseModule, name: String) extends Arg {
   override def fullName(ctx: Component): String =
     if (mod eq ctx.id) name else s"${mod.getRef.name}.$name"
 }
-case class Slot(imm: Node, name: String) extends Arg {
+// For use with CloneModuleAsRecord
+// Note that `name` is the name of the module instance whereas in ModuleIO it's the name of the port
+// The names of ports inside of a ModuleCloneIO are the names of the Slots
+case class ModuleCloneIO(mod: BaseModule, name: String) extends Arg {
   override def fullName(ctx: Component): String =
-    if (imm.fullName(ctx).isEmpty) name else s"${imm.fullName(ctx)}.${name}"
+    if (mod eq ctx.id) "" else name
+}
+case class Slot(imm: Node, name: String) extends Arg {
+  override def fullName(ctx: Component): String = {
+    val immName = imm.fullName(ctx)
+    if (immName.isEmpty) name else s"$immName.$name"
+  }
 }
 case class Index(imm: Arg, value: Arg) extends Arg {
   def name: String = s"[$value]"

--- a/src/test/scala/chiselTests/CloneModuleSpec.scala
+++ b/src/test/scala/chiselTests/CloneModuleSpec.scala
@@ -4,7 +4,7 @@ package chiselTests
 
 import chisel3._
 import chisel3.stage.ChiselStage
-import chisel3.util.{Queue, EnqIO, DeqIO, QueueIO, log2Ceil}
+import chisel3.util.{Decoupled, Queue, EnqIO, DeqIO, QueueIO, log2Ceil}
 import chisel3.experimental.{CloneModuleAsRecord, IO}
 import chisel3.testers.BasicTester
 
@@ -57,6 +57,26 @@ class QueueCloneTester(x: Int, multiIO: Boolean = false) extends BasicTester {
   }
 }
 
+class CloneModuleAsRecordAnnotate extends Module {
+  override def desiredName = "Top"
+  val in = IO(Flipped(Decoupled(UInt(8.W))))
+  val out = IO(Decoupled(UInt(8.W)))
+
+  val q1 = Module(new Queue(UInt(8.W), 4))
+  val q2 = CloneModuleAsRecord(q1)
+  val q2_io = q2("io").asInstanceOf[q1.io.type]
+  // Also make a wire to check that cloning works, can be connected to, and annotated
+  val q2_wire = {
+    val w = Wire(chiselTypeOf(q2))
+    w <> q2
+    w
+  }
+  // But connect to the original (using last connect semantics to override connects to wire
+  q1.io.enq <> in
+  q2_io.enq <> q1.io.deq
+  out <> q2_io.deq
+}
+
 class CloneModuleSpec extends ChiselPropSpec {
 
   val xVals = Table(
@@ -85,6 +105,50 @@ class CloneModuleSpec extends ChiselPropSpec {
   property("Clones of MultiIOModules should share the same module") {
     val c = ChiselStage.convert(new QueueClone(multiIO=true))
     assert(c.modules.length == 3)
+  }
+
+  property("Cloned Modules should annotate correctly") {
+    // Hackily get the actually Module object out
+    var mod: CloneModuleAsRecordAnnotate = null
+    val res = ChiselStage.convert {
+      mod = new CloneModuleAsRecordAnnotate
+      mod
+    }
+    // ********** Checking the output of CloneModuleAsRecord **********
+    // Note that we overrode desiredName so that Top is named "Top"
+    mod.q1.io.enq.toTarget.serialize should be ("~Top|Queue>io.enq")
+    mod.q2_io.deq.toTarget.serialize should be ("~Top|Queue>io.deq")
+    mod.q1.io.enq.toAbsoluteTarget.serialize should be ("~Top|Top/q1:Queue>io.enq")
+    mod.q2_io.deq.toAbsoluteTarget.serialize should be ("~Top|Top/q2:Queue>io.deq")
+    // Legacy APIs that nevertheless were tricky to get right
+    mod.q1.io.enq.toNamed.serialize should be ("Top.Queue.io.enq")
+    mod.q2_io.deq.toNamed.serialize should be ("Top.Queue.io.deq")
+    mod.q1.io.enq.instanceName should be ("io.enq")
+    mod.q2_io.deq.instanceName should be ("io.deq")
+    mod.q1.io.enq.pathName should be ("Top.q1.io.enq")
+    mod.q2_io.deq.pathName should be ("Top.q2.io.deq")
+    mod.q1.io.enq.parentPathName should be ("Top.q1")
+    mod.q2_io.deq.parentPathName should be ("Top.q2")
+    mod.q1.io.enq.parentModName should be ("Queue")
+    mod.q2_io.deq.parentModName should be ("Queue")
+
+    // ********** Checking the wire cloned from the output of CloneModuleAsRecord **********
+    val wire_io = mod.q2_wire("io").asInstanceOf[QueueIO[UInt]]
+    mod.q2_wire.toTarget.serialize should be ("~Top|Top>q2_wire")
+    wire_io.enq.toTarget.serialize should be ("~Top|Top>q2_wire.io.enq")
+    mod.q2_wire.toAbsoluteTarget.serialize should be ("~Top|Top>q2_wire")
+    wire_io.enq.toAbsoluteTarget.serialize should be ("~Top|Top>q2_wire.io.enq")
+    // Legacy APIs
+    mod.q2_wire.toNamed.serialize should be ("Top.Top.q2_wire")
+    wire_io.enq.toNamed.serialize should be ("Top.Top.q2_wire.io.enq")
+    mod.q2_wire.instanceName should be ("q2_wire")
+    wire_io.enq.instanceName should be ("q2_wire.io.enq")
+    mod.q2_wire.pathName should be ("Top.q2_wire")
+    wire_io.enq.pathName should be ("Top.q2_wire.io.enq")
+    mod.q2_wire.parentPathName should be ("Top")
+    wire_io.enq.parentPathName should be ("Top")
+    mod.q2_wire.parentModName should be ("Top")
+    wire_io.enq.parentModName should be ("Top")
   }
 
 }


### PR DESCRIPTION
This fixes an issue where you cannot currently annotate the fields of the `Record` returned by `CloneModuleAsRecord`.
This is due to the fact that `CloneModuleAsRecord` violates many assumptions in the Chisel internals and currently only works for generating FIRRTL by coincidence. I wanted to make it as first class as possible without a full refactor of the internals.

Basically, there are 3 pieces of bookkeeping (often with duplicated information) that need to be in sync and "correct" with regard to the baked-in assumptions in the compiler:
* binding - used mostly for correctness checking 
*  `_ref` - the "IR" information for most things, used for generating FIRRTL and for generating targets
* `_parent` - the parent module, used for generating targets, correctness checking, and in converting `_ref` to FIRRTL

The current implementation returns a Record that is the "IO" of a Module that doesn't actually exist with a WireBinding. The conversion to FIRRTL works because the `Emitter` and `Converter` (speaking of duplicated logic lol) both think that this Record is an Aggregate Wire whose name just happens to correspond to the name of the module instance that was created.

The fundamental issue is that this `Record` is weird--the `Record` itself isn't a real entity, connecting to it only works because we split up connections in `import chisel3._`, never emitting bulk connections. My goal in this PR was to support these `Records` as "first class" as I can, which I did in the following way:

I added a new private `BaseModule` subtype called `ModuleClone` so that the the cloned `Records` can have a true parent with the correct instance and module names. This necessitated 1 very reasonable change that `generateComponent()` now returns an `Option` so that we can legally instantiate modules that don't have a definition. 

~~The hackiness here is that we need to name the instance of the module from the name the Record ultimately gets. This is the weird `setRef` stuff you see in the overridden `setRef` in `ClonePorts`.~~

~~Speaking of overriding `setRef` in `ClonePorts`, this is definitely weird. I added a new `Arg` type `ModuleCloneIO` (analogous to `ModuleIO` with slightly different behavior, look at IR.scala and see them side-by-side). The problem is that `ModuleIO` is usually set when closing the parent Module of the ports, but the `ClonePorts` `Record` is actually created inside the _parent_ of the module whose ports it represents, so we need a way of it knowing to do this. Worse, you only want to do this for the first instance of `ClonePorts` since clones of *that* could be valid `Wires` or `Regs` and you definitely don't want to accidentally set their refs to be `ModuleCloneIO`~~

(Writing this made me come up with another idea. I'm keeping this text but there's a better way inbound)

The main hackiness in this PR is that we need to set the `_parent` for all of the `Data` elements within the `ClonePorts` `Record`. Currently in Chisel, `_parent` is set upon construction for `Data` and `Modules`. I think this basic pattern should probably change (There's no reason to set `_parent` for literals or unbound types for example), but I didn't want to try to refactor internals in a bug fix.

The main contribution of this PR is that by having a **real** `Module` and a **real** `Arg` for the `ClonePorts` `Records`, most assumptions baked into Chisel's internals are now correct. It's still not perfect because the `Record` itself still exposes `.toTarget` which returns `ReferenceTarget` and it'd be nice if we could instead return an `InstanceTarget` or `ModuleTarget`. 


### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [NA] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

 - bug fix
 - code refactoring

#### API Impact

No impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

  - Squash

#### Release Notes

Fix `.toTarget` and related naming APIs for `CloneModuleAsRecord` `Records` so that they can be annotated

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.x, 3.5.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
