### PR TITLE
[docs] Add example of stripping directions from type

### DIFF
--- a/docs/src/cookbooks/cookbook.md
+++ b/docs/src/cookbooks/cookbook.md
@@ -27,6 +27,8 @@ Please note that these examples make use of [Chisel's scala-style printing](../e
   * [How do I get Chisel to name signals properly in blocks like when/withClockAndReset?](#how-do-i-get-chisel-to-name-signals-properly-in-blocks-like-whenwithclockandreset)
   * [How do I get Chisel to name the results of vector reads properly?](#how-do-i-get-chisel-to-name-the-results-of-vector-reads-properly)
   * [How can I dynamically set/parametrize the name of a module?](#how-can-i-dynamically-setparametrize-the-name-of-a-module)
+* Directionality
+  * [How do I strip directions from a bidirectional Bundle (or other Data)?](#how-do-i-strip-directions-from-a-bidirectional-bundle-or-other-data)
 
 ## Type Conversions
 
@@ -461,4 +463,53 @@ ChiselStage.emitVerilog(new Salt)
 
 ```scala mdoc:verilog
 ChiselStage.emitVerilog(new Salt)
+```
+
+## Directionality
+
+### How do I strip directions from a bidirectional Bundle (or other Data)?
+
+Given a bidirectional port like a `Decoupled`, you will get an error if you try to connect it directly
+to a register:
+
+```scala mdoc:silent
+import chisel3.util.Decoupled
+class BadRegConnect extends Module {
+  val io = IO(new Bundle {
+    val enq = Decoupled(UInt(8.W))
+  })
+  
+  val monitor = RegNext(io.enq)
+}
+```
+
+```scala mdoc:crash
+ChiselStage.emitVerilog(new BadRegConnect)
+```
+
+While there is no construct to "strip direction" in Chisel3, wrapping a type in `Output(...)` will
+coerce the direction to `Output` (even if the input is bidirectional).
+This will have the desired result when used to construct a Register:
+
+```scala mdoc:silent
+import chisel3.util.Decoupled
+class CoercedRegConnect extends Module {
+  val io = IO(new Bundle {
+    val enq = Flipped(Decoupled(UInt(8.W)))
+  })
+  
+  // Make a Reg of the correct type instead of using RegNext
+  val monitor = Reg(Output(chiselTypeOf(io.enq)))
+  monitor := io.enq // monoconnect will ignore directions of right-hand side
+  // dontTouch so that it shows up in the Verilog
+  dontTouch(monitor)
+}
+```
+
+<!-- Just make sure it actually works -->
+```scala mdoc:invisible
+ChiselStage.emitVerilog(new CoercedRegConnect {
+  // Provide default connections that would just muddy the example
+  io.enq.ready := true.B
+})
 ```

--- a/docs/src/cookbooks/cookbook.md
+++ b/docs/src/cookbooks/cookbook.md
@@ -502,9 +502,8 @@ class CoercedRegConnect extends Module {
   
   // Make a Reg which contains all of the bundle's signals, regardless of their directionality
   val monitor = Reg(Output(chiselTypeOf(io.enq)))
-  monitor := io.enq // monoconnect will ignore directions of right-hand side
-  // dontTouch so that it shows up in the Verilog
-  dontTouch(monitor)
+  // Even though io.enq is bidirectional, := will drive all fields of monitor with the fields of io.enq
+  monitor := io.enq
 }
 ```
 
@@ -513,5 +512,7 @@ class CoercedRegConnect extends Module {
 ChiselStage.emitVerilog(new CoercedRegConnect {
   // Provide default connections that would just muddy the example
   io.enq.ready := true.B
+  // dontTouch so that it shows up in the Verilog
+  dontTouch(monitor)
 })
 ```

--- a/docs/src/cookbooks/cookbook.md
+++ b/docs/src/cookbooks/cookbook.md
@@ -479,7 +479,8 @@ class BadRegConnect extends Module {
     val enq = Decoupled(UInt(8.W))
   })
   
-  val monitor = RegNext(io.enq)
+  val monitor = Reg(chiselTypeOf(io.enq))
+  monitor := io.enq
 }
 ```
 
@@ -487,8 +488,9 @@ class BadRegConnect extends Module {
 ChiselStage.emitVerilog(new BadRegConnect)
 ```
 
-While there is no construct to "strip direction" in Chisel3, wrapping a type in `Output(...)` will
-coerce the direction to `Output` (even if the input is bidirectional).
+While there is no construct to "strip direction" in Chisel3, wrapping a type in `Output(...)`
+(the default direction in Chisel3) will
+set all of the individual elements to output direction.
 This will have the desired result when used to construct a Register:
 
 ```scala mdoc:silent
@@ -498,7 +500,7 @@ class CoercedRegConnect extends Module {
     val enq = Flipped(Decoupled(UInt(8.W)))
   })
   
-  // Make a Reg of the correct type instead of using RegNext
+  // Make a Reg which contains all of the bundle's signals, regardless of their directionality
   val monitor = Reg(Output(chiselTypeOf(io.enq)))
   monitor := io.enq // monoconnect will ignore directions of right-hand side
   // dontTouch so that it shows up in the Verilog


### PR DESCRIPTION
This question came up on gitter: https://gitter.im/freechipsproject/chisel3?at=6117c83e7555e333510edb83

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [NA] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

  - documentation


#### API Impact

No impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

 - Squash
 
#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [x] Did you add the appropriate labels?
- [x] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.x, 3.5.0) ?
- [x] Did you review?
- [x] Did you check whether all relevant Contributor checkboxes have been checked?
- [x] Did you mark as `Please Merge`?
