### PR TITLE
Add multiple dimensions to VecInit fill and iterate 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,6 @@ jobs:
         jvm: ["adopt@1.8"]
         scala: ["2.13.6", "2.12.13"]
         verilator: ["4.204"]
-        z3: ["4.8.10"]
         espresso: ["2.4"]
     runs-on: ${{ matrix.system }}
 
@@ -26,32 +25,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Install Z3 Build Dependencies(Ubuntu)
+      - name: Install Z3
         if: matrix.system == 'ubuntu-20.04'
-        run: sudo apt-get install -y libfl2 libfl-dev
-
-      - name: Cache Z3 ${{ matrix.z3 }}
-        uses: actions/cache@v2
-        id: cache-z3
-        with:
-          path: z3-z3-${{ matrix.z3 }}
-          key: ${{ matrix.system }}-z3-${{ matrix.z3 }}
-      - name: Compile Z3
-        if: steps.cache-z3.outputs.cache-hit != 'true'
         run: |
-          wget https://github.com/Z3Prover/z3/archive/refs/tags/z3-${{ matrix.z3 }}.tar.gz
-          tar xvf z3-${{ matrix.z3 }}.tar.gz
-          cd z3-z3-${{ matrix.z3 }}
-          mkdir -p build
-          cd build
-          cmake .. \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DZ3_LINK_TIME_OPTIMIZATION=1
-          make
-      - name: Install Z3 ${{ matrix.z3 }}
-        run: |
-          cd z3-z3-${{ matrix.z3 }}/build
-          sudo make install
+          sudo apt-get install -y z3
           z3 --version
 
       - name: Cache Verilator ${{ matrix.verilator }}

