### PR TITLE
Builder: downgrade "Elaborating design" message to info

### DIFF
--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -701,11 +701,11 @@ private[chisel3] object Builder extends LazyLogging {
       ViewParent // Must initialize the singleton in a Builder context or weird things can happen
                  // in tiny designs/testcases that never access anything in chisel3.internal
       checkScalaVersion()
-      logger.warn("Elaborating design...")
+      logger.info("Elaborating design...")
       val mod = f
       mod.forceName(None, mod.name, globalNamespace)
       errors.checkpoint(logger)
-      logger.warn("Done elaborating.")
+      logger.info("Done elaborating.")
 
       (Circuit(components.last.name, components.toSeq, annotations.toSeq, makeViewRenameMap), mod)
     }


### PR DESCRIPTION
This does break user visible behavior. However, I see no other way to prevent unit tests that go through a bunch of different designs from printing out:

```
Elaborating design...
Done elaborating.
Elaborating design...
Done elaborating.
Elaborating design...
Done elaborating.
Elaborating design...
Done elaborating.
Elaborating design...
Done elaborating.
```

with no end and no information to the user where this message is coming from.

### Contributor Checklist

- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement
- change message severity from `warn` to `info`

#### API Impact

- elaborating a design does not print out `Elaborating` design by default anymore.

#### Backend Code Generation Impact
- none

#### Desired Merge Strategy
- squash

#### Release Notes
- Builder: when elaborating a chisel design the "Elaborating design..." and "Done elaborating." message is no longer shown by default. Set the log level to `info` in order to see it.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (3.2.x, 3.3.x, 3.4.x, 3.5.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
