### PR TITLE
Fix chisel3 <> for Bundles that contain compatibility Bundles (Take 2)

### DIFF
--- a/core/src/main/scala/chisel3/internal/BiConnect.scala
+++ b/core/src/main/scala/chisel3/internal/BiConnect.scala
@@ -120,9 +120,10 @@ private[chisel3] object BiConnect {
         if (notStrict) {
           // chisel3 <> is commutative but FIRRTL <- is not
           val flipped = {
+            import ActualDirection._
             // Everything is flipped when it's the port of a child
             val childPort = left_r._parent.get != context_mod
-            val isFlipped = left_r.direction == ActualDirection.Bidirectional(ActualDirection.Flipped)
+            val isFlipped = Seq(Bidirectional(Flipped), Input).contains(left_r.direction)
             isFlipped ^ childPort
           }
           val (newLeft, newRight) = if (flipped) pair.swap else pair

--- a/src/test/scala/chiselTests/CompatibilityInteroperabilitySpec.scala
+++ b/src/test/scala/chiselTests/CompatibilityInteroperabilitySpec.scala
@@ -294,16 +294,21 @@ class CompatibiltyInteroperabilitySpec extends ChiselFlatSpec {
     compile {
       object Compat {
         import Chisel._
-        class Foo extends Bundle {
+        class BiDir extends Bundle {
           val a = Input(UInt(8.W))
           val b = Output(UInt(8.W))
+        }
+        class Struct extends Bundle {
+          val a = UInt(8.W)
         }
       }
       import chisel3._
       import Compat._
       class Bar extends Bundle {
-        val foo1 = new Foo
-        val foo2 = Flipped(new Foo)
+        val bidir1 = new BiDir
+        val bidir2 = Flipped(new BiDir)
+        val struct1 = Output(new Struct)
+        val struct2 = Input(new Struct)
       }
       // Check every connection both ways to see that chisel3 <>'s commutativity holds
       class Child extends RawModule {


### PR DESCRIPTION
PR #2023 fixed a composition issue for chisel3 biconnects delegating to
FIRRTL partial connect when compatibility mode Bundles are elements of
chisel3 Bundles. It missed an important case though that caused
previously working code to break.

The bug is fixed by doing the automatic flipping for compatibility mode
Bundles that have "Input" as a direction in addition to those that are
"Flipped".

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [NA] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

 - bug fix

#### API Impact

No impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

 - Squash

#### Release Notes

(Not applicable - fixing an unreleased bug)

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.x, 3.5.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
