### PR TITLE
Fix ChiselEnum docs

### DIFF
--- a/docs-target/src/main/scala/chisel3/docs/VerilogMdocModifier.scala
+++ b/docs-target/src/main/scala/chisel3/docs/VerilogMdocModifier.scala
@@ -27,7 +27,7 @@ class VerilogMdocModifier extends PostModifier {
         case (None, _) => None
       }
     result match {
-      case Some(content) => s"```verilog\n$content```"
+      case Some(content) => s"```verilog\n$content```\n"
       case None          => ""
     }
   }

--- a/docs/src/explanations/chisel-enum.md
+++ b/docs/src/explanations/chisel-enum.md
@@ -74,6 +74,7 @@ class AluMux1File extends Module {
   }
 }
 ```
+
 ```scala mdoc:verilog
 ChiselStage.emitVerilog(new AluMux1File)
 ```
@@ -140,8 +141,9 @@ that the `UInt` could hit, you will see a warning like the following:
 
 ```scala mdoc:passthrough
 val (log, _) = grabLog(ChiselStage.emitChirrtl(new FromUInt))
-println(s"```$log```")
+println(s"```\n$log```")
 ```
+
 (Note that the name of the Enum is ugly as an artifact of our documentation generation flow, it will
 be cleaner in normal use).
 
@@ -162,7 +164,7 @@ Now there will be no warning:
 
 ```scala mdoc:passthrough
 val (log2, _) = grabLog(ChiselStage.emitChirrtl(new SafeFromUInt))
-println(s"```$log2```")
+println(s"```\n$log2```")
 ```
 
 ## Testing
@@ -181,6 +183,7 @@ def expectedSel(sel: AluMux1Sel.Type): Boolean = sel match {
 ```
 
 Some additional useful methods defined on the `ChiselEnum` object are:
+
 * `.all`: returns the enum values within the enumeration
 * `.getWidth`: returns the width of the hardware type
 


### PR DESCRIPTION
Also add newline to end of `verilog` modifier code blocks so that there
is always a newline between code blocks and following material.

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [NA] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

  - documentation           


#### API Impact

No impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

 - Squash
 
#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.x, 3.5.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
