### PR TITLE
make ExtModule able to extends HasBlackBoxResource, HasBlackBoxInline and HasBlackBoxPath.

### DIFF
--- a/src/main/scala/chisel3/util/BlackBoxUtils.scala
+++ b/src/main/scala/chisel3/util/BlackBoxUtils.scala
@@ -4,8 +4,8 @@ package chisel3.util
 
 import chisel3._
 import chisel3.experimental.{ChiselAnnotation, RunFirrtlTransform}
-import firrtl.transforms.{BlackBoxPathAnno, BlackBoxResourceAnno, BlackBoxInlineAnno, BlackBoxSourceHelper,
-  BlackBoxNotFoundException}
+import chisel3.internal.BaseBlackBox
+import firrtl.transforms.{BlackBoxInlineAnno, BlackBoxNotFoundException, BlackBoxPathAnno, BlackBoxResourceAnno, BlackBoxSourceHelper}
 import firrtl.annotations.ModuleName
 import logger.LazyLogging
 
@@ -32,8 +32,8 @@ private[util] object BlackBoxHelpers {
 
 import BlackBoxHelpers._
 
-trait HasBlackBoxResource extends BlackBox {
-  self: BlackBox =>
+trait HasBlackBoxResource extends BaseBlackBox {
+  self: BaseBlackBox =>
 
   /** Copies a Java resource containing some text into the output directory. This is typically used to copy a Verilog file
     * to the final output directory, but may be used to copy any Java resource (e.g., a C++ testbench).
@@ -53,8 +53,8 @@ trait HasBlackBoxResource extends BlackBox {
   }
 }
 
-trait HasBlackBoxInline extends BlackBox {
-  self: BlackBox =>
+trait HasBlackBoxInline extends BaseBlackBox {
+  self: BaseBlackBox =>
 
   /** Creates a black box verilog file, from the contents of a local string
     *
@@ -70,8 +70,8 @@ trait HasBlackBoxInline extends BlackBox {
   }
 }
 
-trait HasBlackBoxPath extends BlackBox {
-  self: BlackBox =>
+trait HasBlackBoxPath extends BaseBlackBox {
+  self: BaseBlackBox =>
 
   /** Copies a file to the target directory
     *


### PR DESCRIPTION
Users are upgrading to Chisel 3.5, However they seems don't like `suggestName` for `io` in BlackBox, so I suggest them to migrate to `ExtModule`, but I just found, `ExtModule` doesn't support `HasBlackBoxResource`, `HasBlackBoxInline` and `HasBlackBoxPath`. This patch should fix this.
### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [ ] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [ ] Did you state the API impact?
- [ ] Did you specify the code generation impact?
- [ ] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

- new feature/API

#### API Impact

None

#### Backend Code Generation Impact

None

#### Desired Merge Strategy
- Rebase: You will rebase the PR onto master and it will be merged with a merge commit. 

#### Release Notes
ExtModule can extend `HasBlackBoxResource`, `HasBlackBoxInline` and `HasBlackBoxPath` now

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.3.x`, [small] API extension: `3.4.x`, API modification or big change: `3.5.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
