### PR TITLE
Update Scala and publish plugin for more minor versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         system: ["ubuntu-20.04"]
         jvm: ["adopt@1.8"]
-        scala: ["2.13.6", "2.12.14"]
+        scala: ["2.13.6", "2.12.15"]
         verilator: ["4.204"]
         espresso: ["2.4"]
     runs-on: ${{ matrix.system }}
@@ -67,7 +67,7 @@ jobs:
       - name: Cache Scala
         uses: coursier/cache-action@v5
       - name: Documentation (Scala 2.12 only)
-        if: matrix.scala == '2.12.14'
+        if: startsWith(matrix.scala, '2.12')
         run: sbt ++${{ matrix.scala }} docs/mdoc
       - name: Test
         run: sbt ++${{ matrix.scala }} test noPluginTests/test

--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ lazy val commonSettings = Seq (
   version := "3.5-SNAPSHOT",
   autoAPIMappings := true,
   scalaVersion := "2.13.6",
-  crossScalaVersions := Seq("2.13.6", "2.12.14"),
+  crossScalaVersions := Seq("2.13.6", "2.12.15"),
   scalacOptions := Seq("-deprecation", "-feature"),
   libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value,
   // Macros paradise is integrated into 2.13 but requires a scalacOption
@@ -105,12 +105,15 @@ lazy val pluginScalaVersions = Seq(
   "2.12.11",
   "2.12.12",
   "2.12.13",
+  "2.12.14",
+  "2.12.15",
   "2.13.0",
   "2.13.1",
   "2.13.2",
   "2.13.3",
   "2.13.4",
-  "2.13.5"
+  "2.13.5",
+  "2.13.6"
 )
 
 lazy val plugin = (project in file("plugin")).


### PR DESCRIPTION
Bump Scala to so that plugin publishes for more minor versions of Scala.

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [NA] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

 - new feature/API 

#### API Impact

This publishes the plugin for more minor versions of Scala

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

   - Squash

#### Release Notes

Publish chisel3-plugin for Scala 2.12.14, 2.12.15, and 2.13.6

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.3.x`, [small] API extension: `3.4.x`, API modification or big change: `3.5.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
