### PR TITLE
Update docs on dontTouch as optimization barrier

### DIFF
--- a/core/src/main/scala/chisel3/dontTouch.scala
+++ b/core/src/main/scala/chisel3/dontTouch.scala
@@ -5,7 +5,8 @@ package chisel3
 import chisel3.experimental.{ChiselAnnotation, annotate, requireIsHardware}
 import firrtl.transforms.DontTouchAnnotation
 
-/** Marks that a signal should not be removed by Chisel and Firrtl optimization passes
+/** Marks that a signal is an optimization barrier to Chisel and the FIRRTL compiler. This has the effect of
+  * guaranteeing that a signal will not be removed.
   *
   * @example {{{
   * class MyModule extends Module {
@@ -21,9 +22,11 @@ import firrtl.transforms.DontTouchAnnotation
   * @note Calling this on [[Data]] creates an annotation that Chisel emits to a separate annotations
   * file. This file must be passed to FIRRTL independently of the `.fir` file. The execute methods
   * in [[chisel3.Driver]] will pass the annotations to FIRRTL automatically.
+  * @note Because this is an optimization barrier, constants will not be propagated through a signal marked as
+  * dontTouch.
   */
 object dontTouch {
-  /** Marks a signal to be preserved in Chisel and Firrtl
+  /** Mark a signal as an optimization barrier to Chisel and FIRRTL.
     *
     * @note Requires the argument to be bound to hardware
     * @param data The signal to be marked


### PR DESCRIPTION
Change the Scaladoc for the dontTouch utility.  Indicate that this is an
_optimization barrier_ and not just a guarantee that the signal won't be
removed.  The optimization barrier interpretation is the current
implementation in the Scala FIRRTL Compiler.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [n/a] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
- documentation                      
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

None.

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

None.

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
- Squash: The PR will be squashed and merged (choose this if you have no preference.
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.x, 3.5.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
