### PR TITLE
Fix chisel3 <> for Bundles that contain compatibility Bundles

### DIFF
--- a/src/test/scala/chiselTests/CompatibilityInteroperabilitySpec.scala
+++ b/src/test/scala/chiselTests/CompatibilityInteroperabilitySpec.scala
@@ -289,5 +289,43 @@ class CompatibiltyInteroperabilitySpec extends ChiselFlatSpec {
       }
     }
   }
+
+  "A chisel3 Bundle that instantiates a Chisel Bundle" should "bulk connect correctly" in {
+    compile {
+      object Compat {
+        import Chisel._
+        class Foo extends Bundle {
+          val a = Input(UInt(8.W))
+          val b = Output(UInt(8.W))
+        }
+      }
+      import chisel3._
+      import Compat._
+      class Bar extends Bundle {
+        val foo1 = new Foo
+        val foo2 = Flipped(new Foo)
+      }
+      // Check every connection both ways to see that chisel3 <>'s commutativity holds
+      class Child extends RawModule {
+        val deq = IO(new Bar)
+        val enq = IO(Flipped(new Bar))
+        enq <> deq
+        deq <> enq
+      }
+      new RawModule {
+        val deq = IO(new Bar)
+        val enq = IO(Flipped(new Bar))
+        // Also important to check connections to child ports
+        val c1 = Module(new Child)
+        val c2 = Module(new Child)
+        c1.enq <> enq
+        enq <> c1.enq
+        c2.enq <> c1.deq
+        c1.deq <> c2.enq
+        deq <> c2.deq
+        c2.deq <> deq
+      }
+    }
+  }
 }
 


### PR DESCRIPTION
BiConnect in chisel3 delegates to FIRRTL <- semantics whenever it hits a
Bundle defined in `import Chisel._`. Because chisel3 <> is commutative
it needs to be mindful of flippedness when emitting a FIRRTL <- (which
is *not* commutative).

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

   - bug fix

#### API Impact

No impact, just a bugfix

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

  - Squash

#### Release Notes

Fix handling of `import Chisel._` Bundles when used as elements in `import chisel3._` Bundles when connecting with `<>`.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.x, 3.5.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
