### PR TITLE
Added VecInit factory methods (fill,iterate)

### DIFF
--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -590,6 +590,33 @@ object VecInit extends SourceInfoDoc {
   /** @group SourceInfoTransformMacro */
   def do_tabulate[T <: Data](n: Int)(gen: (Int) => T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Vec[T] =
     apply((0 until n).map(i => gen(i)))
+
+  /** Creates a new [[Vec]] of length `n` composed of the result of the given
+   * function applied to an element of data type T.
+   * 
+   * @param n number of elements in the vector
+   * @param gen function that takes in an element T and returns an output 
+   * element of the same type
+   */
+  def fill[T <: Data](n: Int)(gen: => T): Vec[T] = macro VecTransform.fill
+
+  /** @group SourceInfoTransformMacro */
+  def do_fill[T <: Data](n: Int)(gen: => T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Vec[T] =
+    apply(Seq.fill(n)(gen))
+
+  /** Creates a new [[Vec]] of length `n` composed of the result of the given
+   * function applied to an element of data type T.
+   * 
+   * @param start First element in the Vec
+   * @param len Lenth of elements in the Vec
+   * @param f Function that applies the element T from previous index and returns the output 
+   * element to the next index
+   */
+  def iterate[T <: Data](start: T, len: Int)(f: (T) => T): Vec[T] = macro VecTransform.iterate
+  
+  /** @group SourceInfoTransformMacro */
+  def do_iterate[T <: Data](start: T, len: Int)(f: (T) => T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Vec[T] = 
+    apply(Seq.iterate(start, len)(f)) 
 }
 
 /** A trait for [[Vec]]s containing common hardware generators for collection
@@ -964,7 +991,7 @@ abstract class Bundle(implicit compileOptions: CompileOptions) extends Record {
       getBundleField(m) match {
         case Some(d: Data) =>
           requireIsChiselType(d)
-
+          
           if (nameMap contains m.getName) {
             require(nameMap(m.getName) eq d)
           } else {
@@ -1268,3 +1295,4 @@ abstract class Bundle(implicit compileOptions: CompileOptions) extends Record {
     */
   override def toPrintable: Printable = toPrintableHelper(elements.toList.reverse)
 }
+

--- a/macros/src/main/scala/chisel3/internal/sourceinfo/SourceInfoTransform.scala
+++ b/macros/src/main/scala/chisel3/internal/sourceinfo/SourceInfoTransform.scala
@@ -84,6 +84,9 @@ class VecTransform(val c: Context) extends SourceInfoTransformMacro {
   def fill(n: c.Tree)(gen: c.Tree): c.Tree = {
     q"$thisObj.do_fill($n)($gen)($implicitSourceInfo, $implicitCompileOptions)"
   }
+  def iterate(start: c.Tree, len: c.Tree)(f: c.Tree): c.Tree = {
+    q"$thisObj.do_iterate($start,$len)($f)($implicitSourceInfo, $implicitCompileOptions)"
+  }
   def contains(x: c.Tree)(ev: c.Tree): c.Tree = {
     q"$thisObj.do_contains($x)($implicitSourceInfo, $ev, $implicitCompileOptions)"
   }


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
 - new feature/API                    

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->
This PR adds additional companion object factory methods to the VecInit class, such as .fill and .iterate.

A .empty method was not added because VecInit does not allow for empty hardware values at this time.
#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->
This should not change the backend code generation as it only provides different ways to fill a Vec.
#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
 - Squash: The PR will be squashed and merged (choose this if you have no preference. 
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
This PR adds additional companion object factory methods to the VecInit class, such as .fill and .iterate.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [x] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.x, 3.5.0) ?
- [x] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
