### PR TITLE
verification: fix off by one error in deprecation message

### DIFF
--- a/src/main/scala/chisel3/experimental/verification/package.scala
+++ b/src/main/scala/chisel3/experimental/verification/package.scala
@@ -8,19 +8,19 @@ import chisel3.internal.sourceinfo.SourceInfo
 package object verification {
 
   object assert {
-    @deprecated("Please use chisel3.assert instead. The chisel3.experimental.verification package will be removed.", "Chisel 3.4")
+    @deprecated("Please use chisel3.assert instead. The chisel3.experimental.verification package will be removed.", "Chisel 3.5")
     def apply(predicate: Bool, msg: String = "")
       (implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): chisel3.assert.Assert = chisel3.assert(predicate, msg)
   }
 
   object assume {
-    @deprecated("Please use chisel3.assume instead. The chisel3.experimental.verification package will be removed.", "Chisel 3.4")
+    @deprecated("Please use chisel3.assume instead. The chisel3.experimental.verification package will be removed.", "Chisel 3.5")
     def apply(predicate: Bool, msg: String = "")
       (implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): chisel3.assume.Assume = chisel3.assume(predicate, msg)
   }
 
   object cover {
-    @deprecated("Please use chisel3.cover instead. The chisel3.experimental.verification package will be removed.", "Chisel 3.4")
+    @deprecated("Please use chisel3.cover instead. The chisel3.experimental.verification package will be removed.", "Chisel 3.5")
     def apply(predicate: Bool, msg: String = "")
       (implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): chisel3.cover.Cover = chisel3.cover(predicate, msg)
   }


### PR DESCRIPTION
The deprecation message in my previous PR was off by one.


### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.3.x`, [small] API extension: `3.4.x`, API modification or big change: `3.5.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
