### PR TITLE
Error on MPort Escaping When, Fix SyncReadMem.read(addr, en) to not do this

### DIFF
--- a/core/src/main/scala/chisel3/Mem.scala
+++ b/core/src/main/scala/chisel3/Mem.scala
@@ -209,12 +209,13 @@ sealed class SyncReadMem[T <: Data] private (t: T, n: BigInt, val readUnderWrite
   /** @group SourceInfoTransformMacro */
   def do_read(addr: UInt, enable: Bool)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T = {
     val a = Wire(UInt())
+    val port = Wire(t)
     a := DontCare
-    var port: Option[T] = None
+    port := DontCare
     when (enable) {
       a := addr
-      port = Some(read(a))
+      port := read(a)
     }
-    port.get
+    port
   }
 }

--- a/core/src/main/scala/chisel3/internal/MonoConnect.scala
+++ b/core/src/main/scala/chisel3/internal/MonoConnect.scala
@@ -64,7 +64,6 @@ private[chisel3] object MonoConnect {
 
   def checkWhenVisibility(x: Data): Boolean = {
     x.topBinding match {
-      case mp: MemoryPortBinding => true // TODO (albert-magyar): remove this "bridge" for odd enable logic of current CHIRRTL memories
       case cd: ConditionalDeclarable => cd.visibility.map(_.active()).getOrElse(true)
       case _ => true
     }


### PR DESCRIPTION
Extend the stricter checking introduced in #1518 by removing the special casing around mports escaping when scopes.  Now, Chisel code that tries to do this will result in an error.

There was one known usage of this in the Chisel standard library: `SyncReadMem.read(addr, en)`.  Change this to use a dummy wire instead.

This attempts to fix code generation where an `mport` is used directly in a later block with a different enable.  An example of this is shown here: https://scastie.scala-lang.org/seldridge/pt0ARTQtTuWkTJfoLfB05g/37.

With this patch, the `Bar` module will now produce the following CHIRRTL:

```scala
circuit Bar :
  module Bar :
    input clock : Clock
    input reset : UInt<1>
    input addr : UInt<3>
    input cond : UInt<1>
    output out : UInt<1>

    smem mem : UInt<1> [8] 
    wire _r_WIRE : UInt 
    wire _r_WIRE_1 : UInt<1> 
    _r_WIRE is invalid 
    _r_WIRE_1 is invalid 
    when cond : 
      _r_WIRE <= addr 
      node _r_T = or(_r_WIRE, UInt<3>("h0")) 
      node _r_T_1 = bits(_r_T, 2, 0) 
      read mport r_MPORT = mem[_r_T_1], clock 
      _r_WIRE_1 <= r_MPORT 
    reg r_REG : UInt<1>, clock with :
      reset => (UInt<1>("h0"), r_REG) 
    r_REG <= cond 
    reg r : UInt<1>, clock with :
      reset => (UInt<1>("h0"), r) 
    when r_REG : 
      r <= _r_WIRE_1 
    out <= r
```