### PR TITLE
Add nullary .fire to Valid and deprecate dummy version

### DIFF
--- a/src/main/scala/chisel3/util/Arbiter.scala
+++ b/src/main/scala/chisel3/util/Arbiter.scala
@@ -47,7 +47,7 @@ abstract class LockingArbiterLike[T <: Data](gen: T, n: Int, count: Int, needsLo
     val locked = lockCount.value =/= 0.U
     val wantsLock = needsLock.map(_(io.out.bits)).getOrElse(true.B)
 
-    when (io.out.fire() && wantsLock) {
+    when (io.out.fire && wantsLock) {
       lockIdx := io.chosen
       lockCount.inc()
     }
@@ -63,7 +63,7 @@ abstract class LockingArbiterLike[T <: Data](gen: T, n: Int, count: Int, needsLo
 
 class LockingRRArbiter[T <: Data](gen: T, n: Int, count: Int, needsLock: Option[T => Bool] = None)
     extends LockingArbiterLike[T](gen, n, count, needsLock) {
-  lazy val lastGrant = RegEnable(io.chosen, io.out.fire())
+  lazy val lastGrant = RegEnable(io.chosen, io.out.fire)
   lazy val grantMask = (0 until n).map(_.asUInt > lastGrant)
   lazy val validMask = io.in zip grantMask map { case (in, g) => in.valid && g }
 

--- a/src/main/scala/chisel3/util/Valid.scala
+++ b/src/main/scala/chisel3/util/Valid.scala
@@ -28,6 +28,9 @@ class Valid[+T <: Data](gen: T) extends Bundle {
   /** True when `valid` is asserted
     * @return a Chisel [[Bool]] true if `valid` is asserted
     */
+  def fire: Bool = valid
+
+  @deprecated("Calling this function with an empty argument list is invalid in Scala 3. Use the form without parentheses instead", "Chisel 3.5")
   def fire(dummy: Int = 0): Bool = valid
 }
 

--- a/src/main/scala/chisel3/util/random/PRNG.scala
+++ b/src/main/scala/chisel3/util/random/PRNG.scala
@@ -62,7 +62,7 @@ abstract class PRNG(val width: Int, val seed: Option[BigInt], step: Int = 1, upd
     state := nextState(state)
   }
 
-  when (io.seed.fire()) {
+  when (io.seed.fire) {
     state := (if (updateSeed) { nextState(io.seed.bits) } else { io.seed.bits })
   }
 

--- a/src/test/scala/chiselTests/QueueFlushSpec.scala
+++ b/src/test/scala/chiselTests/QueueFlushSpec.scala
@@ -40,11 +40,11 @@ abstract class FlushQueueTesterBase(elements: Seq[Int], queueDepth: Int, bitWidt
   q.io.deq.ready := LFSR(16)(tap)
 
   q.io.enq.bits := elems(inCnt.value)
-  when(q.io.enq.fire()) {
+  when(q.io.enq.fire) {
     inCnt.inc()
     currQCnt := currQCnt + 1.U //counts how many items have been enqueued
   }
-  when(q.io.deq.fire()) {     
+  when(q.io.deq.fire) {
     assert(flushRegister === false.B) //check queue isn't flushed (can't dequeue an empty queue)
   }
   when(flushRegister) { //Internal signal maybe_full is a register so some signals update on the next cycle
@@ -70,18 +70,18 @@ class QueueGetsFlushedTester(elements: Seq[Int], queueDepth: Int, bitWidth: Int,
   flush := LFSR(16)((tap + 3) % 16)  //testing a flush when flush is called randomly
   val halfCnt = (queueDepth + 1)/2
 
-  when(q.io.deq.fire()) {
+  when(q.io.deq.fire) {
     //ensure that what comes out is what comes in
     assert(currQCnt <= queueDepth.U)
     assert(elems(outCnt) === q.io.deq.bits)
     outCnt := outCnt + 1.U
     when (currQCnt > 0.U) {
-      currQCnt := Mux(q.io.enq.fire(), currQCnt, (currQCnt - 1.U))
+      currQCnt := Mux(q.io.enq.fire, currQCnt, (currQCnt - 1.U))
     }
   }
   when(flush) {
     assert(currQCnt === 0.U || q.io.deq.valid)
-    outCnt := outCnt + Mux(q.io.enq.fire(), (currQCnt + 1.U), currQCnt)
+    outCnt := outCnt + Mux(q.io.enq.fire, (currQCnt + 1.U), currQCnt)
     currQCnt := 0.U //resets the number of items currently inside queue
   }
 }
@@ -102,7 +102,7 @@ class EmptyFlushEdgecaseTester (elements: Seq[Int], queueDepth: Int, bitWidth: I
   flush := (cycleCounter.value === 0.U && inCnt.value === 0.U) //flushed only before anything is enqueued  
   q.io.enq.valid := (inCnt.value < elements.length.U) && !flush
 
-  when(q.io.deq.fire()) {
+  when(q.io.deq.fire) {
     assert(elems(outCnt) === q.io.deq.bits)
     outCnt := outCnt + 1.U
   }
@@ -124,7 +124,7 @@ class EnqueueEmptyFlushEdgecaseTester (elements: Seq[Int], queueDepth: Int, bitW
   flush := (cycleCounter.value === 0.U && inCnt.value === 0.U) //flushed only before anything is enqueued  
   cycleCounter.inc() //counts every cycle
 
-  when(q.io.deq.fire()) {
+  when(q.io.deq.fire) {
     //flush and enqueue were both active on the first cycle, 
     //so that element is flushed immediately which makes outCnt off by one
     assert(elems(outCounter.value + 1.U) === q.io.deq.bits) //ensure that what comes out is what comes in
@@ -145,7 +145,7 @@ class FullQueueFlushEdgecaseTester (elements: Seq[Int], queueDepth: Int, bitWidt
   //testing a flush when queue is full
   flush := (currQCnt === queueDepth.U)
 
-  when(q.io.deq.fire()) {
+  when(q.io.deq.fire) {
     //ensure that what comes out is what comes in
     assert(currQCnt <= queueDepth.U)
     assert(elems(outCnt) === q.io.deq.bits)
@@ -177,7 +177,7 @@ class DequeueFullQueueEdgecaseTester (elements: Seq[Int], queueDepth: Int, bitWi
   q.io.enq.valid := !flushRegister
   q.io.deq.ready := flush
 
-  when(q.io.deq.fire()) {
+  when(q.io.deq.fire) {
     //ensure that what comes out is what comes in
     assert(currQCnt <= queueDepth.U)
     assert(elems(outCnt) === q.io.deq.bits)
@@ -191,7 +191,7 @@ class DequeueFullQueueEdgecaseTester (elements: Seq[Int], queueDepth: Int, bitWi
   }
   when(flushRegister) {
     //check that queue gets flushed when queue is full
-    assert(q.io.deq.fire() === false.B)
+    assert(q.io.deq.fire === false.B)
   } 
 
 }

--- a/src/test/scala/chiselTests/QueueSpec.scala
+++ b/src/test/scala/chiselTests/QueueSpec.scala
@@ -21,10 +21,10 @@ class ThingsPassThroughTester(elements: Seq[Int], queueDepth: Int, bitWidth: Int
   q.io.deq.ready := LFSR(16)(tap)
   q.io.flush.foreach { _ := false.B } //Flush behavior is tested in QueueFlushSpec
   q.io.enq.bits := elems(inCnt.value)
-  when(q.io.enq.fire()) {
+  when(q.io.enq.fire) {
     inCnt.inc()
   }
-  when(q.io.deq.fire()) {
+  when(q.io.deq.fire) {
     //ensure that what comes out is what comes in
     assert(elems(outCnt.value) === q.io.deq.bits)
     outCnt.inc()
@@ -51,10 +51,10 @@ class QueueReasonableReadyValid(elements: Seq[Int], queueDepth: Int, bitWidth: I
   assert(q.io.deq.valid || q.io.count === 0.U)
 
   q.io.enq.bits := elems(inCnt.value)
-  when(q.io.enq.fire()) {
+  when(q.io.enq.fire) {
     inCnt.inc()
   }
-  when(q.io.deq.fire()) {
+  when(q.io.deq.fire) {
     outCnt.inc()
   }
   when(outCnt.value === elements.length.U) {
@@ -74,11 +74,11 @@ class CountIsCorrectTester(elements: Seq[Int], queueDepth: Int, bitWidth: Int, t
   q.io.deq.ready := LFSR(16)(tap)
 
   q.io.enq.bits := elems(inCnt.value)
-  when(q.io.enq.fire()) {
+  when(q.io.enq.fire) {
     inCnt.inc()
     assert(q.io.count === (inCnt.value - outCnt.value))
   }
-  when(q.io.deq.fire()) {
+  when(q.io.deq.fire) {
     outCnt.inc()
     assert(q.io.count === (inCnt.value - outCnt.value))
   }
@@ -103,10 +103,10 @@ class QueueSinglePipeTester(elements: Seq[Int], bitWidth: Int, tap: Int, useSync
   assert(q.io.enq.ready || (q.io.count === 1.U && !q.io.deq.ready))
 
   q.io.enq.bits := elems(inCnt.value)
-  when(q.io.enq.fire()) {
+  when(q.io.enq.fire) {
     inCnt.inc()
   }
-  when(q.io.deq.fire()) {
+  when(q.io.deq.fire) {
     outCnt.inc()
   }
 
@@ -129,10 +129,10 @@ class QueuePipeTester(elements: Seq[Int], queueDepth: Int, bitWidth: Int, tap: I
   assert(q.io.enq.ready || (q.io.count === queueDepth.U && !q.io.deq.ready))
 
   q.io.enq.bits := elems(inCnt.value)
-  when(q.io.enq.fire()) {
+  when(q.io.enq.fire) {
     inCnt.inc()
   }
-  when(q.io.deq.fire()) {
+  when(q.io.deq.fire) {
     outCnt.inc()
   }
 
@@ -155,13 +155,13 @@ class QueueFlowTester(elements: Seq[Int], queueDepth: Int, bitWidth: Int, tap: I
 
   q.io.deq.ready := LFSR(16)(tap)
   //Queue should be empty or valid
-  assert(q.io.deq.valid || (q.io.count === 0.U && !q.io.enq.fire()))
+  assert(q.io.deq.valid || (q.io.count === 0.U && !q.io.enq.fire))
 
   q.io.enq.bits := elems(inCnt.value)
-  when(q.io.enq.fire()) {
+  when(q.io.enq.fire) {
     inCnt.inc()
   }
-  when(q.io.deq.fire()) {
+  when(q.io.deq.fire) {
     outCnt.inc()
   }
   when(outCnt.value === elements.length.U) {
@@ -183,10 +183,10 @@ class QueueFactoryTester(elements: Seq[Int], queueDepth: Int, bitWidth: Int, tap
   deq.ready := LFSR(16)(tap)
 
   enq.bits := elems(inCnt.value)
-  when(enq.fire()) {
+  when(enq.fire) {
     inCnt.inc()
   }
-  when(deq.fire()) {
+  when(deq.fire) {
     //ensure that what comes out is what comes in
     assert(elems(outCnt.value) === deq.bits)
     outCnt.inc()


### PR DESCRIPTION
Also replace all uses of .fire() with .fire

Missed by https://github.com/chipsalliance/chisel3/pull/2124 because we only had the `(dummy: Int = 0)` version of `.fire` in `Valid`, what a blast from the past!

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [NA] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

 - code refactoring    
  - code cleanup       

#### API Impact

Deprecates any uses of `.fire()` on `Valid`s

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

  - Squash

#### Release Notes

Deprecate use of `.fire()` (with the parentheses) on objects of type `Valid`, use `.fire` instead.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [x] Did you mark the proper milestone (Bug fix: `3.3.x`, [small] API extension: `3.4.x`, API modification or big change: `3.5.0`)?
- [x] Did you review?
- [x] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
