### PR TITLE
SyncReadMem: fix bug with read(addr) and add some formal tests

### DIFF
--- a/core/src/main/scala/chisel3/Mem.scala
+++ b/core/src/main/scala/chisel3/Mem.scala
@@ -213,8 +213,14 @@ sealed class SyncReadMem[T <: Data] private (t: T, n: BigInt, val readUnderWrite
     var port: Option[T] = None
     when (enable) {
       a := addr
-      port = Some(read(a))
+      port = Some(super.do_read(a))
     }
     port.get
   }
+
+  /** @group SourceInfoTransformMacro*/
+  override def do_read(idx: UInt)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions) =
+    do_read(addr = idx, enable = true.B)
+  // note: we implement do_read(addr) for SyncReadMem in terms of do_read(addr, en) in order to ensure that
+  //       `mem.read(addr)` will always behave the same as `mem.read(addr, true.B)`
 }

--- a/integration-tests/src/test/scala/chiselTest/MemFormalSpec.scala
+++ b/integration-tests/src/test/scala/chiselTest/MemFormalSpec.scala
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiselTest
+
+import chisel3._
+import chisel3.experimental._
+import chiseltest._
+import chiseltest.formal._
+import firrtl.annotations.MemoryArrayInitAnnotation
+import org.scalatest.flatspec.AnyFlatSpec
+
+class MemFormalSpec extends AnyFlatSpec with ChiselScalatestTester with Formal {
+  behavior of "SyncReadMem read enable"
+
+  private def check(mod: Boolean => ReadEnTestModule, alwaysEnabeld: Boolean = false): Unit = {
+    // we first check that the read is enabled when it should be
+    verify(mod(true), Seq(BoundedCheck(4)))
+    if(!alwaysEnabeld) {
+      // now we check that it is disabled, when it should be
+      // however, note that this check is not exhaustive/complete!
+      assertThrows[FailedBoundedCheckException] {
+        verify(mod(false), Seq(BoundedCheck(4)))
+      }
+    }
+  }
+
+  it should "always be true when calling read(addr)" in {
+    check(new ReadEnTestModule(_) { out := mem.read(addr) }, true)
+  }
+
+  it should "always be true when calling read(addr, true.B)" in {
+    check(new ReadEnTestModule(_) { out := mem.read(addr, true.B) }, true)
+  }
+
+  it should "always be false when calling read(addr, false.B)" in {
+    check(new ReadEnTestModule(_) {
+      out := mem.read(addr, false.B)
+      shouldRead := false.B
+      shouldNotRead := true.B
+    })
+  }
+
+  it should "be enabled by iff en=1 when calling read(addr, en)" in {
+    check(new ReadEnTestModule(_) {
+      val en = IO(Input(Bool()))
+      out := mem.read(addr, en)
+      shouldRead := en
+      shouldNotRead := !en
+    })
+  }
+}
+
+abstract class ReadEnTestModule(testShouldRead: Boolean) extends Module {
+  val addr = IO(Input(UInt(5.W)))
+  val out = IO(Output(UInt(8.W)))
+  out := DontCare
+  // these can be overwritten by the concrete test
+  val shouldRead = WireInit(true.B)
+  val shouldNotRead = WireInit(false.B)
+
+  // we initialize the memory, so that the output should always equivalent to the read address
+  val mem = SyncReadMem(32, chiselTypeOf(out))
+  annotate(new ChiselAnnotation {
+    override def toFirrtl = MemoryArrayInitAnnotation(mem.toTarget, values = Seq.tabulate(32)(BigInt(_)))
+  })
+
+  // the first cycle after reset, the data will be arbitrary
+  val firstCycle = RegNext(false.B, init=true.B)
+
+  if(testShouldRead) {
+    when(!firstCycle && RegNext(shouldRead)) {
+      verification.assert(out === RegNext(addr))
+    }
+  } else {
+    when(!firstCycle && RegNext(shouldNotRead)) {
+      // this can only fail if the read enable is false and an arbitrary value is provided
+      // note that this test is not complete!!
+      verification.assert(out === 200.U)
+    }
+  }
+}


### PR DESCRIPTION
This essentially fixes a bug where in the following code, the read enable would always be false:
```.scala
class BrokenMem extends MultiIOModule {
  val addr = IO(Input(UInt(5.W)))
  val out = IO(Output(UInt(8.W)))

  val mem = SyncReadMem(32, UInt(8.W))
  out := mem.read(addr)
}
```

You can see the full example [here](https://scastie.scala-lang.org/wLIQK1bKQvaD6FkMTb04Vg)

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?


#### Type of Improvement

- bug fix

#### API Impact

- none

#### Backend Code Generation Impact
- read enables now work in the one situation that I described above

#### Desired Merge Strategy
- squash


### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [x] Did you mark the proper milestone (Bug fix: `3.3.x`, [small] API extension: `3.4.x`, API modification or big change: `3.5.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
