### PR TITLE
Remove v3.4.0 version of autoNameRecursively

### DIFF
--- a/core/src/main/scala/chisel3/internal/plugin/package.scala
+++ b/core/src/main/scala/chisel3/internal/plugin/package.scala
@@ -3,27 +3,8 @@
 package chisel3.internal
 
 package object plugin {
-  /** Used by Chisel's compiler plugin to automatically name signals
-    * DO NOT USE in your normal Chisel code!!!
-    *
-    * @param name The name to use
-    * @param nameMe The thing to be named
-    * @tparam T The type of the thing to be named
-    * @return The thing, but now named
-    * @note This is the version called by chisel3-plugin prior to v3.4.1
-    */
-  def autoNameRecursively[T <: Any](name: String, nameMe: T): T = {
-    chisel3.internal.Builder.nameRecursively(
-      name.replace(" ", ""),
-      nameMe,
-      (id: chisel3.internal.HasId, n: String) => id.autoSeed(n)
-    )
-    nameMe
-  }
 
   // The actual implementation
-  // Cannot be unified with (String, T) => T (v3.4.0 version) because of special behavior of ports
-  // in .autoSeed
   private def _autoNameRecursively[T <: Any](prevId: Long, name: String, nameMe: T): T = {
     chisel3.internal.Builder.nameRecursively(
       name,


### PR DESCRIPTION
This only existed to maintain binary compatibility with the v3.4.0 version of the chisel3-plugin in version v3.4.1 and beyond. We break binary compatibility in v3.5.0 anyway.

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

 - code cleanup      

#### API Impact

This does break a technically public API but not one users are supposed to use (and hidden from ScalaDoc). It also breaks binary compatibility with the v3.4.0 version of the plugin but that is expected in a major release and we will likely have further breakages (like requiring the plugin in v3.5.0 and beyond).

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

   - Squash

#### Release Notes

Break binary compatibility with v3.4.0 version of chisel3-plugin.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.3.x`, [small] API extension: `3.4.x`, API modification or big change: `3.5.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
