### PR TITLE
Fix Cat rename signal #2010

### DIFF
--- a/core/src/main/scala/chisel3/SeqUtils.scala
+++ b/core/src/main/scala/chisel3/SeqUtils.scala
@@ -26,13 +26,12 @@ private[chisel3] object SeqUtils {
     } else if (in.tail.isEmpty) {
       in.head.asUInt
     } else {
-      val in_lo = in.slice(0, in.length/2)
-      val in_hi = in.slice(in.length/2, in.length)
-      def wrapper(s: String, in: Seq[T]) = {
-        prefix(s) { asUInt(in) }.autoSeed(s)
-      }
-      val lo = if (in_lo.length > 1) wrapper("lo", in_lo) else asUInt(in_lo)
-      val hi = if (in_hi.length > 1) wrapper("hi", in_hi) else asUInt(in_hi)
+      val lo = autoNameRecursively("lo") {
+         asUInt(in.slice(0, in.length/2))
+       }
+       val hi = autoNameRecursively("hi") {
+         asUInt(in.slice(in.length/2, in.length))
+       }
       hi ## lo
     }
   }

--- a/core/src/main/scala/chisel3/SeqUtils.scala
+++ b/core/src/main/scala/chisel3/SeqUtils.scala
@@ -26,12 +26,13 @@ private[chisel3] object SeqUtils {
     } else if (in.tail.isEmpty) {
       in.head.asUInt
     } else {
-      val lo = prefix("lo") {
-        asUInt(in.slice(0, in.length/2))
-      }.autoSeed("lo")
-      val hi = prefix("hi") {
-        asUInt(in.slice(in.length/2, in.length))
-      }.autoSeed("hi")
+      val in_lo = in.slice(0, in.length/2)
+      val in_hi = in.slice(in.length/2, in.length)
+      def wrapper(s: String, in: Seq[T]) = {
+        prefix(s) { asUInt(in) }.autoSeed(s)
+      }
+      val lo = if (in_lo.length > 1) wrapper("lo", in_lo) else asUInt(in_lo)
+      val hi = if (in_hi.length > 1) wrapper("hi", in_hi) else asUInt(in_hi)
       hi ## lo
     }
   }

--- a/core/src/main/scala/chisel3/SeqUtils.scala
+++ b/core/src/main/scala/chisel3/SeqUtils.scala
@@ -7,7 +7,7 @@ import chisel3.internal.{prefix, throwException}
 
 import scala.language.experimental.macros
 import chisel3.internal.sourceinfo._
