### PR TITLE
Restore return type of BaseModule.toTarget to ModuleTarget

### DIFF
--- a/core/src/main/scala/chisel3/experimental/hierarchy/Definition.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/Definition.scala
@@ -3,13 +3,14 @@
 package chisel3.experimental.hierarchy
 
 import scala.language.experimental.macros
-
 import chisel3._
+
 import scala.collection.mutable.HashMap
 import chisel3.internal.{Builder, DynamicContext}
 import chisel3.internal.sourceinfo.{DefinitionTransform, DefinitionWrapTransform, SourceInfo}
 import chisel3.experimental.BaseModule
 import chisel3.internal.BaseModule.IsClone
+import firrtl.annotations.{IsModule, ModuleTarget}
 
 /** User-facing Definition type.
   * Represents a definition of an object of type [[A]] which are marked as @instantiable 
@@ -64,12 +65,12 @@ object Definition extends SourceInfoDoc {
     /** If this is an instance of a Module, returns the toTarget of this instance
       * @return target of this instance
       */
-    def toTarget = d.proto.toTarget
+    def toTarget: ModuleTarget = d.proto.toTarget
 
     /** If this is an instance of a Module, returns the toAbsoluteTarget of this instance
       * @return absoluteTarget of this instance
       */
-    def toAbsoluteTarget = d.proto.toAbsoluteTarget
+    def toAbsoluteTarget: IsModule = d.proto.toAbsoluteTarget
   }
   /** A construction method to build a Definition of a Module
     *

--- a/core/src/main/scala/chisel3/experimental/hierarchy/Instance.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/Instance.scala
@@ -4,11 +4,11 @@ package chisel3.experimental.hierarchy
 
 import scala.collection.mutable.{ArrayBuffer, HashMap}
 import scala.language.experimental.macros
-
 import chisel3._
-import chisel3.internal.BaseModule.{ModuleClone, IsClone, InstantiableClone}
+import chisel3.internal.BaseModule.{InstantiableClone, IsClone, ModuleClone}
 import chisel3.internal.sourceinfo.{InstanceTransform, SourceInfo}
 import chisel3.experimental.BaseModule
+import firrtl.annotations.IsModule
 
 /** User-facing Instance type.
   * Represents a unique instance of type [[A]] which are marked as @instantiable 
@@ -75,15 +75,15 @@ object Instance extends SourceInfoDoc {
     /** If this is an instance of a Module, returns the toTarget of this instance
       * @return target of this instance
       */
-    def toTarget = i.cloned match {
-      case Left(x: BaseModule) => x.toTarget
-      case Right(x: IsClone[_] with BaseModule) => x.toTarget
+    def toTarget: IsModule = i.cloned match {
+      case Left(x: BaseModule) => x.getTarget
+      case Right(x: IsClone[_] with BaseModule) => x.getTarget
     }
 
     /** If this is an instance of a Module, returns the toAbsoluteTarget of this instance
       * @return absoluteTarget of this instance
       */
-    def toAbsoluteTarget = i.cloned match {
+    def toAbsoluteTarget: IsModule = i.cloned match {
       case Left(x) => x.toAbsoluteTarget
       case Right(x: IsClone[_] with BaseModule) => x.toAbsoluteTarget
     }

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -309,7 +309,7 @@ private[chisel3] trait NamedComponent extends HasId {
     val root = _parent.map {
       case ViewParent => reifyParent
       case other => other
-    }.get.toTarget // All NamedComponents will have a parent, only the top module can have None here
+    }.get.getTarget // All NamedComponents will have a parent, only the top module can have None here
     Target.toTargetTokens(name).toList match {
       case TargetToken.Ref(r) :: components => root.ref(r).copy(component = components)
       case other =>


### PR DESCRIPTION
Definition/Instance introduced the need for representing the targets of
instances as InstanceTargets. This original implementation changed the
return type of BaseModule.toTarget to express this need. This is a
backwards incompatible change that is actually unnecessary because it is
impossible for users to get references to the internal InstanceClone
objects, instead only accessing such modules via Instance[_] wrappers
and cloned Data. We restored the old API by adding a new internal method
"getTarget" which will give the correct targets for InstanceClones while
maintaining the API of BaseModule.toTarget.

This fixes the issue @sequencer noted https://github.com/chipsalliance/chisel3/pull/2045#issuecomment-913349957. I expect similar issues to drop up elsewhere so I thought it best to try not to break the API if we don't have to.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [NA] Did you add text to be included in the Release Notes for this change?

No release notes necessary other than not breaking an API in 3.5.0 release.

#### Type of Improvement

 - bug fix          

#### API Impact

This restores the Chisel 3.4 and before API for `BaseModule.toTarget` while still supporting all of Definition/Instance's use cases.

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

 - Squash

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [x] Did you mark the proper milestone (Bug fix: `3.3.x`, [small] API extension: `3.4.x`, API modification or big change: `3.5.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
