### PR TITLE
Add type parameter support for @instantiable

### DIFF
--- a/macros/src/main/scala/chisel3/internal/InstantiableMacro.scala
+++ b/macros/src/main/scala/chisel3/internal/InstantiableMacro.scala
@@ -42,17 +42,19 @@ private[chisel3] object instantiableMacro {
           val defname = TypeName(tpname + c.freshName())
           val instname = TypeName(tpname + c.freshName())
           val (newStats, extensions) = processBody(stats)
+          val argTParams = tparams.map(_.name)
           (q""" $mods class $tpname[..$tparams] $ctorMods(...$paramss) extends { ..$earlydefns } with ..$parents with chisel3.experimental.hierarchy.IsInstantiable { $self => ..$newStats } """,
-           Seq(q"""implicit class $defname(module: chisel3.experimental.hierarchy.Definition[$tpname]) { ..$extensions }""",
-               q"""implicit class $instname(module: chisel3.experimental.hierarchy.Instance[$tpname]) { ..$extensions } """),
+           Seq(q"""implicit class $defname[..$tparams](module: chisel3.experimental.hierarchy.Definition[$tpname[..$argTParams]]) { ..$extensions }""",
+               q"""implicit class $instname[..$tparams](module: chisel3.experimental.hierarchy.Instance[$tpname[..$argTParams]]) { ..$extensions } """),
            tpname)
         case q"$mods trait $tpname[..$tparams] extends { ..$earlydefns } with ..$parents { $self => ..$stats }" =>
           val defname = TypeName(tpname + c.freshName())
           val instname = TypeName(tpname + c.freshName())
           val (newStats, extensions) = processBody(stats)
+          val argTParams = tparams.map(_.name)
           (q"$mods trait $tpname[..$tparams] extends { ..$earlydefns } with ..$parents with chisel3.experimental.hierarchy.IsInstantiable { $self => ..$newStats }",
-           Seq(q"""implicit class $defname(module: chisel3.experimental.hierarchy.Definition[$tpname]) { ..$extensions }""",
-               q"""implicit class $instname(module: chisel3.experimental.hierarchy.Instance[$tpname]) { ..$extensions } """),
+           Seq(q"""implicit class $defname[..$tparams](module: chisel3.experimental.hierarchy.Definition[$tpname[..$argTParams]]) { ..$extensions }""",
+               q"""implicit class $instname[..$tparams](module: chisel3.experimental.hierarchy.Instance[$tpname[..$argTParams]]) { ..$extensions } """),
            tpname)
       }
       val newObj = objOpt match {

--- a/src/test/scala/chiselTests/experimental/hierarchy/Examples.scala
+++ b/src/test/scala/chiselTests/experimental/hierarchy/Examples.scala
@@ -192,4 +192,8 @@ object Examples {
   class ConcreteHasBlah() extends HasBlah {
     val blah = 10
   }
+  @instantiable
+  class HasTypeParams[D <: Data](d: D) extends Module {
+    @public val blah = Wire(d)
+  }
 }

--- a/src/test/scala/chiselTests/experimental/hierarchy/InstanceSpec.scala
+++ b/src/test/scala/chiselTests/experimental/hierarchy/InstanceSpec.scala
@@ -144,6 +144,15 @@ class InstanceSpec extends ChiselFunSpec with Utils {
       val (_, annos) = getFirrtlAndAnnos(new Top)
       annos should contain (MarkAnnotation("~Top|AddOneWithAnnotation>innerWire".rt, "innerWire"))
     }
+    it("1.11: should work on things with type parameters"){
+      class Top extends Module {
+        val definition = Definition(new HasTypeParams[UInt](UInt(3.W)))
+        val i0 = Instance(definition)
+        mark(i0.blah, "blah")
+      }
+      val (_, annos) = getFirrtlAndAnnos(new Top)
+      annos should contain (MarkAnnotation("~Top|Top/i0:HasTypeParams>blah".rt, "blah"))
+    }
   }
   describe("2: Annotations on designs not in the same chisel compilation") {
     it("2.0: should work on an innerWire, marked in a different compilation") {


### PR DESCRIPTION
### Contributor Checklist

- [N/A] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [N/A] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [N/A] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
 - bug fix 
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->
Lets `@instantiable` be used on classes with type parameters properly.

#### Backend Code Generation Impact

None

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
 - Squash: The PR will be squashed and merged (choose this if you have no preference.)
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->


### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.3.x`, [small] API extension: `3.4.x`, API modification or big change: `3.5.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
