### PR TITLE
Remove workaround for fixed issue in mdoc crash blocks

### DIFF
--- a/docs/src/explanations/dataview.md
+++ b/docs/src/explanations/dataview.md
@@ -285,7 +285,6 @@ class BundleB extends Bundle {
 ```
 
 ```scala mdoc:crash
-{ // Using an extra scope here to avoid a bug in mdoc (documentation generation)
 // We forgot BundleA.foo in the mapping!
 implicit val myView = DataView[BundleA, BundleB](_ => new BundleB, _.bar -> _.fizz)
 class BadMapping extends Module {
@@ -295,7 +294,6 @@ class BadMapping extends Module {
 }
 // We must run Chisel to see the error
 emitVerilog(new BadMapping)
-}
 ```
 
 As that error suggests, if we *want* the view to be non-total, we can use a `PartialDataView`:
@@ -321,7 +319,6 @@ This has the consequence that `PartialDataViews` are **not** invertible in the s
 For example:
 
 ```scala mdoc:crash
-{ // Using an extra scope here to avoid a bug in mdoc (documentation generation)
 implicit val myView2 = myView.invert(_ => new BundleA)
 class PartialDataViewModule2 extends Module {
    val in = IO(Input(new BundleA))
@@ -331,7 +328,6 @@ class PartialDataViewModule2 extends Module {
 }
 // We must run Chisel to see the error
 emitVerilog(new PartialDataViewModule2)
-}
 ```
 
 As noted, the mapping must **always** be total for the `View`.


### PR DESCRIPTION
This was fixed in the latest version of mdoc (that we have already bumped to).

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [NA] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

   - documentation   

#### API Impact

No impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

  - Squash

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.3.x`, [small] API extension: `3.4.x`, API modification or big change: `3.5.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
