### PR TITLE
Bundles can no longer be instantiated with bound hardware

### DIFF
--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -963,6 +963,9 @@ abstract class Bundle(implicit compileOptions: CompileOptions) extends Record {
     for (m <- getPublicFields(classOf[Bundle])) {
       getBundleField(m) match {
         case Some(d: Data) =>
+          if (!d.binding.isEmpty)
+            throwException(s"Bundle can only take type elements (got value binding on '${m.getName()}')")
+
           if (nameMap contains m.getName) {
             require(nameMap(m.getName) eq d)
           } else {

--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -963,8 +963,9 @@ abstract class Bundle(implicit compileOptions: CompileOptions) extends Record {
     for (m <- getPublicFields(classOf[Bundle])) {
       getBundleField(m) match {
         case Some(d: Data) =>
-          if (!d.binding.isEmpty)
-            throwException(s"Bundle can only take type elements (got value binding on '${m.getName()}')")
+          if (d.binding.nonEmpty) {
+            throwException(s"Bundle can only take type elements (got value binding '$d' on '${m.getName()}')")
+          }
 
           if (nameMap contains m.getName) {
             require(nameMap(m.getName) eq d)

--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -963,9 +963,7 @@ abstract class Bundle(implicit compileOptions: CompileOptions) extends Record {
     for (m <- getPublicFields(classOf[Bundle])) {
       getBundleField(m) match {
         case Some(d: Data) =>
-          if (d.binding.nonEmpty) {
-            throwException(s"Bundle can only take type elements (got value binding '$d' on '${m.getName()}')")
-          }
+          requireIsChiselType(d)
 
           if (nameMap contains m.getName) {
             require(nameMap(m.getName) eq d)

--- a/src/test/scala/chiselTests/BundleSpec.scala
+++ b/src/test/scala/chiselTests/BundleSpec.scala
@@ -129,6 +129,17 @@ class BundleSpec extends ChiselFlatSpec with BundleSpecUtils with Utils {
     }).getMessage should include("aliased fields")
   }
 
+  "Bundles" should "not have bound hardware" in {
+    (the[ChiselException] thrownBy extractCause[ChiselException] {
+      ChiselStage.elaborate { new Module {
+        class MyBundle(val foo: UInt) extends Bundle
+        val in  = IO(Input(new MyBundle(123.U))) // This should error: value passed in instead of type
+        val out = IO(Output(new MyBundle(UInt(8.W))))
+
+        out := in
+      } }
+    }).getMessage should include("got value binding")
+  }
   "Unbound bundles sharing a field" should "not error" in {
     ChiselStage.elaborate {
       new RawModule {
@@ -142,7 +153,11 @@ class BundleSpec extends ChiselFlatSpec with BundleSpecUtils with Utils {
     }
   }
 
-  "Bound Data" should "have priority in setting ref over unbound Data" in {
+  /**
+   * Broken in Chisel 3.5
+   * Bundles should not be able to be instantiated using any kind of bound hardware.
+   */
+  /*"Bound Data" should "have priority in setting ref over unbound Data" in {
     class MyModule extends RawModule {
       val foo = IO(new Bundle {
         val x = Output(UInt(8.W))
@@ -153,5 +168,5 @@ class BundleSpec extends ChiselFlatSpec with BundleSpecUtils with Utils {
       }
     }
     ChiselStage.emitChirrtl(new MyModule)
-  }
+  }*/
 }

--- a/src/test/scala/chiselTests/BundleSpec.scala
+++ b/src/test/scala/chiselTests/BundleSpec.scala
@@ -152,21 +152,4 @@ class BundleSpec extends ChiselFlatSpec with BundleSpecUtils with Utils {
       }
     }
   }
-
-  /**
-   * Broken in Chisel 3.5
-   * Bundles should not be able to be instantiated using any kind of bound hardware.
-   */
-  /*"Bound Data" should "have priority in setting ref over unbound Data" in {
-    class MyModule extends RawModule {
-      val foo = IO(new Bundle {
-        val x = Output(UInt(8.W))
-      })
-      foo.x := 0.U // getRef on foo.x is None.get without fix
-      val bar = new Bundle {
-        val y = foo.x
-      }
-    }
-    ChiselStage.emitChirrtl(new MyModule)
-  }*/
 }

--- a/src/test/scala/chiselTests/BundleSpec.scala
+++ b/src/test/scala/chiselTests/BundleSpec.scala
@@ -138,7 +138,7 @@ class BundleSpec extends ChiselFlatSpec with BundleSpecUtils with Utils {
 
         out := in
       } }
-    }).getMessage should include("got value binding")
+    }).getMessage should include("must be a Chisel type, not hardware")
   }
   "Unbound bundles sharing a field" should "not error" in {
     ChiselStage.elaborate {

--- a/src/test/scala/chiselTests/BundleSpec.scala
+++ b/src/test/scala/chiselTests/BundleSpec.scala
@@ -140,6 +140,16 @@ class BundleSpec extends ChiselFlatSpec with BundleSpecUtils with Utils {
       } }
     }).getMessage should include("must be a Chisel type, not hardware")
   }
+  "Bundles" should "not recursively contain aggregates with bound hardware" in {
+    (the[ChiselException] thrownBy extractCause[ChiselException] {
+      ChiselStage.elaborate { new Module {
+        class MyBundle(val foo: UInt) extends Bundle
+        val out = IO(Output(Vec(2, UInt(8.W))))
+        val in  = IO(Input(new MyBundle(out(0)))) // This should error: Bound aggregate passed
+        out := in
+      } }
+    }).getMessage should include("must be a Chisel type, not hardware")
+  }
   "Unbound bundles sharing a field" should "not error" in {
     ChiselStage.elaborate {
       new RawModule {


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

Bug fix

#### API Impact

Changes existing API: Code previously taking advantage of `Bundle`s with bound hardware elements will crash.

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

Squash and merge

#### Release Notes
`Bundle`s can no longer be instantiated with value bindings or bound hardware. Fixes #1894

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.x, 3.5.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
