### PR TITLE
Fix naming of unwrapped val io in Chisel.Modules

### DIFF
--- a/core/src/main/scala/chisel3/RawModule.scala
+++ b/core/src/main/scala/chisel3/RawModule.scala
@@ -199,7 +199,7 @@ package object internal {
 
     tryJavaReflect
       .orElse(tryScalaReflect)
-      .map(_.autoSeed("io"))
+      .map(_.forceFinalName("io"))
       .orElse {
         // Fallback if reflection fails, user can wrap in IO(...)
         self.findPort("io")

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -154,6 +154,17 @@ private[chisel3] trait HasId extends InstanceId {
     this
   }
 
+  // Internal version of .suggestName that can override a user-suggested name
+  // This only exists for maintaining "val io" naming in compatibility-mode Modules without IO
+  // wrapping
+  private[chisel3] def forceFinalName(seed: String): this.type = {
+    // This could be called with user prefixes, ignore them
+    noPrefix {
+      suggested_seed = Some(seed)
+      this.suggestName(seed)
+    }
+  }
+
   /** Computes the name of this HasId, if one exists
     * @param defaultPrefix Optionally provide a default prefix for computing the name
     * @param defaultSeed Optionally provide default seed for computing the name

--- a/src/test/scala/chiselTests/CompatibilitySpec.scala
+++ b/src/test/scala/chiselTests/CompatibilitySpec.scala
@@ -566,4 +566,32 @@ class CompatibiltySpec extends ChiselFlatSpec with ScalaCheckDrivenPropertyCheck
     verilog should include ("assign io_out_0 = io_in_0;")
   }
 
+  it should "ignore .suggestName on field io" in {
+    class MyModule extends Module {
+      val io = new Bundle {
+        val foo = UInt(width = 8).asInput
+        val bar = UInt(width = 8).asOutput
+      }
+      io.suggestName("potato")
+      io.bar := io.foo
+    }
+    val verilog = ChiselStage.emitVerilog(new MyModule)
+    verilog should include ("input  [7:0] io_foo")
+    verilog should include ("output [7:0] io_bar")
+  }
+
+  it should "properly name field io" in {
+    class MyModule extends Module {
+      val io = new Bundle {
+        val foo = UInt(width = 8).asInput
+        val bar = UInt(width = 8).asOutput
+      }
+      val wire = Wire(init = io.foo)
+      io.bar := wire
+    }
+    val verilog = ChiselStage.emitVerilog(new MyModule)
+    verilog should include ("input  [7:0] io_foo")
+    verilog should include ("output [7:0] io_bar")
+  }
+
 }


### PR DESCRIPTION
The removal of virtual method io accidentally made the naming of io in
compatibility mode Bundles sensitive to the prefix at the time of the
first access of the field. It also made .suggestName able to override
the name. This commit fixes that issue by forcing the name of the io
Data to be "io" no matter what.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [NA] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

   - bug fix   

#### API Impact

This restores the pre-3.5.0-RC1 naming behavior for `io` in `Chisel.Modules`

#### Backend Code Generation Impact

Fixes Verilog naming

#### Desired Merge Strategy

  - Squash
  - 
#### Release Notes

Fix regression in naming of field `io` in compatibility mode `Modules` where `io` may accidentally get prefixed and where `.suggetName` would work on `io`.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.3.x`, [small] API extension: `3.4.x`, API modification or big change: `3.5.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
