### PR TITLE
Fix aop.Select behavior for CloneModuleAsRecord

### DIFF
--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -184,12 +184,14 @@ package internal {
 
   object BaseModule {
     // Private internal class to serve as a _parent for Data in cloned ports
-    private[chisel3] class ModuleClone(_proto: BaseModule) extends BaseModule {
+    private[chisel3] class ModuleClone(private[chisel3] val _proto: BaseModule) extends BaseModule {
       // ClonePorts that hold the bound ports for this module
       // Used for setting the refs of both this module and the Record
       private[BaseModule] var _portsRecord: Record = _
       // Don't generate a component, but point to the one for the cloned Module
       private[chisel3] def generateComponent(): Option[Component] = {
+        require(!_closed, "Can't generate module more than once")
+        _closed = true
         _component = _proto._component
         None
       }

--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -184,7 +184,7 @@ package internal {
 
   object BaseModule {
     // Private internal class to serve as a _parent for Data in cloned ports
-    private[chisel3] class ModuleClone(private[chisel3] val _proto: BaseModule) extends BaseModule {
+    private[chisel3] class ModuleClone(_proto: BaseModule) extends BaseModule {
       // ClonePorts that hold the bound ports for this module
       // Used for setting the refs of both this module and the Record
       private[BaseModule] var _portsRecord: Record = _

--- a/src/main/scala/chisel3/aop/Select.scala
+++ b/src/main/scala/chisel3/aop/Select.scala
@@ -82,11 +82,12 @@ object Select {
   def instances(module: BaseModule): Seq[BaseModule] = {
     check(module)
     module._component.get match {
-      case d: DefModule => d.commands.collect {
+      case d: DefModule => d.commands.flatMap {
         case i: DefInstance => i.id match {
-          case clone: ModuleClone => clone._proto
-          case other              => other
+          case _: ModuleClone => None
+          case other          => Some(other)
         }
+        case _ => None
       }
       case other => Nil
     }

--- a/src/main/scala/chisel3/aop/Select.scala
+++ b/src/main/scala/chisel3/aop/Select.scala
@@ -6,6 +6,7 @@ import chisel3._
 import chisel3.experimental.{BaseModule, FixedPoint}
 import chisel3.internal.HasId
 import chisel3.internal.firrtl._
+import chisel3.internal.BaseModule.ModuleClone
 import firrtl.annotations.ReferenceTarget
 
 import scala.collection.mutable
@@ -82,7 +83,10 @@ object Select {
     check(module)
     module._component.get match {
       case d: DefModule => d.commands.collect {
-        case i: DefInstance => i.id
+        case i: DefInstance => i.id match {
+          case clone: ModuleClone => clone._proto
+          case other              => other
+        }
       }
       case other => Nil
     }

--- a/src/test/scala/chiselTests/aop/SelectSpec.scala
+++ b/src/test/scala/chiselTests/aop/SelectSpec.scala
@@ -153,7 +153,7 @@ class SelectSpec extends ChiselFlatSpec {
     assert(bbs.size == 1)
   }
 
-  "CloneModuleAsRecord" should "show up in Select aspects as duplicates" in {
+  "CloneModuleAsRecord" should "NOT show up in Select aspects" in {
     import chisel3.experimental.CloneModuleAsRecord
     class Child extends RawModule {
       val in = IO(Input(UInt(8.W)))
@@ -174,8 +174,9 @@ class SelectSpec extends ChiselFlatSpec {
     }).elaborate
       .collectFirst { case DesignAnnotation(design: Top) => design }
       .get
-    val mods = Select.collectDeep(top) { case mod => mod }
-    mods should equal (Seq(top, top.inst0, top.inst0))
+    Select.collectDeep(top) { case x => x } should equal (Seq(top, top.inst0))
+    Select.getDeep(top)(x => Seq(x)) should equal (Seq(top, top.inst0))
+    Select.instances(top) should equal (Seq(top.inst0))
   }
 
 }


### PR DESCRIPTION
It turns out the behavior of `Select` differs from what we discussed in dev today, it actually returns the same module multiple times when you have `CloneModuleAsRecord` clones. Perhaps this isn't what we want, but I decided to add a test (that passed prior to https://github.com/chipsalliance/chisel3/pull/1974 and failed after it).

We could filter out these duplicates, but I wanted to document the behavior and discuss on this PR.

**EDIT:**

I have pushed another commit that changes this behavior to the intended behavior

Previously, CloneModuleAsRecord clones would result in the same BaseModule object coming up multiple times when using APIs like .instances, .collectDeep, and .getDeep. This was not the intended behavior and can lead to very subtle bugs.

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

  - bug fix             


#### API Impact

Fixes `aop.Select` behavior for `CloneModuleAsRecord`; duplicates of the cloned module will no longer appear.

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

  - Rebase (and merge commit)

#### Release Notes

Fixes `aop.Select` behavior for `CloneModuleAsRecord`; duplicates of the cloned module will no longer appear.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.x, 3.5.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
