### PR TITLE
Install Z3 with apt-get in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,6 @@ jobs:
         jvm: ["adopt@1.8"]
         scala: ["2.13.6", "2.12.13"]
         verilator: ["4.204"]
-        z3: ["4.8.10"]
         espresso: ["2.4"]
     runs-on: ${{ matrix.system }}
 
@@ -26,32 +25,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Install Z3 Build Dependencies(Ubuntu)
+      - name: Install Z3
         if: matrix.system == 'ubuntu-20.04'
-        run: sudo apt-get install -y libfl2 libfl-dev
-
-      - name: Cache Z3 ${{ matrix.z3 }}
-        uses: actions/cache@v2
-        id: cache-z3
-        with:
-          path: z3-z3-${{ matrix.z3 }}
-          key: ${{ matrix.system }}-z3-${{ matrix.z3 }}
-      - name: Compile Z3
-        if: steps.cache-z3.outputs.cache-hit != 'true'
         run: |
-          wget https://github.com/Z3Prover/z3/archive/refs/tags/z3-${{ matrix.z3 }}.tar.gz
-          tar xvf z3-${{ matrix.z3 }}.tar.gz
-          cd z3-z3-${{ matrix.z3 }}
-          mkdir -p build
-          cd build
-          cmake .. \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DZ3_LINK_TIME_OPTIMIZATION=1
-          make
-      - name: Install Z3 ${{ matrix.z3 }}
-        run: |
-          cd z3-z3-${{ matrix.z3 }}/build
-          sudo make install
+          sudo apt-get install -y z3
           z3 --version
 
       - name: Cache Verilator ${{ matrix.verilator }}


### PR DESCRIPTION
Something is wrong with the Z3 caching and it rebuilds every time. On @ekiwi's suggestion, since the version of Z3 really doesn't matter for our tests and doesn't affect users (unlike Verilator and Espresso), we should just use the apt-get version.

If we need to build from source in the future for some reason, we can, but there's really no need for the complexity at the moment.

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [NA] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [NA] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

  - CI fix

#### API Impact

No impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

   - Squash (**Please squash** I screwed up the branch name lol)

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.x, 3.5.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
