### PR TITLE
TruthTable: use ListMap instead of Map

### DIFF
--- a/src/main/scala/chisel3/util/experimental/decode/QMCMinimizer.scala
+++ b/src/main/scala/chisel3/util/experimental/decode/QMCMinimizer.scala
@@ -5,6 +5,7 @@ package chisel3.util.experimental.decode
 import chisel3.util.BitPat
 
 import scala.annotation.tailrec
+import scala.collection.immutable.ListMap
 import scala.math.Ordered.orderingToOrdered
 import scala.language.implicitConversions
 
@@ -282,7 +283,7 @@ object QMCMinimizer extends Minimizer {
       (essentialPrimeImplicants ++ getCover(nonessentialPrimeImplicants, uncoveredImplicants)).map(a => (a.bp, outputBp))
     })
 
-    minimized.tail.foldLeft(table.copy(table = Map(minimized.head))) { case (tb, t) =>
+    minimized.tail.foldLeft(table.copy(table = ListMap(minimized.head))) { case (tb, t) =>
       if (tb.table.exists(x => x._1 == t._1)) {
         tb.copy(table = tb.table.map { case (k, v) =>
           if (k == t._1) {

--- a/src/main/scala/chisel3/util/pla.scala
+++ b/src/main/scala/chisel3/util/pla.scala
@@ -3,6 +3,7 @@
 package chisel3.util
 
 import chisel3._
+import scala.collection.immutable.ListMap
 
 object pla {
 
@@ -81,7 +82,7 @@ object pla {
 
     // the AND matrix
     // use `term -> AND line` map to reuse AND matrix output lines
-    val andMatrixOutputs: Map[String, Bool] = inputTerms.map { t =>
+    val andMatrixOutputs = ListMap(inputTerms.map { t =>
       val andMatrixInput = Seq
         .tabulate(numberOfInputs) { i =>
           if (t.mask.testBit(i)) {
@@ -95,7 +96,7 @@ object pla {
         }
         .flatten
       if (andMatrixInput.nonEmpty) t.toString -> Cat(andMatrixInput).andR() else t.toString -> true.B
-    }.toMap
+    }: _*)
 
     // the OR matrix
     val orMatrixOutputs: UInt = Cat(


### PR DESCRIPTION
**Map** is an unordered data structure, so using **Map** as a parameter of **TruthTable** will cause the decoder to generate a non-reproducible circuit. This will cause the modules that use the decoder unable to be Deduped.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [ ] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [ ] Did you state the API impact?
- [ ] Did you specify the code generation impact?
- [ ] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement
- bug fix

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.3.x`, [small] API extension: `3.4.x`, API modification or big change: `3.5.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
