### PR TITLE
Fix a bug causes incorrect pla generation when input is `?`

### DIFF
--- a/src/test/scala/chiselTests/util/experimental/PlaSpec.scala
+++ b/src/test/scala/chiselTests/util/experimental/PlaSpec.scala
@@ -52,14 +52,13 @@ class PlaSpec extends ChiselFlatSpec {
   "#2112" should "be generated correctly" in {
     assertTesterPasses(new BasicTester {
       val table = Seq(
-        (BitPat("b0"), BitPat("b?0")),
-        (BitPat("b1"), BitPat("b?1")),
-        (BitPat("b?"), BitPat("b1?")),
+        (BitPat("b000"), BitPat("b?01")),
+        (BitPat("b111"), BitPat("b?01")),
       )
       table.foreach { case (i, o) =>
         val (plaIn, plaOut) = pla(table)
         plaIn := WireDefault(i.value.U(3.W))
-        chisel3.assert(plaOut === o.value.U(8.W), "Input " + i.toString + " produced incorrect output BitPat(%b)", plaOut)
+        chisel3.assert(o === plaOut, "Input " + i.toString + " produced incorrect output BitPat(%b)", plaOut)
       }
       stop()
     })

--- a/src/test/scala/chiselTests/util/experimental/PlaSpec.scala
+++ b/src/test/scala/chiselTests/util/experimental/PlaSpec.scala
@@ -49,6 +49,22 @@ class PlaSpec extends ChiselFlatSpec {
     })
   }
 
+  "#2112" should "be generated correctly" in {
+    assertTesterPasses(new BasicTester {
+      val table = Seq(
+        (BitPat("b0"), BitPat("b?0")),
+        (BitPat("b1"), BitPat("b?1")),
+        (BitPat("b?"), BitPat("b1?")),
+      )
+      table.foreach { case (i, o) =>
+        val (plaIn, plaOut) = pla(table)
+        plaIn := WireDefault(i.value.U(3.W))
+        chisel3.assert(plaOut === o.value.U(8.W), "Input " + i.toString + " produced incorrect output BitPat(%b)", plaOut)
+      }
+      stop()
+    })
+  }
+
   "A simple PLA" should "be generated correctly" in {
     assertTesterPasses(new BasicTester {
       val table = Seq(


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [N/A] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [N/A] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
- bug fix
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact
No.
<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

#### Backend Code Generation Impact
Extracted from ScalaDoc:
```
There is one special case which we call it `? -> 1`. In this scenario, for some of the output functions (bits),
all input terms that make this function value to `1` is purely composed by `?`. In a real pla, this will result in
no connection to the gates in the AND Plane (verilog `z` on gate inputs), which in turn makes the outputs of the
AND Plane undetermined (verilog `x` on outputs). This is not desired behavior in most cases, for example the
minimization result of following truth table:
0 -> 1
1 -> 1
which is:
? -> 1
actually means something other than a verilog `x`. To ease the generation of minimized truth tables, this pla
generation api will hard wire outputs to a `1` on this special case.
This behavior is formally described as: if product terms that make one function value to `1` is solely consisted
of don't-cares (`?`s), then this function is implemented as a constant `1`.
```
<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
- Squash: The PR will be squashed and merged (choose this if you have no preference.
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.3.x`, [small] API extension: `3.4.x`, API modification or big change: `3.5.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