--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -590,6 +590,33 @@ object VecInit extends SourceInfoDoc {
   /** @group SourceInfoTransformMacro */
   def do_tabulate[T <: Data](n: Int)(gen: (Int) => T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Vec[T] =
     apply((0 until n).map(i => gen(i)))
+
+  /** Creates a new [[Vec]] of length `n` composed of the result of the given
+   * function applied to an element of data type T.
+   * 
+   * @param n number of elements in the vector
+   * @param gen function that takes in an element T and returns an output 
+   * element of the same type
+   */
+  def fill[T <: Data](n: Int)(gen: => T): Vec[T] = macro VecTransform.fill
+
+  /** @group SourceInfoTransformMacro */
+  def do_fill[T <: Data](n: Int)(gen: => T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Vec[T] =
+    apply(Seq.fill(n)(gen))
+
+  /** Creates a new [[Vec]] of length `n` composed of the result of the given
+   * function applied to an element of data type T.
+   * 
+   * @param start First element in the Vec
+   * @param len Lenth of elements in the Vec
+   * @param f Function that applies the element T from previous index and returns the output 
+   * element to the next index
+   */
+  def iterate[T <: Data](start: T, len: Int)(f: (T) => T): Vec[T] = macro VecTransform.iterate
+  
+  /** @group SourceInfoTransformMacro */
+  def do_iterate[T <: Data](start: T, len: Int)(f: (T) => T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Vec[T] = 
+    apply(Seq.iterate(start, len)(f)) 
 }
 
 /** A trait for [[Vec]]s containing common hardware generators for collection
@@ -964,7 +991,7 @@ abstract class Bundle(implicit compileOptions: CompileOptions) extends Record {
       getBundleField(m) match {
         case Some(d: Data) =>
           requireIsChiselType(d)
-
+          
           if (nameMap contains m.getName) {
             require(nameMap(m.getName) eq d)
           } else {
@@ -1268,3 +1295,4 @@ abstract class Bundle(implicit compileOptions: CompileOptions) extends Record {
     */
   override def toPrintable: Printable = toPrintableHelper(elements.toList.reverse)
 }
+

--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -528,7 +528,6 @@ object VecInit extends SourceInfoDoc {
     elts.foreach(requireIsHardware(_, "vec element"))
 
     val vec = Wire(Vec(elts.length, cloneSupertype(elts, "Vec")))
-    val tpe = cloneSupertype(elts, "Vec")
     val op = getConnectOpFromDirectionality(vec.head)
     
     (vec zip elts).foreach{ x => 

--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -991,7 +991,7 @@ abstract class Bundle(implicit compileOptions: CompileOptions) extends Record {
       getBundleField(m) match {
         case Some(d: Data) =>
           requireIsChiselType(d)
-          
+
           if (nameMap contains m.getName) {
             require(nameMap(m.getName) eq d)
           } else {

--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -489,6 +489,8 @@ sealed class Vec[T <: Data] private[chisel3] (gen: => T, val length: Int)
 
 object VecInit extends SourceInfoDoc {
 
+  /** Gets the correct operation (directed hardware assign or bulk connect) for element in Vec.
+    */
   def getConnectOpFromDirectionality[T <: Data](proto: T): (T, T) => Unit = macro VecTransform.get_connect_op
 
   /** @group SourceInfoTransformMacro */

--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -591,6 +591,67 @@ object VecInit extends SourceInfoDoc {
   def do_tabulate[T <: Data](n: Int)(gen: (Int) => T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Vec[T] =
     apply((0 until n).map(i => gen(i)))
 
+  /** Creates a new 2D [[Vec]] of length `n by m` composed of the results of the given
+    * function applied over a range of integer values starting from 0.
+    *
+    * @param n number of 1D vectors inside outer vector
+    * @param m number of elements in each 1D vector (the function is applied from
+    * 0 to `n-1`)
+    * @param gen function that takes in an Int (the index) and returns a
+    * [[Data]] that becomes the output element
+    */
+  def tabulate[T <: Data](n: Int, m: Int)(gen: (Int) => T): Vec[Vec[T]] = macro VecTransform.tabulate2D
+
+  /** @group SourceInfoTransformMacro */
+  def do_tabulate[T <: Data](n: Int, m: Int)(gen: (Int) => T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Vec[Vec[T]] = {
+    val myVec = Wire(Vec(n, Vec(m, cloneSupertype((0 until m).map(i => gen(i)), "Vec"))))
+    myVec.foreach {
+      _ := VecInit.tabulate(m)(gen)
+    }
+    myVec
+  }
+
+  /** Creates a new 3D [[Vec]] of length `n by m by p` composed of the results of the given
+    * function applied over a range of integer values starting from 0.
+    *
+    * @param n number of 2D vectors inside outer vector
+    * @param m number of 1D vectors in each 2D vector
+    * @param p number of elements in each 1D vector
+    * @param gen function that takes in an Int (the index) and returns a
+    * [[Data]] that becomes the output element
+    */
+  def tabulate[T <: Data](n: Int, m: Int, p: Int)(gen: (Int) => T): Vec[Vec[Vec[T]]] = macro VecTransform.tabulate3D
+
+  /** @group SourceInfoTransformMacro */
+  def do_tabulate[T <: Data](n: Int, m: Int, p: Int)(gen: (Int) => T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Vec[Vec[Vec[T]]] = {
+    val myVec = Wire(Vec(n, Vec(m, Vec(p, cloneSupertype((0 until p).map(i => gen(i)), "Vec")))))
+    myVec.foreach {
+      _ := VecInit.tabulate(m, p)(gen)
+    }
+    myVec
+  }
+
+  /** Creates a new 4D [[Vec]] of length `n by m by p by q` composed of the results of the given
+    * function applied over a range of integer values starting from 0.
+    *
+    * @param n number of 3D vectors inside outer vector
+    * @param m number of 2D vectors in each 3D vector
+    * @param p number of 1D vectors in each 2D vector
+    * @param q number of elements in each 1D vector
+    * @param gen function that takes in an Int (the index) and returns a
+    * [[Data]] that becomes the output element
+    */
+  def tabulate[T <: Data](n: Int, m: Int, p: Int, q: Int)(gen: (Int) => T): Vec[Vec[Vec[Vec[T]]]] = macro VecTransform.tabulate4D
+
+  /** @group SourceInfoTransformMacro */
+  def do_tabulate[T <: Data](n: Int, m: Int, p: Int, q: Int)(gen: (Int) => T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Vec[Vec[Vec[Vec[T]]]] = {
+    val myVec = Wire(Vec(n, Vec(m, Vec(p, Vec(q, cloneSupertype((0 until q).map(i => gen(i)), "Vec"))))))
+    myVec.foreach {
+      _ := VecInit.tabulate(m, p, q)(gen)
+    }
+    myVec
+  }
+
   /** Creates a new [[Vec]] of length `n` composed of the result of the given
    * function applied to an element of data type T.
    * 
@@ -603,6 +664,66 @@ object VecInit extends SourceInfoDoc {
   /** @group SourceInfoTransformMacro */
   def do_fill[T <: Data](n: Int)(gen: => T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Vec[T] =
     apply(Seq.fill(n)(gen))
+
+  /** Creates a new 2D [[Vec]] of length `n by m` composed of the result of the given
+   * function applied to an element of data type T.
+   * 
+   * @param n number of inner vectors (rows) in the outer vector
+   * @param m number of elements in each inner vector (column)
+   * @param gen function that takes in an element T and returns an output 
+   * element of the same type
+   */
+  def fill[T <: Data](n: Int, m: Int)(gen: => T): Vec[Vec[T]] = macro VecTransform.fill2D
+
+  /** @group SourceInfoTransformMacro */
+  def do_fill[T <: Data](n: Int, m: Int)(gen: => T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Vec[Vec[T]] = {
+    val myVec = Wire(Vec(n, Vec(m, cloneSupertype(Seq.fill(m)(gen), "Vec"))))
+    myVec.foreach {
+      _ := VecInit.fill(m)(gen)
+    }
+    myVec
+  }
+
+  /** Creates a new 3D [[Vec]] of length `n by m by p` composed of the result of the given
+   * function applied to an element of data type T.
+   * 
+   * @param n number of 2D vectors inside outer vector
+   * @param m number of 1D vectors in each 2D vector
+   * @param p number of elements in each 1D vector
+   * @param gen function that takes in an element T and returns an output 
+   * element of the same type
+   */
+  def fill[T <: Data](n: Int, m: Int, p: Int)(gen: => T): Vec[Vec[Vec[T]]] = macro VecTransform.fill3D
+
+  /** @group SourceInfoTransformMacro */
+  def do_fill[T <: Data](n: Int, m: Int, p: Int)(gen: => T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Vec[Vec[Vec[T]]] = {
+    val myVec = Wire(Vec(n, Vec(m, Vec(p, cloneSupertype(Seq.fill(p)(gen), "Vec")))))
+    myVec.foreach { 
+      _ := VecInit.fill(m, p)(gen)
+    }
+    myVec
+  }
+
+  /** Creates a new 4D [[Vec]] of length `n by m by p by q` composed of the result of the given
+   * function applied to an element of data type T.
+   * 
+   * @param n number of 3D vectors inside outer vector
+   * @param m number of 2D vectors inside each 3D vector
+   * @param p number of 1D vectors in each 2D vector
+   * @param q number of elements in each 1D vector
+   * @param gen function that takes in an element T and returns an output 
+   * element of the same type
+   */
+  def fill[T <: Data](n: Int, m: Int, p: Int, q: Int)(gen: => T): Vec[Vec[Vec[Vec[T]]]] = macro VecTransform.fill4D
+
+  /** @group SourceInfoTransformMacro */
+  def do_fill[T <: Data](n: Int, m: Int, p: Int, q: Int)(gen: => T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Vec[Vec[Vec[Vec[T]]]] = {
+    val myVec = Wire(Vec(n, Vec(m, Vec(p, Vec(q, cloneSupertype(Seq.fill(q)(gen), "Vec"))))))
+    myVec.foreach { 
+      _ := VecInit.fill(m, p, q)(gen)
+    }
+    myVec
+  }
 
   /** Creates a new [[Vec]] of length `n` composed of the result of the given
    * function applied to an element of data type T.

--- a/docs/src/cookbooks/cookbook.md
+++ b/docs/src/cookbooks/cookbook.md
@@ -16,6 +16,7 @@ Please note that these examples make use of [Chisel's scala-style printing](../e
   * [How do I create a Vec of Bools from a UInt?](#how-do-i-create-a-vec-of-bools-from-a-uint)
   * [How do I create a UInt from a Vec of Bool?](#how-do-i-create-a-uint-from-a-vec-of-bool)
 * Vectors and Registers
+  * [Can I make a 2D or 3D Vector?](#can-i-make-a-2D-or-3D-Vector)
   * [How do I create a Vector of Registers?](#how-do-i-create-a-vector-of-registers)
   * [How do I create a Reg of type Vec?](#how-do-i-create-a-reg-of-type-vec)
 * [How do I create a finite state machine?](#how-do-i-create-a-finite-state-machine-fsm)
@@ -149,6 +150,39 @@ class Foo extends RawModule {
 ```
 
 ## Vectors and Registers
+
+### Can I make a 2D or 3D Vector?
+
+Yes. Using `VecInit` you can make Vectors that hold Vectors of Chisel types. Methods `fill` and `tabulate` make these multi-dimensional Vectors.
+
+```scala mdoc:silent:reset
+import chisel3._
+
+class MyBundle extends Bundle {
+  val foo = UInt(4.W)
+  val bar = UInt(4.W)
+}
+
+class Foo extends Module {
+  
+  val twoDVec = VecInit.fill(2,3)(5.U)
+  val threeDVec = VecInit.fill(1,2,4)(new MyBundle)
+
+  val indexTiedVec = VecInit.tabulate(2,2){ (x, y) => (x+y).asUInt }
+  assert(indexTiedVec(0)(0) === 0.U)
+  assert(indexTiedVec(0)(1) === 1.U)
+  assert(indexTiedVec(1)(0) === 1.U)
+  assert(indexTiedVec(1)(1) === 2.U)
+
+  val indexTiedVec3D = VecInit.tabulate(1,2,3){ (x, y, z) => (x*y*z).asUInt }
+  assert(indexTiedVec(0)(0)(0) === 0.U)
+  assert(indexTiedVec(1)(1)(1) === 1.U)
+  assert(indexTiedVec(1)(1)(2) === 2.U)
+  assert(indexTiedVec(1)(1)(3) === 3.U)
+  assert(indexTiedVec(1)(2)(3) === 6.U)
+
+}
+```
 
 ### How do I create a Vector of Registers?
 

--- a/docs/src/cookbooks/cookbook.md
+++ b/docs/src/cookbooks/cookbook.md
@@ -175,13 +175,13 @@ class Foo extends Module {
   val twoDVec = VecInit.fill(2,3)(5.U)
   val threeDVec = VecInit.fill(1,2,4)(new MyBundle)
 
-  val indexTiedVec = VecInit.tabulate(2,2){ (x, y) => (x+y).asUInt }
+  val indexTiedVec = VecInit.tabulate(2, 2){ (x, y) => (x + y).U }
   assert(indexTiedVec(0)(0) === 0.U)
   assert(indexTiedVec(0)(1) === 1.U)
   assert(indexTiedVec(1)(0) === 1.U)
   assert(indexTiedVec(1)(1) === 2.U)
 
-  val indexTiedVec3D = VecInit.tabulate(1,2,3){ (x, y, z) => (x*y*z).asUInt }
+  val indexTiedVec3D = VecInit.tabulate(1, 2, 3){ (x, y, z) => (x * y * z).U }
   assert(indexTiedVec(0)(0)(0) === 0.U)
   assert(indexTiedVec(1)(1)(1) === 1.U)
   assert(indexTiedVec(1)(1)(2) === 2.U)
@@ -190,6 +190,11 @@ class Foo extends Module {
 
 }
 ```
+```scala mdoc:invisible
+// Hidden but will make sure this actually compiles
+ChiselStage.emitVerilog(new Foo)
+```
+
 
 ### How do I create a Vector of Registers?
 

--- a/docs/src/cookbooks/cookbook.md
+++ b/docs/src/cookbooks/cookbook.md
@@ -192,6 +192,8 @@ class Foo extends Module {
 ```
 ```scala mdoc:invisible
 // Hidden but will make sure this actually compiles
+import chisel3.stage.ChiselStage
+
 ChiselStage.emitVerilog(new Foo)
 ```
 

--- a/docs/src/cookbooks/cookbook.md
+++ b/docs/src/cookbooks/cookbook.md
@@ -171,23 +171,28 @@ class MyBundle extends Bundle {
 }
 
 class Foo extends Module {
-  
-  val twoDVec = VecInit.fill(2,3)(5.U)
-  val threeDVec = VecInit.fill(1,2,4)(new MyBundle)
+  //2D Fill
+  val twoDVec = VecInit.fill(2, 3)(5.U)
+  //3D Fill
+  val myBundle = Wire(new MyBundle)
+  myBundle.foo := 0xc.U
+  myBundle.bar := 0x3.U
+  val threeDVec = VecInit.fill(1, 2, 3)(myBundle)
+  assert(threeDVec(0)(0)(0).foo === 0xc.U && threeDVec(0)(0)(0).bar === 0x3.U)
 
+  //2D Tabulate
   val indexTiedVec = VecInit.tabulate(2, 2){ (x, y) => (x + y).U }
   assert(indexTiedVec(0)(0) === 0.U)
   assert(indexTiedVec(0)(1) === 1.U)
   assert(indexTiedVec(1)(0) === 1.U)
   assert(indexTiedVec(1)(1) === 2.U)
-
-  val indexTiedVec3D = VecInit.tabulate(1, 2, 3){ (x, y, z) => (x * y * z).U }
-  assert(indexTiedVec(0)(0)(0) === 0.U)
-  assert(indexTiedVec(1)(1)(1) === 1.U)
-  assert(indexTiedVec(1)(1)(2) === 2.U)
-  assert(indexTiedVec(1)(1)(3) === 3.U)
-  assert(indexTiedVec(1)(2)(3) === 6.U)
-
+  //3D Tabulate
+  val indexTiedVec3D = VecInit.tabulate(2, 3, 4){ (x, y, z) => (x + y * z).U }
+  assert(indexTiedVec3D(0)(0)(0) === 0.U)
+  assert(indexTiedVec3D(1)(1)(1) === 2.U)
+  assert(indexTiedVec3D(1)(1)(2) === 3.U)
+  assert(indexTiedVec3D(1)(1)(3) === 4.U)
+  assert(indexTiedVec3D(1)(2)(3) === 7.U)
 }
 ```
 ```scala mdoc:invisible

--- a/macros/src/main/scala/chisel3/internal/sourceinfo/SourceInfoTransform.scala
+++ b/macros/src/main/scala/chisel3/internal/sourceinfo/SourceInfoTransform.scala
@@ -84,6 +84,9 @@ class VecTransform(val c: Context) extends SourceInfoTransformMacro {
   def fill(n: c.Tree)(gen: c.Tree): c.Tree = {
     q"$thisObj.do_fill($n)($gen)($implicitSourceInfo, $implicitCompileOptions)"
   }
+  def iterate(start: c.Tree, len: c.Tree)(f: c.Tree): c.Tree = {
+    q"$thisObj.do_iterate($start,$len)($f)($implicitSourceInfo, $implicitCompileOptions)"
+  }
   def contains(x: c.Tree)(ev: c.Tree): c.Tree = {
     q"$thisObj.do_contains($x)($implicitSourceInfo, $ev, $implicitCompileOptions)"
   }

--- a/macros/src/main/scala/chisel3/internal/sourceinfo/SourceInfoTransform.scala
+++ b/macros/src/main/scala/chisel3/internal/sourceinfo/SourceInfoTransform.scala
@@ -72,9 +72,6 @@ class MuxTransform(val c: Context) extends SourceInfoTransformMacro {
 object VecTransform
 class VecTransform(val c: Context) extends SourceInfoTransformMacro {
   import c.universe._
-  def get_connect_op(proto: c.Tree): c.Tree = {
-    q"$thisObj.do_getConnectOpFromDirectionality($proto)($implicitSourceInfo, $implicitCompileOptions)"
-  }
   def apply_elts(elts: c.Tree): c.Tree = {
     q"$thisObj.do_apply($elts)($implicitSourceInfo, $implicitCompileOptions)"
   }

--- a/macros/src/main/scala/chisel3/internal/sourceinfo/SourceInfoTransform.scala
+++ b/macros/src/main/scala/chisel3/internal/sourceinfo/SourceInfoTransform.scala
@@ -81,8 +81,26 @@ class VecTransform(val c: Context) extends SourceInfoTransformMacro {
   def tabulate(n: c.Tree)(gen: c.Tree): c.Tree = {
     q"$thisObj.do_tabulate($n)($gen)($implicitSourceInfo, $implicitCompileOptions)"
   }
+  def tabulate2D(n: c.Tree, m: c.Tree)(gen: c.Tree): c.Tree = {
+    q"$thisObj.do_tabulate($n,$m)($gen)($implicitSourceInfo, $implicitCompileOptions)"
+  }
+  def tabulate3D(n: c.Tree, m: c.Tree, p: c.Tree)(gen: c.Tree): c.Tree = {
+    q"$thisObj.do_tabulate($n,$m,$p)($gen)($implicitSourceInfo, $implicitCompileOptions)"
+  }
+  def tabulate4D(n: c.Tree, m: c.Tree, p: c.Tree, q: c.Tree)(gen: c.Tree): c.Tree = {
+    q"$thisObj.do_tabulate($n,$m,$p,$q)($gen)($implicitSourceInfo, $implicitCompileOptions)"
+  }
   def fill(n: c.Tree)(gen: c.Tree): c.Tree = {
     q"$thisObj.do_fill($n)($gen)($implicitSourceInfo, $implicitCompileOptions)"
+  }
+  def fill2D(n: c.Tree, m: c.Tree)(gen: c.Tree): c.Tree = {
+    q"$thisObj.do_fill($n,$m)($gen)($implicitSourceInfo, $implicitCompileOptions)"
+  }
+  def fill3D(n: c.Tree, m: c.Tree, p: c.Tree)(gen: c.Tree): c.Tree = {
+    q"$thisObj.do_fill($n,$m,$p)($gen)($implicitSourceInfo, $implicitCompileOptions)"
+  }
+  def fill4D(n: c.Tree, m: c.Tree, p: c.Tree, q: c.Tree)(gen: c.Tree): c.Tree = {
+    q"$thisObj.do_fill($n,$m,$p,$q)($gen)($implicitSourceInfo, $implicitCompileOptions)"
   }
   def iterate(start: c.Tree, len: c.Tree)(f: c.Tree): c.Tree = {
     q"$thisObj.do_iterate($start,$len)($f)($implicitSourceInfo, $implicitCompileOptions)"

--- a/macros/src/main/scala/chisel3/internal/sourceinfo/SourceInfoTransform.scala
+++ b/macros/src/main/scala/chisel3/internal/sourceinfo/SourceInfoTransform.scala
@@ -72,6 +72,9 @@ class MuxTransform(val c: Context) extends SourceInfoTransformMacro {
 object VecTransform
 class VecTransform(val c: Context) extends SourceInfoTransformMacro {
   import c.universe._
+  def get_connect_op(proto: c.Tree): c.Tree = {
+    q"$thisObj.do_getConnectOpFromDirectionality($proto)($implicitSourceInfo, $implicitCompileOptions)"
+  }
   def apply_elts(elts: c.Tree): c.Tree = {
     q"$thisObj.do_apply($elts)($implicitSourceInfo, $implicitCompileOptions)"
   }
@@ -87,9 +90,6 @@ class VecTransform(val c: Context) extends SourceInfoTransformMacro {
   def tabulate3D(n: c.Tree, m: c.Tree, p: c.Tree)(gen: c.Tree): c.Tree = {
     q"$thisObj.do_tabulate($n,$m,$p)($gen)($implicitSourceInfo, $implicitCompileOptions)"
   }
-  def tabulate4D(n: c.Tree, m: c.Tree, p: c.Tree, q: c.Tree)(gen: c.Tree): c.Tree = {
-    q"$thisObj.do_tabulate($n,$m,$p,$q)($gen)($implicitSourceInfo, $implicitCompileOptions)"
-  }
   def fill(n: c.Tree)(gen: c.Tree): c.Tree = {
     q"$thisObj.do_fill($n)($gen)($implicitSourceInfo, $implicitCompileOptions)"
   }
@@ -102,7 +102,6 @@ class VecTransform(val c: Context) extends SourceInfoTransformMacro {
   def fill4D(n: c.Tree, m: c.Tree, p: c.Tree, q: c.Tree)(gen: c.Tree): c.Tree = {
     q"$thisObj.do_fill($n,$m,$p,$q)($gen)($implicitSourceInfo, $implicitCompileOptions)"
   }
-
   def iterate(start: c.Tree, len: c.Tree)(f: c.Tree): c.Tree = {
     q"$thisObj.do_iterate($start,$len)($f)($implicitSourceInfo, $implicitCompileOptions)"
   }

--- a/src/test/scala/chiselTests/Vec.scala
+++ b/src/test/scala/chiselTests/Vec.scala
@@ -184,12 +184,12 @@ object VecMultiDimTester {
     val tester = Module(new PassthroughModuleTester)
     
     for {
-        vec2D <- vec3D
-        vec1D <- vec2D
-        module <- vec1D
+      vec2D <- vec3D
+      vec1D <- vec2D
+      module <- vec1D
     } yield {
-        module <> tester.io
-        assert(module.out === 123.U)
+      module <> tester.io
+      assert(module.out === 123.U)
     }
     stop()
   }

--- a/src/test/scala/chiselTests/Vec.scala
+++ b/src/test/scala/chiselTests/Vec.scala
@@ -169,13 +169,11 @@ object VecMultiDimTester {
   class BidirectionalTester2D(n: Int, m: Int) extends BasicTester {
     val mod = Module(new PassthroughModule)
     val vec2D = VecInit.fill(n, m)(mod.io)
-    val tester = Module(new PassthroughModuleTester)
     for {
-        vec1D <- vec2D
-        module <- vec1D
+      vec1D <- vec2D
+      module <- vec1D
     } yield {
-        module <> tester.io
-        assert(module.out === 123.U)
+      module <> (Module(new PassthroughModuleTester).io)
     }
     stop()
   }


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
- new feature/API   

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->
This extends the tabulate and fill functions for VecInit to create multi-dimensional Vecs 
Ex. Vec[Vec[UInt]]
#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
This should not change the backend code generation as it only provides different ways to fill a multi-dimensional Vec.
<!-- How does it change it or in what circumstances would it?  -->

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
- Squash: The PR will be squashed and merged (choose this if you have no preference. 
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
This PR adds builds upon companion object factory methods for the VecInit class, .fill and .iterate, to include multi-dimensional Vecs.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.x, 3.5.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
