### PR TITLE
Update developer documentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,14 +111,14 @@ If you like a textbook to learn Chisel and also a bit of digital design in gener
 
 ### Build Your Own Chisel Projects
 
-See [the setup instructions](https://github.com/chipsalliance/chisel3/blob/master/SETUP.md) for how to set up your environment to run Chisel locally.
+See [the setup instructions](SETUP.md) for how to set up your environment to build Chisel locally.
 
 When you're ready to build your own circuits in Chisel, **we recommend starting from the [Chisel Template](https://github.com/freechipsproject/chisel-template) repository**, which provides a pre-configured project, example design, and testbench. Follow the [chisel-template readme](https://github.com/freechipsproject/chisel-template) to get started.
 
 If you insist on setting up your own project, the magic SBT lines are:
 ```scala
-libraryDependencies += "edu.berkeley.cs" %% "chisel3" % "3.4.0"
-libraryDependencies += "edu.berkeley.cs" %% "chiseltest" % "0.3.0" % "test"
+libraryDependencies += "edu.berkeley.cs" %% "chisel3" % "3.4.4"
+libraryDependencies += "edu.berkeley.cs" %% "chiseltest" % "0.3.4" % "test"
 ```
 
 ### Design Verification
@@ -155,18 +155,11 @@ The [Useful Resources](#useful-resources) for users are also helpful for contrib
 
 ### Compiling and Testing Chisel
 
-First, clone and build the master branch of [FIRRTL](https://github.com/chipsalliance/firrtl) and [Treadle](https://github.com/chipsalliance/treadle), as the master branch of Chisel may depend on unreleased changes in those projects:
-
-```
-git clone https://github.com/chipsalliance/firrtl.git
-git clone https://github.com/chipsalliance/treadle.git
-pushd firrtl; sbt publishLocal; popd
-pushd treadle; sbt publishLocal; popd
-```
+You must first install required dependencies to build Chisel locally, please see [the setup instructions](SETUP.md).
 
 Clone and build the Chisel library:
 
-```
+```bash
 git clone https://github.com/chipsalliance/chisel3.git
 cd chisel3
 sbt compile
@@ -185,14 +178,13 @@ If the compilation succeeded and the dependencies noted above are installed, you
 sbt test
 ```
 
-
-
 If you would like to run the tests without the compiler plugin (less common), you can do so by first launching `sbt`,
 then running `noPluginTests / test`:
 ```
 sbt
 > noPluginTests / test
 ```
+
 ### Running Projects Against Local Chisel
 
 To use the development version of Chisel (`master` branch), you will need to build from source and `publishLocal`.


### PR DESCRIPTION
There are several potential contributors asking questions on Gitter and it has highlighted some deficiencies in our developer documentation. Here's a quick pass at improvements but I think more are probably necessary. Main change is deleting the stuff about building firrtl and treadle locally which is no longer necessary because we now push SNAPSHOTs on every push to master.

Marked `3.4.x` so that this will show up on the website.

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [NA] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [NA] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

 - documentation     

#### API Impact

No impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

   - Squash

#### Release Notes

Update developer documentation

### Reviewer Checklist (only modified by reviewer)
- [x] Did you add the appropriate labels?
- [x] Did you mark the proper milestone (Bug fix: `3.3.x`, [small] API extension: `3.4.x`, API modification or big change: `3.5.0`)?
- [x] Did you review?
- [x] Did you check whether all relevant Contributor checkboxes have been checked?
- [x] Did you mark as `Please Merge`?