-import chisel3.internal.plugin._
+import chisel3.internal.plugin.autoNameRecursively
 
 private[chisel3] object SeqUtils {
   /** Concatenates the data elements of the input sequence, in sequence order, together.
@@ -26,12 +26,12 @@ private[chisel3] object SeqUtils {
     } else if (in.tail.isEmpty) {
       in.head.asUInt
     } else {
-      val lo = autoNameRecursively("lo") {
+      val lo = autoNameRecursively("lo")(prefix("lo") {
         asUInt(in.slice(0, in.length/2))
-      }
-      val hi = autoNameRecursively("hi") {
+      })
+      val hi = autoNameRecursively("hi")(prefix("hi") {
         asUInt(in.slice(in.length/2, in.length))
-      }
+      })
       hi ## lo
     }
   }

--- a/core/src/main/scala/chisel3/SeqUtils.scala
+++ b/core/src/main/scala/chisel3/SeqUtils.scala
@@ -7,7 +7,7 @@ import chisel3.internal.{prefix, throwException}
 
 import scala.language.experimental.macros
 import chisel3.internal.sourceinfo._
-
+import chisel3.internal.plugin._
 
 private[chisel3] object SeqUtils {
   /** Concatenates the data elements of the input sequence, in sequence order, together.
@@ -27,11 +27,11 @@ private[chisel3] object SeqUtils {
       in.head.asUInt
     } else {
       val lo = autoNameRecursively("lo") {
-         asUInt(in.slice(0, in.length/2))
-       }
-       val hi = autoNameRecursively("hi") {
-         asUInt(in.slice(in.length/2, in.length))
-       }
+        asUInt(in.slice(0, in.length/2))
+      }
+      val hi = autoNameRecursively("hi") {
+        asUInt(in.slice(in.length/2, in.length))
+      }
       hi ## lo
     }
   }

--- a/no-plugin-tests/src/test/scala/chiselTests/BetterNamingTests.scala
+++ b/no-plugin-tests/src/test/scala/chiselTests/BetterNamingTests.scala
@@ -1,0 +1,1 @@
+../../../../../src/test/scala/chiselTests/BetterNamingTests.scala

--- a/no-plugin-tests/src/test/scala/chiselTests/CatSpec.scala
+++ b/no-plugin-tests/src/test/scala/chiselTests/CatSpec.scala
@@ -1,0 +1,1 @@
+../../../../../src/test/scala/chiselTests/util/CatSpec.scala

--- a/no-plugin-tests/src/test/scala/chiselTests/CustomBundle.scala
+++ b/no-plugin-tests/src/test/scala/chiselTests/CustomBundle.scala
@@ -1,0 +1,1 @@
+../../../../../src/test/scala/chiselTests/CustomBundle.scala

--- a/no-plugin-tests/src/test/scala/chiselTests/NamingAnnotationTest.scala
+++ b/no-plugin-tests/src/test/scala/chiselTests/NamingAnnotationTest.scala
@@ -1,0 +1,1 @@
+../../../../../src/test/scala/chiselTests/NamingAnnotationTest.scala

--- a/src/test/scala/chiselTests/CustomBundle.scala
+++ b/src/test/scala/chiselTests/CustomBundle.scala
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiselTests
+
+import chisel3._
+import chisel3.experimental.{DataMirror, requireIsChiselType}
+import scala.collection.immutable.ListMap
+
+// An example of how Record might be extended
+// In this case, CustomBundle is a Record constructed from a Tuple of (String, Data)
+//   it is a possible implementation of a programmatic "Bundle"
+//   (and can by connected to MyBundle below)
+final class CustomBundle(elts: (String, Data)*) extends Record {
+  val elements = ListMap(elts map { case (field, elt) =>
+    requireIsChiselType(elt)
+    field -> elt
+  }: _*)
+  def apply(elt: String): Data = elements(elt)
+  override def cloneType: this.type = {
+    val cloned = elts.map { case (n, d) => n -> DataMirror.internal.chiselTypeClone(d) }
+    (new CustomBundle(cloned: _*)).asInstanceOf[this.type]
+  }
+}
+

--- a/src/test/scala/chiselTests/RecordSpec.scala
+++ b/src/test/scala/chiselTests/RecordSpec.scala
@@ -6,24 +6,7 @@ import chisel3._
 import chisel3.stage.ChiselStage
 import chisel3.testers.BasicTester
 import chisel3.util.{Counter, Queue}
-import chisel3.experimental.{DataMirror, requireIsChiselType}
-import scala.collection.immutable.ListMap
-
-// An example of how Record might be extended
-// In this case, CustomBundle is a Record constructed from a Tuple of (String, Data)
-//   it is a possible implementation of a programmatic "Bundle"
-//   (and can by connected to MyBundle below)
-final class CustomBundle(elts: (String, Data)*) extends Record {
-  val elements = ListMap(elts map { case (field, elt) =>
-    requireIsChiselType(elt)
-    field -> elt
-  }: _*)
-  def apply(elt: String): Data = elements(elt)
-  override def cloneType: this.type = {
-    val cloned = elts.map { case (n, d) => n -> DataMirror.internal.chiselTypeClone(d) }
-    (new CustomBundle(cloned: _*)).asInstanceOf[this.type]
-  }
-}
+import chisel3.experimental.DataMirror
 
 trait RecordSpecUtils {
   class MyBundle extends Bundle {

--- a/src/test/scala/chiselTests/util/CatSpec.scala
+++ b/src/test/scala/chiselTests/util/CatSpec.scala
@@ -5,6 +5,7 @@ package chiselTests.util
 import chisel3._
 import chisel3.stage.ChiselStage
 import chisel3.util.Cat
+import chisel3.experimental.noPrefix
 
 import chiselTests.ChiselFlatSpec
 
@@ -30,5 +31,34 @@ class CatSpec extends ChiselFlatSpec {
     ChiselStage.elaborate(new JackIsATypeSystemGod)
 
   }
+
+  it should "not override the names of its arguments" in {
+    class MyModule extends RawModule {
+      val a, b, c, d = IO(Input(UInt(8.W)))
+      val out = IO(Output(UInt()))
+
+      out := Cat(a, b, c, d)
+    }
+    val chirrtl = ChiselStage.emitChirrtl(new MyModule)
+    for (name <- Seq("a", "b", "c", "d")) {
+      chirrtl should include (s"input $name : UInt<8>")
+    }
+  }
+
+  it should "have prefixed naming" in {
+    class MyModule extends RawModule {
+      val in = IO(Input(Vec(8, UInt(8.W))))
+      val out = IO(Output(UInt()))
+
+      // noPrefix to avoid `out` as prefix
+      out := noPrefix(Cat(in))
+    }
+    val chirrtl = ChiselStage.emitChirrtl(new MyModule)
+    chirrtl should include ("node lo_lo = cat(in[6], in[7])")
+    chirrtl should include ("node lo_hi = cat(in[4], in[5])")
+    chirrtl should include ("node hi_lo = cat(in[2], in[3])")
+    chirrtl should include ("node hi_hi = cat(in[0], in[1])")
+  }
+
 
 }


### PR DESCRIPTION
### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

- bug fix

#### API Impact

No

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

It would rename intermediate node to `hi` or `lo` when use `SeqUtils.asUInt` for a sequence.

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
Rebase

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

Fix #2010 
### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.x, 3.5.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
