### PR TITLE
Make it legal for concrete resets to drive abstract reset

### DIFF
--- a/core/src/main/scala/chisel3/Bits.scala
+++ b/core/src/main/scala/chisel3/Bits.scala
@@ -961,11 +961,6 @@ final class ResetType(private[chisel3] val width: Width = Width(1)) extends Elem
   private[chisel3] def typeEquivalent(that: Data): Boolean =
     this.getClass == that.getClass
 
-  override def connect(that: Data)(implicit sourceInfo: SourceInfo, connectCompileOptions: CompileOptions): Unit = that match {
-    case _: Reset | DontCare => super.connect(that)(sourceInfo, connectCompileOptions)
-    case _ => super.badConnect(that)(sourceInfo)
-  }
-
   override def litOption = None
 
   /** Not really supported */
@@ -1007,11 +1002,6 @@ sealed class AsyncReset(private[chisel3] val width: Width = Width(1)) extends El
 
   private[chisel3] def typeEquivalent(that: Data): Boolean =
     this.getClass == that.getClass
-
-  override def connect(that: Data)(implicit sourceInfo: SourceInfo, connectCompileOptions: CompileOptions): Unit = that match {
-    case _: AsyncReset | DontCare => super.connect(that)(sourceInfo, connectCompileOptions)
-    case _ => super.badConnect(that)(sourceInfo)
-  }
 
   override def litOption = None
 

--- a/core/src/main/scala/chisel3/internal/MonoConnect.scala
+++ b/core/src/main/scala/chisel3/internal/MonoConnect.scala
@@ -103,6 +103,8 @@ private[chisel3] object MonoConnect {
         elemConnect(sourceInfo, connectCompileOptions, sink_e, source_e, context_mod)
       case (sink_e: ResetType, source_e: Reset) =>
         elemConnect(sourceInfo, connectCompileOptions, sink_e, source_e, context_mod)
+      case (sink_e: Reset, source_e: ResetType) =>
+        elemConnect(sourceInfo, connectCompileOptions, sink_e, source_e, context_mod)
       case (sink_e: EnumType, source_e: UnsafeEnum) =>
         elemConnect(sourceInfo, connectCompileOptions, sink_e, source_e, context_mod)
       case (sink_e: EnumType, source_e: EnumType) if sink_e.typeEquivalent(source_e) =>

--- a/src/test/scala/chiselTests/ResetSpec.scala
+++ b/src/test/scala/chiselTests/ResetSpec.scala
@@ -44,6 +44,26 @@ class ResetSpec extends ChiselFlatSpec with Utils {
     ChiselStage.elaborate(new AbstractResetDontCareModule)
   }
 
+  it should "be able to drive Bool" in {
+    ChiselStage.emitVerilog(new RawModule {
+      val in = IO(Input(Bool()))
+      val out = IO(Output(Bool()))
+      val w = Wire(Reset())
+      w := in
+      out := w
+    })
+  }
+
+  it should "be able to drive AsyncReset" in {
+    ChiselStage.emitVerilog(new RawModule {
+      val in = IO(Input(AsyncReset()))
+      val out = IO(Output(AsyncReset()))
+      val w = Wire(Reset())
+      w := in
+      out := w
+    })
+  }
+
   it should "allow writing modules that are reset agnostic" in {
     val sync = compile(new Module {
       val io = IO(new Bundle {


### PR DESCRIPTION
This has been legal in FIRRTL since v1.2.3 (when reset inference started
using a unification-style algorithm) but was never exposed in the Chisel
API.

Also delete the overridden connects in AsyncReset and ResetType which
just duplicate logic from MonoConnect.

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

   - new feature/API  

#### API Impact

This makes it legal to drive a concrete reset (`Bool()` or `AsyncReset()`) with an abstract reset (`Reset()`), this has been legal in FIRRTL since v1.2.3 and was always intended to be exposed in Chisel but I forgot 🙃 

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

  - Squash
 
#### Release Notes

Make it legal to drive a concrete reset (`Bool()` or `AsyncReset()`) with an abstract reset (`Reset()`). Reset inference in FIRRTL works both forwards and backwards so the connection to the concrete reset will influence the type of the driving abstract reset.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.x, 3.5.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
