### PR TITLE
Revert "Deprecate auto-application of empty argument lists to parameterless functions (#2124)"

### DIFF
--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -54,7 +54,7 @@ sealed abstract class Aggregate extends Data {
   override def litOption: Option[BigInt] = {
     // Shift the accumulated value by our width and add in our component, masked by our width.
     def shiftAdd(accumulator: Option[BigInt], elt: Data): Option[BigInt] = {
-      (accumulator, elt.litOption) match {
+      (accumulator, elt.litOption()) match {
         case (Some(accumulator), Some(eltLit)) =>
           val width = elt.width.get
           val masked = ((BigInt(1) << width) - 1) & eltLit  // also handles the negative case with two's complement

--- a/core/src/main/scala/chisel3/Bits.scala
+++ b/core/src/main/scala/chisel3/Bits.scala
@@ -25,10 +25,7 @@ private[chisel3] sealed trait ToBoolable extends Element {
     *
     * @note The width must be known and equal to 1
     */
-  final def asBool: Bool = macro SourceInfoWhiteboxTransform.noArg
-
-  @deprecated("Calling this function with an empty argument list is invalid in Scala 3. Use the form without parentheses instead", "Chisel 3.5")
-  final def asBool(dummy: Int*): Bool = macro SourceInfoWhiteboxTransform.noArgDummy
+  final def asBool(): Bool = macro SourceInfoWhiteboxTransform.noArg
 
   /** @group SourceInfoTransformMacro */
   def do_asBool(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool
@@ -225,10 +222,7 @@ sealed abstract class Bits(private[chisel3] val width: Width) extends Element wi
     * @return this $coll with each bit inverted
     * @group Bitwise
     */
-  final def unary_~ : Bits = macro SourceInfoWhiteboxTransform.noArg
-
-  @deprecated("Calling this function with an empty argument list is invalid in Scala 3. Use the form without parentheses instead", "Chisel 3.5")
-  final def unary_~(dummy: Int*): Bits = macro SourceInfoWhiteboxTransform.noArgDummy
+  final def unary_~ (): Bits = macro SourceInfoWhiteboxTransform.noArg
 
   /** @group SourceInfoTransformMacro */
   def do_unary_~ (implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bits
@@ -310,16 +304,10 @@ sealed abstract class Bits(private[chisel3] val width: Width) extends Element wi
   def do_>> (that: UInt)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bits
 
   /** Returns the contents of this wire as a [[scala.collection.Seq]] of [[Bool]]. */
-  final def toBools: Seq[Bool] = macro SourceInfoTransform.noArg
-
-  @deprecated("Calling this function with an empty argument list is invalid in Scala 3. Use the form without parentheses instead", "Chisel 3.5")
-  final def toBools(dummy: Int*): Seq[Bool] = macro SourceInfoWhiteboxTransform.noArgDummy
+  final def toBools(): Seq[Bool] = macro SourceInfoTransform.noArg
 
   /** Returns the contents of this wire as a [[scala.collection.Seq]] of [[Bool]]. */
-  final def asBools: Seq[Bool] = macro SourceInfoTransform.noArg
-
-  @deprecated("Calling this function with an empty argument list is invalid in Scala 3. Use the form without parentheses instead", "Chisel 3.5")
-  final def asBools(dummy: Int*): Seq[Bool] = macro SourceInfoWhiteboxTransform.noArgDummy
+  final def asBools(): Seq[Bool] = macro SourceInfoTransform.noArg
 
   /** @group SourceInfoTransformMacro */
   def do_asBools(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Seq[Bool] =
@@ -330,10 +318,7 @@ sealed abstract class Bits(private[chisel3] val width: Width) extends Element wi
     * @note The arithmetic value is not preserved if the most-significant bit is set. For example, a [[UInt]] of
     * width 3 and value 7 (0b111) would become an [[SInt]] of width 3 and value -1.
     */
-  final def asSInt: SInt = macro SourceInfoTransform.noArg
-
-  @deprecated("Calling this function with an empty argument list is invalid in Scala 3. Use the form without parentheses instead", "Chisel 3.5")
-  final def asSInt(dummy: Int*): SInt = macro SourceInfoWhiteboxTransform.noArgDummy
+  final def asSInt(): SInt = macro SourceInfoTransform.noArg
 
   /** @group SourceInfoTransformMacro */
   def do_asSInt(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): SInt
@@ -425,10 +410,7 @@ sealed class UInt private[chisel3] (width: Width) extends Bits(width) with Num[U
     * $constantWidth
     * @group Arithmetic
     */
-  final def unary_- : UInt = macro SourceInfoTransform.noArg
-
-  @deprecated("Calling this function with an empty argument list is invalid in Scala 3. Use the form without parentheses instead", "Chisel 3.5")
-  final def unary_-(dummy: Int*): UInt = macro SourceInfoTransform.noArgDummy
+  final def unary_- (): UInt = macro SourceInfoTransform.noArg
 
   /** Unary negation (constant width)
     *
@@ -436,10 +418,7 @@ sealed class UInt private[chisel3] (width: Width) extends Bits(width) with Num[U
     * $constantWidth
     * @group Arithmetic
     */
-  final def unary_-% : UInt = macro SourceInfoTransform.noArg
-
-  @deprecated("Calling this function with an empty argument list is invalid in Scala 3. Use the form without parentheses instead", "Chisel 3.5")
-  final def unary_%(dummy: Int*): UInt = macro SourceInfoTransform.noArgDummy
+  final def unary_-% (): UInt = macro SourceInfoTransform.noArg
 
   /** @group SourceInfoTransformMacro */
   def do_unary_- (implicit sourceInfo: SourceInfo, compileOptions: CompileOptions) : UInt = 0.U - this
@@ -543,7 +522,7 @@ sealed class UInt private[chisel3] (width: Width) extends Bits(width) with Num[U
     */
   final def ^ (that: UInt): UInt = macro SourceInfoTransform.thatArg
 
-  //  override def abs: UInt = macro SourceInfoTransform.noArgDummy
+  //  override def abs: UInt = macro SourceInfoTransform.noArg
   def do_abs(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): UInt = this
 
   /** @group SourceInfoTransformMacro */
@@ -566,30 +545,21 @@ sealed class UInt private[chisel3] (width: Width) extends Bits(width) with Num[U
     * @return a hardware [[Bool]] resulting from every bit of this $coll or'd together
     * @group Bitwise
     */
-  final def orR: Bool = macro SourceInfoTransform.noArg
-
-  @deprecated("Calling this function with an empty argument list is invalid in Scala 3. Use the form without parentheses instead", "Chisel 3.5")
-  final def orR(dummy: Int*): Bool = macro SourceInfoTransform.noArgDummy
+  final def orR(): Bool = macro SourceInfoTransform.noArg
 
   /** And reduction operator
     *
     * @return a hardware [[Bool]] resulting from every bit of this $coll and'd together
     * @group Bitwise
     */
-  final def andR: Bool = macro SourceInfoTransform.noArg
-
-  @deprecated("Calling this function with an empty argument list is invalid in Scala 3. Use the form without parentheses instead", "Chisel 3.5")
-  final def andR(dummy: Int*): Bool = macro SourceInfoTransform.noArgDummy
+  final def andR(): Bool = macro SourceInfoTransform.noArg
 
   /** Exclusive or (xor) reduction operator
     *
     * @return a hardware [[Bool]] resulting from every bit of this $coll xor'd together
     * @group Bitwise
     */
-  final def xorR: Bool = macro SourceInfoTransform.noArg
-
-  @deprecated("Calling this function with an empty argument list is invalid in Scala 3. Use the form without parentheses instead", "Chisel 3.5")
-  final def xorR(dummy: Int*): Bool = macro SourceInfoTransform.noArgDummy
+  final def xorR(): Bool = macro SourceInfoTransform.noArg
 
   /** @group SourceInfoTransformMacro */
   def do_orR(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool = redop(sourceInfo, OrReduceOp)
@@ -629,10 +599,7 @@ sealed class UInt private[chisel3] (width: Width) extends Bits(width) with Num[U
     * @return a hardware [[Bool]] asserted if this $coll equals zero
     * @group Bitwise
     */
-  final def unary_! : Bool = macro SourceInfoTransform.noArg
-
-  @deprecated("Calling this function with an empty argument list is invalid in Scala 3. Use the form without parentheses instead", "Chisel 3.5")
-  final def unary_! (dummy: Int*): Bool = macro SourceInfoTransform.noArgDummy
+  final def unary_! () : Bool = macro SourceInfoTransform.noArg
 
   /** @group SourceInfoTransformMacro */
   def do_unary_! (implicit sourceInfo: SourceInfo, compileOptions: CompileOptions) : Bool = this === 0.U(1.W)
@@ -717,11 +684,7 @@ sealed class UInt private[chisel3] (width: Width) extends Bits(width) with Num[U
     * @return an [[SInt]] equal to this $coll with an additional zero in its most significant bit
     * @note The width of the returned [[SInt]] is `width of this` + `1`.
     */
-  final def zext: SInt = macro SourceInfoTransform.noArg
-
-  @deprecated("Calling this function with an empty argument list is invalid in Scala 3. Use the form without parentheses instead", "Chisel 3.5")
-  final def zext(dummy: Int*): SInt = macro SourceInfoTransform.noArgDummy
-
+  final def zext(): SInt = macro SourceInfoTransform.noArg
   /** @group SourceInfoTransformMacro */
   def do_zext(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): SInt =
     pushOp(DefPrim(sourceInfo, SInt(width + 1), ConvertOp, ref))
@@ -798,10 +761,7 @@ sealed class SInt private[chisel3] (width: Width) extends Bits(width) with Num[S
     * $constantWidth
     * @group Arithmetic
     */
-  final def unary_- : SInt = macro SourceInfoTransform.noArg
-
-  @deprecated("Calling this function with an empty argument list is invalid in Scala 3. Use the form without parentheses instead", "Chisel 3.5")
-  final def unary_-(dummy: Int*): SInt = macro SourceInfoTransform.noArgDummy
+  final def unary_- (): SInt = macro SourceInfoTransform.noArg
 
   /** Unary negation (constant width)
     *
@@ -809,15 +769,12 @@ sealed class SInt private[chisel3] (width: Width) extends Bits(width) with Num[S
     * $constantWidth
     * @group Arithmetic
     */
-  final def unary_-% : SInt = macro SourceInfoTransform.noArg
-
-  @deprecated("Calling this function with an empty argument list is invalid in Scala 3. Use the form without parentheses instead", "Chisel 3.5")
-  final def unary_-%(dummy: Int*): SInt = macro SourceInfoTransform.noArgDummy
+  final def unary_-% (): SInt = macro SourceInfoTransform.noArg
 
   /** @group SourceInfoTransformMacro */
-  def do_unary_- (implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): SInt = 0.S - this
+  def unary_- (implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): SInt = 0.S - this
   /** @group SourceInfoTransformMacro */
-  def do_unary_-% (implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): SInt = 0.S -% this
+  def unary_-% (implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): SInt = 0.S -% this
 
   /** add (default - no growth) operator */
   override def do_+ (that: SInt)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): SInt =
@@ -843,7 +800,7 @@ sealed class SInt private[chisel3] (width: Width) extends Bits(width) with Num[S
   final def * (that: UInt): SInt = macro SourceInfoTransform.thatArg
   /** @group SourceInfoTransformMacro */
   def do_* (that: UInt)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): SInt = {
-    val thatToSInt = that.zext
+    val thatToSInt = that.zext()
     val result = binop(sourceInfo, SInt(this.width + thatToSInt.width), TimesOp, thatToSInt)
     result.tail(1).asSInt
   }
@@ -964,10 +921,10 @@ sealed class SInt private[chisel3] (width: Width) extends Bits(width) with Num[S
   /** @group SourceInfoTransformMacro */
   def do_=== (that: SInt)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool = compop(sourceInfo, EqualOp, that)
 
-//  final def abs(): UInt = macro SourceInfoTransform.noArgDummy
+//  final def abs(): UInt = macro SourceInfoTransform.noArg
 
   def do_abs(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): SInt = {
-    Mux(this < 0.S, -this, this)
+    Mux(this < 0.S, (-this), this)
   }
 
   override def do_<< (that: Int)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): SInt =
@@ -1026,10 +983,7 @@ sealed class SInt private[chisel3] (width: Width) extends Bits(width) with Num[S
 
 sealed trait Reset extends Element with ToBoolable {
   /** Casts this $coll to an [[AsyncReset]] */
-  final def asAsyncReset: AsyncReset = macro SourceInfoWhiteboxTransform.noArg
-
-  @deprecated("Calling this function with an empty argument list is invalid in Scala 3. Use the form without parentheses instead", "Chisel 3.5")
-  final def asAsyncReset(dummy: Int*): AsyncReset = macro SourceInfoTransform.noArgDummy
+  final def asAsyncReset(): AsyncReset = macro SourceInfoWhiteboxTransform.noArg
 
   /** @group SourceInfoTransformMacro */
   def do_asAsyncReset(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): AsyncReset
@@ -1215,10 +1169,7 @@ sealed class Bool() extends UInt(1.W) with Reset {
   def do_&& (that: Bool)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool = this & that
 
   /** Reinterprets this $coll as a clock */
-  def asClock: Clock = macro SourceInfoTransform.noArg
-
-  @deprecated("Calling this function with an empty argument list is invalid in Scala 3. Use the form without parentheses instead", "Chisel 3.5")
-  def asClock(dummy: Int*): Clock = macro SourceInfoTransform.noArgDummy
+  def asClock(): Clock = macro SourceInfoTransform.noArg
 
   /** @group SourceInfoTransformMacro */
   def do_asClock(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Clock = pushOp(DefPrim(sourceInfo, Clock(), AsClockOp, ref))
@@ -1314,10 +1265,7 @@ package experimental {
       *         $expandingWidth
       * @group Arithmetic
       */
-    final def unary_- : FixedPoint = macro SourceInfoTransform.noArg
-
-    @deprecated("Calling this function with an empty argument list is invalid in Scala 3. Use the form without parentheses instead", "Chisel 3.5")
-    final def unary_-(dummy: Int*): FixedPoint = macro SourceInfoTransform.noArgDummy
+    final def unary_- (): FixedPoint = macro SourceInfoTransform.noArg
 
     /** Unary negation (constant width)
       *
@@ -1325,9 +1273,7 @@ package experimental {
       *         $constantWidth
       * @group Arithmetic
       */
-    final def unary_-% : FixedPoint = macro SourceInfoTransform.noArg
-    @deprecated("Calling this function with an empty argument list is invalid in Scala 3. Use the form without parentheses instead", "Chisel 3.5")
-    final def unary_-%(dummy: Int*): FixedPoint = macro SourceInfoTransform.noArgDummy
+    final def unary_-% (): FixedPoint = macro SourceInfoTransform.noArg
 
     /** @group SourceInfoTransformMacro */
     def unary_- (implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): FixedPoint = FixedPoint.fromBigInt(0) - this
@@ -1762,15 +1708,8 @@ package experimental {
       }
     }
 
-    final def unary_- : Interval = macro SourceInfoTransform.noArg
-
-    @deprecated("Calling this function with an empty argument list is invalid in Scala 3. Use the form without parentheses instead", "Chisel 3.5")
-    final def unary_-(dummy: Int*): Interval = macro SourceInfoTransform.noArgDummy
-
-    final def unary_-% : Interval = macro SourceInfoTransform.noArg
-
-    @deprecated("Calling this function with an empty argument list is invalid in Scala 3. Use the form without parentheses instead", "Chisel 3.5")
-    final def unary_-%(dummy: Int*): Interval = macro SourceInfoTransform.noArgDummy
+    final def unary_-(): Interval = macro SourceInfoTransform.noArg
+    final def unary_-%(): Interval = macro SourceInfoTransform.noArg
 
     def unary_-(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Interval = {
       Interval.Zero - this
@@ -1885,7 +1824,7 @@ package experimental {
     def do_=/= (that: Interval)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool = compop(sourceInfo, NotEqualOp, that)
     def do_=== (that: Interval)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool = compop(sourceInfo, EqualOp, that)
 
-    //  final def abs(): UInt = macro SourceInfoTransform.noArgDummy
+    //  final def abs(): UInt = macro SourceInfoTransform.noArg
 
     def do_abs(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Interval = {
       Mux(this < Interval.Zero, (Interval.Zero - this), this)

--- a/core/src/main/scala/chisel3/Clock.scala
+++ b/core/src/main/scala/chisel3/Clock.scala
@@ -32,12 +32,8 @@ sealed class Clock(private[chisel3] val width: Width = Width(1)) extends Element
   def toPrintable: Printable = PString("CLOCK")
 
   /** Returns the contents of the clock wire as a [[Bool]]. */
-  final def asBool: Bool = macro SourceInfoTransform.noArg
-
-  @deprecated("Calling this function with an empty argument list is invalid in Scala 3. Use the form without parentheses instead", "Chisel 3.5")
-  final def asBool(dummy: Int*): Bool = macro SourceInfoTransform.noArgDummy
-
-  def do_asBool(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool = this.asUInt.asBool
+  final def asBool(): Bool = macro SourceInfoTransform.noArg
+  def do_asBool(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool = this.asUInt().asBool()
 
   override def do_asUInt(implicit sourceInfo: SourceInfo, connectCompileOptions: CompileOptions): UInt = pushOp(DefPrim(sourceInfo, UInt(this.width), AsUIntOp, ref))
   private[chisel3] override def connectFromBits(that: Bits)(implicit sourceInfo: SourceInfo,

--- a/core/src/main/scala/chisel3/Data.scala
+++ b/core/src/main/scala/chisel3/Data.scala
@@ -645,28 +645,18 @@ abstract class Data extends HasId with NamedComponent with SourceInfoDoc {
     }
   }
 
-  def isLit: Boolean = litOption.isDefined
-
-  @deprecated("Calling this function with an empty argument list is invalid in Scala 3. Use the form without parentheses instead", "Chisel 3.5")
-  def isLit(dummy: Int*): Boolean = isLit
-
+  def isLit(): Boolean = litOption.isDefined
 
   /**
    * If this is a literal that is representable as bits, returns the value as a BigInt.
    * If not a literal, or not representable as bits (for example, is or contains Analog), returns None.
    */
-  def litOption: Option[BigInt]
-
-  @deprecated("Calling this function with an empty argument list is invalid in Scala 3. Use the form without parentheses instead", "Chisel 3.5")
-  def litOption(dummy: Int*): Option[BigInt] = litOption
+  def litOption(): Option[BigInt]
 
   /**
    * Returns the literal value if this is a literal that is representable as bits, otherwise crashes.
    */
-  def litValue: BigInt = litOption.get
-
-  @deprecated("Calling this function with an empty argument list is invalid in Scala 3. Use the form without parentheses instead", "Chisel 3.5")
-  def litValue(dummy: Int*): BigInt = litValue
+  def litValue(): BigInt = litOption.get
 
   /** Returns the width, in bits, if currently known. */
   final def getWidth: Int =
@@ -689,7 +679,7 @@ abstract class Data extends HasId with NamedComponent with SourceInfoDoc {
   /** @group SourceInfoTransformMacro */
   def do_asTypeOf[T <: Data](that: T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T = {
     val thatCloned = Wire(that.cloneTypeFull)
-    thatCloned.connectFromBits(this.asUInt)
+    thatCloned.connectFromBits(this.asUInt())
     thatCloned
   }
 
@@ -705,10 +695,7 @@ abstract class Data extends HasId with NamedComponent with SourceInfoDoc {
     * @note Aggregates are recursively packed with the first element appearing
     * in the least-significant bits of the result.
     */
-  final def asUInt: UInt = macro SourceInfoTransform.noArg
-
-  @deprecated("Calling this function with an empty argument list is invalid in Scala 3. Use the form without parentheses instead", "Chisel 3.5")
-  final def asUInt(dummy: Int*): UInt = macro SourceInfoTransform.noArgDummy
+  final def asUInt(): UInt = macro SourceInfoTransform.noArg
 
   /** @group SourceInfoTransformMacro */
   def do_asUInt(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): UInt
@@ -728,7 +715,7 @@ trait WireFactory {
     val x = t.cloneTypeFull
 
     // Bind each element of x to being a Wire
-    x.bind(WireBinding(Builder.forcedUserModule, Builder.currentWhen))
+    x.bind(WireBinding(Builder.forcedUserModule, Builder.currentWhen()))
 
     pushCommand(DefWire(sourceInfo, x))
     if (!compileOptions.explicitInvalidate) {

--- a/core/src/main/scala/chisel3/Mem.scala
+++ b/core/src/main/scala/chisel3/Mem.scala
@@ -130,7 +130,7 @@ sealed abstract class MemBase[T <: Data](val t: T, val length: BigInt) extends H
        t.cloneTypeFull, Node(this), dir, i.ref, Builder.forcedClock.ref)
     ).id
     // Bind each element of port to being a MemoryPort
-    port.bind(MemoryPortBinding(Builder.forcedUserModule, Builder.currentWhen))
+    port.bind(MemoryPortBinding(Builder.forcedUserModule, Builder.currentWhen()))
     port
   }
 }

--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -39,7 +39,7 @@ object Module extends SourceInfoDoc {
 
     // Save then clear clock and reset to prevent leaking scope, must be set again in the Module
     val (saveClock, saveReset)  = (Builder.currentClock, Builder.currentReset)
-    val savePrefix = Builder.getPrefix
+    val savePrefix = Builder.getPrefix()
     Builder.clearPrefix()
     Builder.currentClock = None
     Builder.currentReset = None

--- a/core/src/main/scala/chisel3/Num.scala
+++ b/core/src/main/scala/chisel3/Num.scala
@@ -148,10 +148,7 @@ trait Num[T <: Data] {
     * $unchangedWidth
     * @group Arithmetic
     */
-  final def abs: T = macro SourceInfoTransform.noArg
-
-  @deprecated("Calling this function with an empty argument list is invalid in Scala 3. Use the form without parentheses instead", "Chisel 3.5")
-  final def abs(dummy: Int*): T = macro SourceInfoTransform.noArgDummy
+  final def abs(): T = macro SourceInfoTransform.noArg
 
   /** @group SourceInfoTransformMacro */
   def do_abs(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T

--- a/core/src/main/scala/chisel3/Reg.scala
+++ b/core/src/main/scala/chisel3/Reg.scala
@@ -41,7 +41,7 @@ object Reg {
     val reg = t.cloneTypeFull
     val clock = Node(Builder.forcedClock)
 
-    reg.bind(RegBinding(Builder.forcedUserModule, Builder.currentWhen))
+    reg.bind(RegBinding(Builder.forcedUserModule, Builder.currentWhen()))
     pushCommand(DefReg(sourceInfo, reg, clock))
     reg
   }
@@ -174,7 +174,7 @@ object RegInit {
     val clock = Builder.forcedClock
     val reset = Builder.forcedReset
 
-    reg.bind(RegBinding(Builder.forcedUserModule, Builder.currentWhen))
+    reg.bind(RegBinding(Builder.forcedUserModule, Builder.currentWhen()))
     requireIsHardware(init, "reg initializer")
     pushCommand(DefRegInit(sourceInfo, reg, clock.ref, reset.ref, init.ref))
     reg

--- a/core/src/main/scala/chisel3/SeqUtils.scala
+++ b/core/src/main/scala/chisel3/SeqUtils.scala
@@ -81,7 +81,7 @@ private[chisel3] object SeqUtils {
       val output = cloneSupertype(in.toSeq map { _._2}, "oneHotMux")
 
       def buildAndOrMultiplexor[TT <: Data](inputs: Iterable[(Bool, TT)]): T = {
-        val masked = for ((s, i) <- inputs) yield Mux(s, i.asUInt, 0.U)
+        val masked = for ((s, i) <- inputs) yield Mux(s, i.asUInt(), 0.U)
         masked.reduceLeft(_ | _).asTypeOf(output)
       }
 

--- a/core/src/main/scala/chisel3/StrongEnum.scala
+++ b/core/src/main/scala/chisel3/StrongEnum.scala
@@ -246,7 +246,7 @@ abstract class EnumFactory {
   private val enumRecords = mutable.ArrayBuffer.empty[EnumRecord]
 
   private def enumNames = enumRecords.map(_.name).toSeq
-  private def enumValues = enumRecords.map(_.inst.litValue).toSeq
+  private def enumValues = enumRecords.map(_.inst.litValue()).toSeq
   private def enumInstances = enumRecords.map(_.inst).toSeq
 
   private[chisel3] val enumTypeName = getClass.getName.init
@@ -265,7 +265,7 @@ abstract class EnumFactory {
   def all: Seq[Type] = enumInstances
 
   private[chisel3] def nameOfValue(id: BigInt): Option[String] = {
-    enumRecords.find(_.inst.litValue == id).map(_.name)
+    enumRecords.find(_.inst.litValue() == id).map(_.name)
   }
 
   protected def Value: Type = macro EnumMacros.ValImpl
@@ -291,11 +291,11 @@ abstract class EnumFactory {
     if (id.litOption.isEmpty) {
       throwException(s"$enumTypeName defined with a non-literal type")
     }
-    if (id.litValue < this.id) {
+    if (id.litValue() < this.id) {
       throwException(s"Enums must be strictly increasing: $enumTypeName")
     }
 
-    this.id = id.litValue
+    this.id = id.litValue()
     do_Value(name)
   }
 

--- a/core/src/main/scala/chisel3/When.scala
+++ b/core/src/main/scala/chisel3/When.scala
@@ -50,7 +50,7 @@ object when {
     implicit val sourceInfo = UnlocatableSourceInfo
     val whens = Builder.whenStack
     whens.foldRight(true.B) {
-      case (ctx, acc) => acc && ctx.localCond
+      case (ctx, acc) => acc && ctx.localCond()
     }
   }
 }
@@ -81,7 +81,7 @@ final class WhenContext private[chisel3] (
   private var scopeOpen = false
 
   /** Returns the local condition, inverted for an otherwise */
-  private[chisel3] def localCond: Bool = {
+  private[chisel3] def localCond(): Bool = {
     implicit val compileOptions = ExplicitCompileOptions.Strict
     implicit val sourceInfo = UnlocatableSourceInfo
     val alt = altConds.foldRight(true.B) {
@@ -111,10 +111,7 @@ final class WhenContext private[chisel3] (
   def otherwise(block: => Any)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Unit =
     new WhenContext(sourceInfo, None, block, firrtlDepth + 1, cond ++: altConds)
 
-  def active: Boolean = scopeOpen
-
-  @deprecated("Calling this function with an empty argument list is invalid in Scala 3. Use the form without parentheses instead", "Chisel 3.5")
-  def active(dummy: Int*): Boolean = active
+  def active(): Boolean = scopeOpen
 
   /*
    *

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -105,7 +105,7 @@ private[chisel3] trait HasId extends InstanceId {
   private var auto_seed: Option[String] = None
 
   // Prefix at time when this class is constructed
-  private val construction_prefix: Prefix = Builder.getPrefix
+  private val construction_prefix: Prefix = Builder.getPrefix()
 
   // Prefix when the latest [[suggestSeed]] or [[autoSeed]] is called
   private var prefix_seed: Prefix = Nil
@@ -133,7 +133,7 @@ private[chisel3] trait HasId extends InstanceId {
   private[chisel3] def forceAutoSeed(seed: String): this.type = {
     auto_seed = Some(seed)
     for(hook <- auto_postseed_hooks) { hook(seed) }
-    prefix_seed = Builder.getPrefix
+    prefix_seed = Builder.getPrefix()
     this
   }
 
@@ -149,7 +149,7 @@ private[chisel3] trait HasId extends InstanceId {
     */
   def suggestName(seed: =>String): this.type = {
     if(suggested_seed.isEmpty) suggested_seed = Some(seed)
-    prefix_seed = Builder.getPrefix
+    prefix_seed = Builder.getPrefix()
     for(hook <- suggest_postseed_hooks) { hook(seed) }
     this
   }
@@ -496,7 +496,7 @@ private[chisel3] object Builder extends LazyLogging {
   }
 
   // Returns the prefix stack at this moment
-  def getPrefix: Prefix = chiselContext.get().prefixStack
+  def getPrefix(): Prefix = chiselContext.get().prefixStack
 
   def currentModule: Option[BaseModule] = dynamicContextVar.value match {
     case Some(dyanmicContext) => dynamicContext.currentModule
@@ -583,7 +583,7 @@ private[chisel3] object Builder extends LazyLogging {
     dynamicContext.whenStack = s
   }
 
-  def currentWhen: Option[WhenContext] = dynamicContext.whenStack.headOption
+  def currentWhen(): Option[WhenContext] = dynamicContext.whenStack.headOption
 
   def currentClock: Option[Clock] = dynamicContext.currentClock
   def currentClock_=(newClock: Option[Clock]): Unit = {
@@ -626,7 +626,7 @@ private[chisel3] object Builder extends LazyLogging {
   }
   def pushOp[T <: Data](cmd: DefPrim[T]): T = {
     // Bind each element of the returned Data to being a Op
-    cmd.id.bind(OpBinding(forcedUserModule, currentWhen))
+    cmd.id.bind(OpBinding(forcedUserModule, currentWhen()))
     pushCommand(cmd).id
   }
 

--- a/core/src/main/scala/chisel3/internal/prefix.scala
+++ b/core/src/main/scala/chisel3/internal/prefix.scala
@@ -51,7 +51,7 @@ private[chisel3] object prefix { // scalastyle:ignore
     // This causes extra prefixes to be added, and subsequently cleared in the
     // Module constructor. Thus, we need to just make sure if the previous push
     // was an incorrect one, to not pop off an empty stack
-    if(Builder.getPrefix.nonEmpty) Builder.popPrefix()
+    if(Builder.getPrefix().nonEmpty) Builder.popPrefix()
     ret
   }
 }
@@ -77,7 +77,7 @@ private[chisel3] object noPrefix {
     * @return The return value of the provided function
     */
   def apply[T](f: => T): T = {
-    val prefix = Builder.getPrefix
+    val prefix = Builder.getPrefix()
     Builder.clearPrefix()
     val ret = f
     Builder.setPrefix(prefix)

--- a/core/src/main/scala/chisel3/package.scala
+++ b/core/src/main/scala/chisel3/package.scala
@@ -50,18 +50,10 @@ package object chisel3 {
 
     /** Int to UInt conversion, recommended style for variables.
       */
-    def asUInt: UInt = UInt.Lit(bigint, Width())
-
-    @deprecated("Calling this function with an empty argument list is invalid in Scala 3. Use the form without parentheses instead", "Chisel 3.5")
-    def asUInt(dummy: Int*): UInt = asUInt
-
+    def asUInt(): UInt = UInt.Lit(bigint, Width())
     /** Int to SInt conversion, recommended style for variables.
       */
-    def asSInt: SInt = SInt.Lit(bigint, Width())
-
-    @deprecated("Calling this function with an empty argument list is invalid in Scala 3. Use the form without parentheses instead", "Chisel 3.5")
-    def asSInt(dummy: Int*): SInt = asSInt
-
+    def asSInt(): SInt = SInt.Lit(bigint, Width())
     /** Int to UInt conversion with specified width, recommended style for variables.
       */
     def asUInt(width: Width): UInt = UInt.Lit(bigint, width)
@@ -76,21 +68,17 @@ package object chisel3 {
   implicit class fromStringToLiteral(str: String) {
     /** String to UInt parse, recommended style for constants.
       */
-    def U: UInt = str.asUInt
+    def U: UInt = str.asUInt()
     /** String to UInt parse with specified width, recommended style for constants.
       */
     def U(width: Width): UInt = str.asUInt(width)
 
     /** String to UInt parse, recommended style for variables.
       */
-    def asUInt: UInt = {
+    def asUInt(): UInt = {
       val bigInt = parse(str)
       UInt.Lit(bigInt, Width(bigInt.bitLength max 1))
     }
-
-    @deprecated("Calling this function with an empty argument list is invalid in Scala 3. Use the form without parentheses instead", "Chisel 3.5")
-    def asUInt(dummy: Int*): UInt = asUInt
-
     /** String to UInt parse with specified width, recommended style for variables.
       */
     def asUInt(width: Width): UInt = UInt.Lit(parse(str), width)
@@ -119,10 +107,7 @@ package object chisel3 {
 
     /** Boolean to Bool conversion, recommended style for variables.
       */
-    def asBool: Bool = Bool.Lit(boolean)
-
-    @deprecated("Calling this function with an empty argument list is invalid in Scala 3. Use the form without parentheses instead", "Chisel 3.5")
-    def asBool(dummy: Int*): Bool = asBool
+    def asBool(): Bool = Bool.Lit(boolean)
   }
 
   // Fixed Point is experimental for now, but we alias the implicit conversion classes here

--- a/macros/src/main/scala/chisel3/internal/sourceinfo/SourceInfoTransform.scala
+++ b/macros/src/main/scala/chisel3/internal/sourceinfo/SourceInfoTransform.scala
@@ -165,12 +165,7 @@ object SourceInfoTransform
 class SourceInfoTransform(val c: Context) extends AutoSourceTransform {
   import c.universe._
 
-  def noArg: c.Tree = {
-    q"$thisObj.$doFuncTerm($implicitSourceInfo, $implicitCompileOptions)"
-  }
-
-  /** Necessary for dummy methods to auto-apply their arguments to this macro */
-  def noArgDummy(dummy: c.Tree*): c.Tree = {
+  def noArg(): c.Tree = {
     q"$thisObj.$doFuncTerm($implicitSourceInfo, $implicitCompileOptions)"
   }
 
@@ -229,12 +224,7 @@ object SourceInfoWhiteboxTransform
 class SourceInfoWhiteboxTransform(val c: whitebox.Context) extends AutoSourceTransform {
   import c.universe._
 
-  def noArg: c.Tree = {
-    q"$thisObj.$doFuncTerm($implicitSourceInfo, $implicitCompileOptions)"
-  }
-
-  /** Necessary for dummy methods to auto-apply their arguments to this macro */
-  def noArgDummy(dummy: c.Tree*): c.Tree = {
+  def noArg(): c.Tree = {
     q"$thisObj.$doFuncTerm($implicitSourceInfo, $implicitCompileOptions)"
   }
 

--- a/src/main/scala/chisel3/compatibility.scala
+++ b/src/main/scala/chisel3/compatibility.scala
@@ -33,10 +33,7 @@ package object Chisel {
   implicit class AddDirectionToData[T<:Data](target: T) {
     def asInput: T = Input(target)
     def asOutput: T = Output(target)
-    def flip: T = Flipped(target)
-
-    @deprecated("Calling this function with an empty argument list is invalid in Scala 3. Use the form without parentheses instead", "Chisel 3.5")
-    def flip(dummy: Int*): T = flip
+    def flip(): T = Flipped(target)
   }
 
   implicit class AddDirMethodToData[T<:Data](target: T) {

--- a/src/main/scala/chisel3/util/Decoupled.scala
+++ b/src/main/scala/chisel3/util/Decoupled.scala
@@ -37,10 +37,7 @@ object ReadyValidIO {
 
     /** Indicates if IO is both ready and valid
      */
-    def fire: Bool = target.ready && target.valid
-
-    @deprecated("Calling this function with an empty argument list is invalid in Scala 3. Use the form without parentheses instead", "Chisel 3.5")
-    def fire(dummy: Int = 0): Bool = fire
+    def fire(): Bool = target.ready && target.valid
 
     /** Push dat onto the output bits of this interface to let the consumer know it has happened.
       * @param dat the values to assign to bits.
@@ -225,8 +222,8 @@ class Queue[T <: Data](val gen: T,
   val ptr_match = enq_ptr.value === deq_ptr.value
   val empty = ptr_match && !maybe_full
   val full = ptr_match && maybe_full
-  val do_enq = WireDefault(io.enq.fire)
-  val do_deq = WireDefault(io.deq.fire)
+  val do_enq = WireDefault(io.enq.fire())
+  val do_deq = WireDefault(io.deq.fire())
   val flush = io.flush.getOrElse(false.B) 
 
   // when flush is high, empty the queue

--- a/src/test/scala/chiselTests/SIntOps.scala
+++ b/src/test/scala/chiselTests/SIntOps.scala
@@ -44,7 +44,7 @@ class SIntOps extends Module {
   io.noteqout := (a =/= b)
   io.lesseqout := a <= b
   io.greateqout := a >= b
-  io.negout := -a(15, 0).asSInt
+  // io.negout := -a(15, 0).toSInt
   io.negout := (0.S -% a)
 }
 

--- a/src/test/scala/chiselTests/StrongEnum.scala
+++ b/src/test/scala/chiselTests/StrongEnum.scala
@@ -257,8 +257,8 @@ class IsLitTester extends BasicTester {
   for (e <- EnumExample.all) {
     val wire = WireDefault(e)
 
-    assert(e.isLit)
-    assert(!wire.isLit)
+    assert(e.isLit())
+    assert(!wire.isLit())
   }
   stop()
 }

--- a/src/test/scala/chiselTests/VecLiteralSpec.scala
+++ b/src/test/scala/chiselTests/VecLiteralSpec.scala
@@ -142,17 +142,17 @@ class VecLiteralSpec extends ChiselFreeSpec with Utils {
 
   "lowest of vec literal contains least significant bits and " in {
     val y = Vec(4, UInt(8.W)).Lit(0 -> 0xAB.U(8.W), 1 -> 0xCD.U(8.W), 2 -> 0xEF.U(8.W), 3 -> 0xFF.U(8.W))
-    y.litValue should be(BigInt("FFEFCDAB", 16))
+    y.litValue() should be(BigInt("FFEFCDAB", 16))
   }
 
   "the order lits are specified does not matter" in {
     val y = Vec(4, UInt(8.W)).Lit(3 -> 0xFF.U(8.W), 2 -> 0xEF.U(8.W), 1 -> 0xCD.U(8.W), 0 -> 0xAB.U(8.W))
-    y.litValue should be(BigInt("FFEFCDAB", 16))
+    y.litValue() should be(BigInt("FFEFCDAB", 16))
   }
 
   "regardless of the literals widths, packing should be done based on the width of the Vec's gen" in {
     val z = Vec(4, UInt(8.W)).Lit(0 -> 0x2.U, 1 -> 0x2.U, 2 -> 0x2.U, 3 -> 0x3.U)
-    z.litValue should be(BigInt("03020202", 16))
+    z.litValue() should be(BigInt("03020202", 16))
   }
 
   "packing sparse vec lits should not pack, litOption returns None" in {
@@ -221,7 +221,7 @@ class VecLiteralSpec extends ChiselFreeSpec with Utils {
         chisel3.assert(outsideVecLit(2) === 0xBB.U)
         chisel3.assert(outsideVecLit(3) === 0xAA.U)
 
-        chisel3.assert(outsideVecLit.litValue.U === outsideVecLit.asUInt())
+        chisel3.assert(outsideVecLit.litValue().U === outsideVecLit.asUInt())
 
         val insideVecLit = Vec(4, UInt(16.W)).Lit(0 -> 0xDD.U, 1 -> 0xCC.U, 2 -> 0xBB.U, 3 -> 0xAA.U)
         chisel3.assert(insideVecLit(0) === 0xDD.U)
@@ -277,15 +277,15 @@ class VecLiteralSpec extends ChiselFreeSpec with Utils {
       1 -> Vec(3, UInt(4.W)).Lit(0 -> 4.U, 1 -> 5.U, 2 -> 6.U)
     )
 
-    outerVec.litValue should be (BigInt("654321", 16))
-    outerVec(0).litValue should be (BigInt("321", 16))
-    outerVec(1).litValue should be (BigInt("654", 16))
-    outerVec(0)(0).litValue should be (BigInt(1))
-    outerVec(0)(1).litValue should be (BigInt(2))
-    outerVec(0)(2).litValue should be (BigInt(3))
-    outerVec(1)(0).litValue should be (BigInt(4))
-    outerVec(1)(1).litValue should be (BigInt(5))
-    outerVec(1)(2).litValue should be (BigInt(6))
+    outerVec.litValue() should be (BigInt("654321", 16))
+    outerVec(0).litValue() should be (BigInt("321", 16))
+    outerVec(1).litValue() should be (BigInt("654", 16))
+    outerVec(0)(0).litValue() should be (BigInt(1))
+    outerVec(0)(1).litValue() should be (BigInt(2))
+    outerVec(0)(2).litValue() should be (BigInt(3))
+    outerVec(1)(0).litValue() should be (BigInt(4))
+    outerVec(1)(1).litValue() should be (BigInt(5))
+    outerVec(1)(2).litValue() should be (BigInt(6))
   }
 
   "contained vecs should work" in {
@@ -473,19 +473,19 @@ class VecLiteralSpec extends ChiselFreeSpec with Utils {
       0 -> (new SubBundle).Lit(_.foo -> 0xab.U, _.bar -> 0xc.U),
       1 -> (new SubBundle).Lit(_.foo -> 0xde.U, _.bar -> 0xf.U)
     )
-    vec.litValue.toString(16) should be("defabc")
+    vec.litValue().toString(16) should be("defabc")
   }
 
   "vec literals can have bundle children assembled incrementally" in {
     val bundle1 = (new SubBundle).Lit(_.foo -> 0xab.U, _.bar -> 0xc.U)
     val bundle2 = (new SubBundle).Lit(_.foo -> 0xde.U, _.bar -> 0xf.U)
 
-    bundle1.litValue.toString(16) should be("abc")
-    bundle2.litValue.toString(16) should be("def")
+    bundle1.litValue().toString(16) should be("abc")
+    bundle2.litValue().toString(16) should be("def")
 
     val vec = Vec(2, new SubBundle).Lit(0 -> bundle1, 1 -> bundle2)
 
-    vec.litValue.toString(16) should be("defabc")
+    vec.litValue().toString(16) should be("defabc")
   }
 
   "bundles can contain vec lits" in {
@@ -495,7 +495,7 @@ class VecLiteralSpec extends ChiselFreeSpec with Utils {
       val foo = Vec(3, UInt(4.W))
       val bar = Vec(2, UInt(4.W))
     }).Lit(_.foo -> vec1, _.bar -> vec2)
-    bundle.litValue.toString(16) should be("cbaed")
+    bundle.litValue().toString(16) should be("cbaed")
   }
 
   "bundles can contain vec lits in-line" in {
@@ -506,21 +506,21 @@ class VecLiteralSpec extends ChiselFreeSpec with Utils {
       _.foo -> Vec(3, UInt(4.W)).Lit(0 -> 0xa.U, 1 -> 0xb.U, 2 -> 0xc.U),
       _.bar -> Vec(2, UInt(4.W)).Lit(0 -> 0xd.U, 1 -> 0xe.U)
     )
-    bundle.litValue.toString(16) should be("cbaed")
+    bundle.litValue().toString(16) should be("cbaed")
   }
 
   "Vec.Lit is a trivial Vec literal factory" in {
     val vec = Vec.Lit(0xa.U, 0xb.U)
-    vec(0).litValue should be(0xa)
-    vec(1).litValue should be(0xb)
+    vec(0).litValue() should be(0xa)
+    vec(1).litValue() should be(0xb)
   }
 
   "Vec.Lit bases it's element width on the widest literal supplied" in {
     val vec = Vec.Lit(0xa.U, 0xbbbb.U)
-    vec(0).litValue should be(0xa)
-    vec(1).litValue should be(0xbbbb)
+    vec(0).litValue() should be(0xa)
+    vec(1).litValue() should be(0xbbbb)
     vec.length should be(2)
     vec.getWidth should be(16 * 2)
-    vec.litValue should be(BigInt("bbbb000a", 16))
+    vec.litValue() should be(BigInt("bbbb000a", 16))
   }
 }


### PR DESCRIPTION
This reverts commit #2124. since it breaks dsptools in: 
```
[#4] [error] /Users/sequencer/projects/playground/wtf/dependencies/dsptools/src/main/scala/dsptools/numbers/chisel_types/FixedPointTypeClass.scala:40:43: ambiguous reference to overloaded definition,
[#4] [error] both method unary_- in class FixedPoint of type (implicit sourceInfo: chisel3.internal.sourceinfo.SourceInfo, implicit compileOptions: chisel3.CompileOptions)chisel3.experimental.FixedPoint
[#4] [error] and  macro method unary_- in class FixedPoint of type => chisel3.experimental.FixedPoint
[#4] [error] match expected type chisel3.experimental.FixedPoint
[#4] [error]   def negate(f: FixedPoint): FixedPoint = -f
[#4] [error]                                           ^
[#4] [error] /Users/sequencer/projects/playground/wtf/dependencies/dsptools/src/main/scala/dsptools/numbers/chisel_types/IntervalTypeClass.scala:44:39: ambiguous reference to overloaded definition,
[#4] [error] both method unary_- in class Interval of type (implicit sourceInfo: chisel3.internal.sourceinfo.SourceInfo, implicit compileOptions: chisel3.CompileOptions)chisel3.experimental.Interval
[#4] [error] and  macro method unary_- in class Interval of type => chisel3.experimental.Interval
[#4] [error] match expected type chisel3.experimental.Interval
[#4] [error]   def negate(f: Interval): Interval = -(f)
[#4] [error]                                       ^
[#4] [error] two errors found
```

no need to merge, I think we can hot fix it.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [ ] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [ ] Did you state the API impact?
- [ ] Did you specify the code generation impact?
- [ ] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.3.x`, [small] API extension: `3.4.x`, API modification or big change: `3.5.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
