### PR TITLE
Fix chisel3 <> for compatibility Bundles (Take 3)

### DIFF
--- a/core/src/main/scala/chisel3/internal/BiConnect.scala
+++ b/core/src/main/scala/chisel3/internal/BiConnect.scala
@@ -11,6 +11,8 @@ import chisel3.internal.firrtl.{Connect, DefInvalid}
 import scala.language.experimental.macros
 import chisel3.internal.sourceinfo._
 
+import scala.annotation.tailrec
+
 /**
 * BiConnect.connect executes a bidirectional connection element-wise.
 *
@@ -120,15 +122,24 @@ private[chisel3] object BiConnect {
         val notStrict =
           Seq(left_r.compileOptions, right_r.compileOptions).contains(ExplicitCompileOptions.NotStrict)
         if (notStrict) {
-          // chisel3 <> is commutative but FIRRTL <- is not
-          val flipped = {
-            import ActualDirection._
-            // Everything is flipped when it's the port of a child
-            val childPort = left_r._parent.get != context_mod
-            val isFlipped = Seq(Bidirectional(Flipped), Input).contains(left_r.direction)
-            isFlipped ^ childPort
+          // Traces flow from a child Data to its parent
+          @tailrec def traceFlow(currentlyFlipped: Boolean, data: Data): Boolean = {
+            import SpecifiedDirection.{Input => SInput, Flip => SFlip}
+            val sdir = data.specifiedDirection
+            val flipped = sdir == SInput || sdir == SFlip
+            data.binding.get match {
+              case ChildBinding(parent) => traceFlow(flipped ^ currentlyFlipped, parent)
+              case PortBinding(enclosure) =>
+                val childPort = enclosure != context_mod
+                childPort ^ flipped ^ currentlyFlipped
+              case _ => true
+            }
           }
-          val (newLeft, newRight) = if (flipped) pair.swap else pair
+          def canBeSink(data: Data): Boolean = traceFlow(true, data)
+          def canBeSource(data: Data): Boolean = traceFlow(false, data)
+          // chisel3 <> is commutative but FIRRTL <- is not
+          val flipConnection = !canBeSink(left_r) || !canBeSource(right_r)
+          val (newLeft, newRight) = if (flipConnection) pair.swap else pair
           newLeft.bulkConnect(newRight)(sourceInfo, ExplicitCompileOptions.NotStrict)
         } else {
           recordConnect(sourceInfo, connectCompileOptions, left_r, right_r, context_mod)


### PR DESCRIPTION
Third time's the charm?

Previous incomplete fixes in #2023 and #2031.

The legality of a FIRRTL connection is determined by type and flow.
Chisel does not have access to true flow information. Previous fix
attempts tried to use ActualDirection as a stand-in for flow, but it is
incorrect in many cases. This new approach checks the flows of the
lvalue and rvalues in the connect and flips the connection if either
the lvalue cannot be a sink or the rvalue cannot be a source.

**Note** I marked this for backporting to 3.2.x because the previous 2 PRs were and this is a fix to those fixes.

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [NA] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

 - bug fix   


#### API Impact

No impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

  - Squash

#### Release Notes

Fix handling of `import Chisel._` Bundles when bulk connected inside of `import chisel3._` code

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.3.x`, [small] API extension: `3.4.x`, API modification or big change: `3.5.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
