### PR TITLE
[3.4.x] Update Scala so that plugin (mainly for plugin)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        scala: [2.12.13, 2.11.12]
+        scala: [2.12.15, 2.11.12]
     container:
       image: ucbbar/chisel3-tools
       options: --user github --entrypoint /bin/bash
@@ -32,16 +32,16 @@ jobs:
       - name: Cache Scala
         uses: coursier/cache-action@v5
       - name: Documentation (Scala 2.12 only)
-        if: matrix.scala == '2.12.13'
+        if: startsWith(matrix.scala, '2.12')
         run: sbt ++${{ matrix.scala }} docs/mdoc
       - name: Test
         run: sbt ++${{ matrix.scala }} test noPluginTests/test
       - name: Binary compatibility
         run: sbt ++${{ matrix.scala }} mimaReportBinaryIssues
-      # Chisel plugin not yet release for Scala 2.12.13, test with 2.12.12
+      # Chisel plugin not yet released for Scala 2.12.14 and 2.12.15
       - name: Binary compatibility (Plugin, Scala 2.12 only)
-        if: matrix.scala == '2.12.13'
-        run: sbt ++2.12.12 "plugin / mimaReportBinaryIssues"
+        if: startsWith(matrix.scala, '2.12')
+        run: sbt ++2.12.13 "plugin / mimaReportBinaryIssues"
 
   # Sentinel job to simplify how we specify which checks need to pass in branch
   # protection and in Mergify

--- a/build.sbt
+++ b/build.sbt
@@ -43,8 +43,8 @@ lazy val commonSettings = Seq (
   organization := "edu.berkeley.cs",
   version := "3.4-SNAPSHOT",
   autoAPIMappings := true,
-  scalaVersion := "2.12.13",
-  crossScalaVersions := Seq("2.12.12", "2.11.12"),
+  scalaVersion := "2.12.15",
+  crossScalaVersions := Seq("2.12.15", "2.11.12"),
   scalacOptions := Seq("-deprecation", "-feature") ++ scalacOptionsVersion(scalaVersion.value),
   libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value,
   addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full),
@@ -126,6 +126,8 @@ lazy val pluginScalaVersions = Seq(
   "2.12.11",
   "2.12.12",
   "2.12.13",
+  "2.12.14",
+  "2.12.15",
 )
 
 lazy val plugin = (project in file("plugin")).
@@ -147,9 +149,12 @@ lazy val plugin = (project in file("plugin")).
   ).
   settings(
     mimaPreviousArtifacts := {
-      // Not published for 2.11, do not try to check binary compatibility with a 2.11 artifact
-      if (scalaVersion.value.startsWith("2.11")) Set()
-      else Set("edu.berkeley.cs" % "chisel3-plugin" % "3.4.3" cross CrossVersion.full)
+      // Only check plugin against versions it's published for
+      if (VersionNumber(scalaVersion.value) matchesSemVer SemanticSelector("2.12.2 - 2.12.13")) {
+        Set("edu.berkeley.cs" % "chisel3-plugin" % "3.4.4" cross CrossVersion.full)
+      } else {
+        Set()
+      }
     }
   )
 
@@ -169,7 +174,7 @@ lazy val macros = (project in file("macros")).
   settings(name := "chisel3-macros").
   settings(commonSettings: _*).
   settings(publishSettings: _*).
-  settings(mimaPreviousArtifacts := Set("edu.berkeley.cs" %% "chisel3-macros" % "3.4.3"))
+  settings(mimaPreviousArtifacts := Set("edu.berkeley.cs" %% "chisel3-macros" % "3.4.4"))
 
 lazy val firrtlRef = ProjectRef(workspaceDirectory / "firrtl", "firrtl")
 
@@ -184,7 +189,7 @@ lazy val core = (project in file("core")).
   ).
   settings(publishSettings: _*).
   settings(
-    mimaPreviousArtifacts := Set("edu.berkeley.cs" %% "chisel3-core" % "3.4.3"),
+    mimaPreviousArtifacts := Set("edu.berkeley.cs" %% "chisel3-core" % "3.4.4"),
     mimaBinaryIssueFilters ++= Seq(
       // Modified package private methods (https://github.com/lightbend/mima/issues/53)
       ProblemFilters.exclude[IncompatibleMethTypeProblem]("chisel3.internal.Builder.pushPrefix"),
@@ -243,7 +248,7 @@ lazy val chisel = (project in file(".")).
   dependsOn(core).
   aggregate(macros, core, plugin).
   settings(
-    mimaPreviousArtifacts := Set("edu.berkeley.cs" %% "chisel3" % "3.4.3"),
+    mimaPreviousArtifacts := Set("edu.berkeley.cs" %% "chisel3" % "3.4.4"),
     mimaBinaryIssueFilters ++= Seq(
       // Private class
       ProblemFilters.exclude[FinalClassProblem]("chisel3.internal.firrtl.Emitter"),

--- a/build.sc
+++ b/build.sc
@@ -5,7 +5,7 @@ import coursier.maven.MavenRepository
 import $ivy.`com.lihaoyi::mill-contrib-buildinfo:$MILL_VERSION`
 import mill.contrib.buildinfo.BuildInfo
 
-object chisel3 extends mill.Cross[chisel3CrossModule]("2.11.12", "2.12.13")
+object chisel3 extends mill.Cross[chisel3CrossModule]("2.11.12", "2.12.15")
 
 // The following stanza is searched for and used when preparing releases.
 // Please retain it.


### PR DESCRIPTION
Also update previous version for binary compatibility checking.

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [NA] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

 - new feature/API     

#### API Impact

Should have done this before release Chisel 3.4.4, this will ensure the chisel3 plugin will be published for Scala 2.12.14 and 2.12.15 in Chisel 3.4.5

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

   - Squash

#### Release Notes

Update Scala, publish chisel3-plugin for Scala 2.12.14 and 2.12.15

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.3.x`, [small] API extension: `3.4.x`, API modification or big change: `3.5.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
