### PR TITLE
[RFC] Deprecate switch-is

### DIFF
--- a/src/main/scala/chisel3/util/Conditional.scala
+++ b/src/main/scala/chisel3/util/Conditional.scala
@@ -90,6 +90,12 @@ object is {
   * }
   * }}}
   */
+@deprecated(
+  """switch-is has been deprecated in 3.4, it will be removed in 3.5
+    |if you are look for Verilog Case Statement, please use chisel3.util.experimental.decode.decoder
+    |switch-is results to a cascade `when` block, which leads to a priority mux in the final RTL.
+    |for parallel lookup, please use chisel3.util.Mux1H or chisel3.util.experimental.decode.decoder
+    |""".stripMargin, "3.4")
 object switch {
   def apply[T <: Element](cond: T)(x: => Any): Unit = macro impl
   def impl(c: Context)(cond: c.Tree)(x: c.Tree): c.Tree = { import c.universe._


### PR DESCRIPTION
## tl;dr
`switch-is` is very misleading, users are complaining the bad QoR result from switch.

## Reason to deprecate this API
The implementation of `switch-case` is a cascade `when` block which will return to a cascade `PriorityMux`, lead to a bad QoR of RTL.

Commercial synthesis tool seems being able to statically detect the Mux select signal are mutually exclusive, while `yosys` not being able to generate the parallel look-up-table with this RTL. This may result different circuit in different synthesis tools, since FIRRTL won't check ME among the priorities `Mux`.

High-end Verilog designer will use `parallel_case`, which seems never being able to be provided by Chisel. they always require a parallel PLA(LUT) via case statement, they believe `switch-is` API provide this since it is similar to the Verilog Case Statement, and most of them rightfully use this API.
If they fail to run their circuit to very high frequency, they will blame Chisel PPA...

## Replacement
For the QoR of circuit, I suggest user should migrate to `decode` API to construct PLA or use `Mux1H` explicitly, to achieve a better timing. Neither of them provide a same syntax as `case` statement, but both of them are parallel circuit which provides a better QoR, if users really need a parallel selection logic, they should directly this those API.

## Migration Effort
It is seems to be a tough migration path, however, in UCB-Bar+ChipsAlliance projects, usage of switch is really small(maybe advance users know they should avoid this API. entire `rocket-chip` only uses two `switch` for two times.)
```
hwacha/src/main/scala/smu.scala:139:  switch (state) {
hwacha/src/main/scala/vfu-rpred.scala:71:  switch (state) {
hwacha/src/main/scala/vmu-addr.scala:116:  switch (state) {
hwacha/src/main/scala/vmu-addr.scala:283:  switch (state) {
hwacha/src/main/scala/vmu-addr.scala:380:  switch (state) {
hwacha/src/main/scala/vfu-rfirst.scala:78:  switch (state) {
hwacha/src/main/scala/dcc-fu.scala:163:  switch (state) {
hwacha/src/main/scala/dcc-mem.scala:72:  switch (state) {
hwacha/src/main/scala/dcc-mem.scala:171:  switch (state) {
hwacha/src/main/scala/dcc-mem.scala:335:  switch (state) {
hwacha/src/main/scala/xcpt.scala:111:  switch (state) {
hwacha/src/main/scala/vmu.scala:233:  switch (state) {
hwacha/src/main/scala/vmu-pred.scala:109:  switch (state) {
hwacha/src/main/scala/vmu-pred.scala:271:  switch (state) {
hwacha/src/main/scala/rocc-unit.scala:351:      switch (state) {
firesim/sim/src/main/scala/midasexamples/RiscSRAM.scala:56:  switch(state) {
firesim/sim/midas/src/main/scala/midas/models/dram/LastLevelCache.scala:357:  switch (state) {
firesim/sim/midas/src/main/scala/midas/models/dram/DramCommon.scala:389:    switch(io.selectedCmd) {
firesim/sim/midas/src/main/scala/midas/models/dram/DramCommon.scala:585:  switch (io.cmd) {
firesim/sim/midas/src/main/scala/midas/models/dram/DramCommon.scala:684:    switch(io.selectedCmd) {
firesim/sim/src/main/scala/midasexamples/Risc.scala:43:    switch(op) {
firesim/sim/firesim-lib/src/main/scala/bridges/UARTBridge.scala:119:    switch(txState) {
firesim/sim/firesim-lib/src/main/scala/bridges/UARTBridge.scala:159:    switch(rxState) {
icenet/src/main/scala/Pauser.scala:85:    switch (state) {
rocket-chip/src/main/scala/rocket/PTW.scala:329:  switch (state) {
rocket-chip/src/main/scala/jtag/JtagStateMachine.scala:80:  switch (currState) {
riscv-boom/src/main/scala/exu/rob.scala:802:    switch (rob_state) {
riscv-boom/src/main/scala/exu/rob.scala:832:    switch (rob_state) {
chisel3/src/test/scala/cookbook/FSM.scala:29:  switch (state) {
chisel3/src/test/scala/chiselTests/CompatibilitySpec.scala:169:      switch(op) {
chisel3/src/test/scala/chiselTests/Mem.scala:27:  switch (cnt) {
chisel3/src/test/scala/chiselTests/Mem.scala:65:  switch (cnt) {
chisel3/src/test/scala/chiselTests/Mem.scala:77:  switch (cnt) {
chisel3/src/test/scala/chiselTests/Mem.scala:90:  switch (cnt) {
chisel3/src/test/scala/chiselTests/Mem.scala:107:  switch (cnt) {
chisel3/src/test/scala/chiselTests/Risc.scala:44:    switch(op) {
gemmini/src/main/scala/gemmini/LoadController.scala:125:  switch (control_state) {
gemmini/src/main/scala/gemmini/Transposer.scala:27:  switch(state) {
gemmini/src/main/scala/gemmini/LoopConv.scala:1106:    switch (cmd.bits.inst.funct) {
gemmini/src/main/scala/gemmini/LoopMatmul.scala:705:    switch (cmd.bits.inst.funct) {
gemmini/src/main/scala/gemmini/StoreController.scala:181:  switch (control_state) {
gemmini/src/main/scala/gemmini/TilerFSM.scala:214:  switch (state) {
gemmini/src/main/scala/gemmini/ExecuteController.scala:529:  switch (control_state) {
gemmini/src/main/scala/gemmini/Im2Col.scala:184:  switch(im2col_state){
rocket-dsp-utils/src/main/scala/freechips/rocketchip/jtag2mm/JtagStateMachine.scala:102:    switch(lastState) {
rocket-dsp-utils/src/main/scala/freechips/rocketchip/jtag2mm/JtagToMaster.scala:231:    switch(state) {
rocket-dsp-utils/src/main/scala/freechips/rocketchip/jtag2mm/JtagToMaster.scala:600:    switch(state) {
rocket-dsp-utils/src/main/scala/freechips/rocketchip/jtag2mm/JtagFuzzer.scala:54:  switch(state) {
chisel-testers2/src/test/scala/chiseltest/tests/TestUtils.scala:69:  switch(io.fn) {
sifive-blocks/src/main/scala/devices/spi/SPIMedia.scala:74:  switch (state) {
sifive-blocks/src/main/scala/devices/spi/SPIPhysical.scala:220:      switch (op.fn) {
sifive-blocks/src/main/scala/devices/spi/SPIFlash.scala:97:  switch (state) {
sifive-blocks/src/main/scala/devices/uart/UARTRx.scala:63:  switch (state) {
sifive-blocks/src/main/scala/devices/chiplink/SinkC.scala:34:    switch (state) {
sifive-blocks/src/main/scala/devices/chiplink/SinkB.scala:32:    switch (state) {
sifive-blocks/src/main/scala/devices/chiplink/SourceC.scala:47:    switch (state) {
sifive-blocks/src/main/scala/devices/chiplink/SourceA.scala:49:    switch (state) {
sifive-blocks/src/main/scala/devices/chiplink/SourceD.scala:53:    switch (state) {
sifive-blocks/src/main/scala/devices/i2c/I2C.scala:235:      switch (bitState) {
sifive-blocks/src/main/scala/devices/i2c/I2C.scala:237:          switch (bitCmd) {
sifive-blocks/src/main/scala/devices/i2c/I2C.scala:402:    switch (byteState) {
sifive-blocks/src/main/scala/devices/chiplink/SinkA.scala:37:    switch (state) {
sifive-blocks/src/main/scala/devices/chiplink/SinkD.scala:32:    switch (state) {
sifive-blocks/src/main/scala/devices/chiplink/SourceB.scala:44:    switch (state) {
chisel-testers2/src/main/scala/chiseltest/simulator/jna/VerilatorCppJNAHarnessGenerator.scala:51:    switch(id) {
chisel-testers2/src/main/scala/chiseltest/simulator/jna/VerilatorCppJNAHarnessGenerator.scala:65:    switch(id) {
chisel-testers2/src/main/scala/chiseltest/simulator/jna/VerilatorCppJNAHarnessGenerator.scala:83:    switch(id) {
chisel-testers2/src/main/scala/chiseltest/simulator/jna/VerilatorCppJNAHarnessGenerator.scala:110:    switch(id) {
sha3/src/main/scala/dpath.scala:74:  switch(io.stage){
sha3/src/main/scala/ctrl.scala:186:  switch(rocc_s) {
sha3/src/main/scala/ctrl.scala:216:  switch(mem_s){
sha3/src/main/scala/ctrl.scala:602:  switch(state) {
firrtl/src/main/scala/firrtl/passes/CheckWidths.scala:163:            // Beyond that, switch to an explicit, iterative DFS to avoid stack overflow
firrtl/src/main/scala/firrtl/Driver.scala:192:    StageUtils.dramaticWarning("firrtl.Driver is deprecated since 1.2!\nPlease switch to firrtl.stage.FirrtlMain")
dsptools/src/test/scala/examples/SimpleDspModuleSpec.scala:87:        // you need to switch the backend to Verilator. Note that tests currently need to be dumped in
dsptools/src/main/scala/dsptools/numbers/algebra_types/Order.scala:66:    * Defines an ordering on `A` where all arrows switch direction.
dsptools/src/main/scala/dsptools/numbers/algebra_types/PartialOrder.scala:96:    * Defines a partial order on `A` where all arrows switch direction.
firrtl/src/test/scala/firrtlTests/features/LetterCaseTransformSpec.scala:169:      /* Instance "SuB2" and "SuB3" switch their modules from the lower case test due to namespace behavior. */ {
dsptools/src/test/scala/dsptools/numbers/BlackBoxFloat.scala:116:  switch (io.opsel) {
dsptools/src/test/scala/dsptools/numbers/BlackBoxFloat.scala:152:  switch (io.opsel) {
block-inclusivecache-sifive/design/craft/inclusivecache/src/MSHR.scala:314:    switch (entry.state) {
testchipip/src/main/scala/CustomBootPin.scala:50:        switch (state) {
testchipip/src/main/scala/UARTAdapter.scala:46:  switch(txState) {
testchipip/src/main/scala/UARTAdapter.scala:86:  switch(rxState) {
```

However for young projects, XiangShan as an example:
```
src/main/scala/device/AXI4SlaveModule.scala:96:  switch(state){
src/main/scala/device/AXI4DummySD.scala:94:      switch(cmd) {
src/main/scala/xiangshan/cache/L1plusCache.scala:435:  switch (state) {
src/main/scala/xiangshan/cache/ICacheMissQueue.scala:128:    switch(state){
src/main/scala/xiangshan/cache/prefetch/L1plusPrefetcher.scala:40:    // switch
src/main/scala/xiangshan/cache/PTW.scala:1195:  switch (state) {
src/main/scala/xiangshan/mem/sbuffer/NewSbuffer.scala:287:  switch(sbuffer_state){
src/main/scala/xiangshan/mem/lsqueue/LSQWrapper.scala:140:  switch(pendingstate){
src/main/scala/xiangshan/mem/lsqueue/StoreQueue.scala:319:  switch(uncacheState) {
src/main/scala/xiangshan/mem/lsqueue/LoadQueue.scala:588:  switch(uncacheState) {
src/main/scala/xiangshan/backend/fu/fpu/IntToFP.scala:47:  switch(state){
src/main/scala/xiangshan/backend/fu/SRT4Divider.scala:69:  switch(state) {
src/main/scala/xiangshan/backend/fu/fpu/FDivSqrt.scala:44:  switch(state){
src/main/scala/xiangshan/backend/decode/StoreSet.scala:86:    switch (Cat(loadAssigned, storeAssigned)) {
src/main/scala/xiangshan/backend/roq/Roq.scala:452:    XSDebug("roq full, switched to s_extrawalk. needExtraSpaceForMPR: %b\n", io.enq.needAlloc.asUInt)
src/main/scala/xiangshan/backend/roq/Roq.scala:546:    * (1) exceptions: when exception occurs, cancels all and switch to s_idle
src/main/scala/xiangshan/backend/roq/Roq.scala:547:    * (2) redirect: switch to s_walk or s_extrawalk (depends on whether there're pending instructions in dispatch1)
src/main/scala/xiangshan/backend/roq/Roq.scala:548:    * (3) walk: when walking comes to the end, switch to s_walk
src/main/scala/xiangshan/frontend/FakeICache.scala:69:  switch(state){
src/main/scala/xiangshan/frontend/LoopBuffer.scala:150://     switch(LBstate) {
src/main/scala/utils/TLDump.scala:45:    switch(a.opcode) {
src/main/scala/utils/TLDump.scala:89:        switch(a.param) {
src/main/scala/utils/TLDump.scala:112:        switch(a.param) {
src/main/scala/utils/TLDump.scala:138:    switch(b.opcode) {
src/main/scala/utils/TLDump.scala:182:        switch(b.param) {
src/main/scala/utils/TLDump.scala:208:    switch(c.opcode) {
src/main/scala/utils/TLDump.scala:231:        switch(c.param) {
src/main/scala/utils/TLDump.scala:272:        switch(c.param) {
src/main/scala/utils/TLDump.scala:313:        switch(c.param) {
src/main/scala/utils/TLDump.scala:354:        switch(c.param) {
src/main/scala/utils/TLDump.scala:398:    switch(d.opcode) {
src/main/scala/utils/TLDump.scala:421:        switch(d.param) {
src/main/scala/utils/TLDump.scala:444:        switch(d.param) {
src/test/scala/cache/UnalignedGetTest.scala:302:    switch(state){
```
They use it for 34 times, I asked the circuit design of XiangShan, most of them doesn't know `switch` will return a parallel Mux in FIRRTL.

if a synthesis tool doesn't successfully test the ME, it will result a bad PPA. I don't wanna user suffer from a bad PPA and blame Chisel generated a very-very-deep `if` block for them. HuaWei and ICT both complain this to me :( 

So I'm proposing deprecate `switch` in 3.4 and remove it since 3.5, I can handle migration flow for most of open source projects.
  
### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [ ] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [ ] Did you state the API impact?
- [ ] Did you specify the code generation impact?
- [ ] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement
- code cleanup

#### API Impact
- deprecate API

#### Backend Code Generation Impact
None

#### Desired Merge Strategy

- Squash: The PR will be squashed and merged (choose this if you have no preference.

#### Release Notes
`switch-is` is deprecated.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.x, 3.5.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
