### PR TITLE
Move annotations to firrtl

### DIFF
--- a/core/src/main/scala/chisel3/StrongEnum.scala
+++ b/core/src/main/scala/chisel3/StrongEnum.scala
@@ -15,54 +15,20 @@ import firrtl.annotations._
 
 
 object EnumAnnotations {
-  /** An annotation for strong enum instances that are ''not'' inside of Vecs
-    *
-    * @param target the enum instance being annotated
-    * @param enumTypeName the name of the enum's type (e.g. ''"mypackage.MyEnum"'')
-    */
-  case class EnumComponentAnnotation(target: Named, enumTypeName: String) extends SingleTargetAnnotation[Named] {
-    def duplicate(n: Named): EnumComponentAnnotation = this.copy(target = n)
-  }
+  type EnumComponentAnnotation = firrtl.annotations.EnumComponentAnnotation
+  val EnumComponentAnnotation = firrtl.annotations.EnumComponentAnnotation
+  type EnumDefAnnotation = firrtl.annotations.EnumDefAnnotation
+  val EnumDefAnnotation = firrtl.annotations.EnumDefAnnotation
+  type EnumVecAnnotation = firrtl.annotations.EnumVecAnnotation
+  val EnumVecAnnotation = firrtl.annotations.EnumVecAnnotation
 
   case class EnumComponentChiselAnnotation(target: InstanceId, enumTypeName: String) extends ChiselAnnotation {
     def toFirrtl: EnumComponentAnnotation = EnumComponentAnnotation(target.toNamed, enumTypeName)
   }
 
-  /** An annotation for Vecs of strong enums.
-    *
-    * The ''fields'' parameter deserves special attention, since it may be difficult to understand. Suppose you create a the following Vec:
-
-    *               {{{
-    *               VecInit(new Bundle {
-    *                 val e = MyEnum()
-    *                 val b = new Bundle {
-    *                   val inner_e = MyEnum()
-    *                 }
-    *                 val v = Vec(3, MyEnum())
-    *               }
-    *               }}}
-    *
-    *               Then, the ''fields'' parameter will be: ''Seq(Seq("e"), Seq("b", "inner_e"), Seq("v"))''. Note that for any Vec that doesn't contain Bundles, this field will simply be an empty Seq.
-    *
-    * @param target the Vec being annotated
-    * @param typeName the name of the enum's type (e.g. ''"mypackage.MyEnum"'')
-    * @param fields a list of all chains of elements leading from the Vec instance to its inner enum fields.
-    *
-    */
-  case class EnumVecAnnotation(target: Named, typeName: String, fields: Seq[Seq[String]]) extends SingleTargetAnnotation[Named] {
-    def duplicate(n: Named): EnumVecAnnotation = this.copy(target = n)
-  }
-
   case class EnumVecChiselAnnotation(target: InstanceId, typeName: String, fields: Seq[Seq[String]]) extends ChiselAnnotation {
     override def toFirrtl: EnumVecAnnotation = EnumVecAnnotation(target.toNamed, typeName, fields)
   }
-
-  /** An annotation for enum types (rather than enum ''instances'').
-    *
-    * @param typeName the name of the enum's type (e.g. ''"mypackage.MyEnum"'')
-    * @param definition a map describing which integer values correspond to which enum names
-    */
-  case class EnumDefAnnotation(typeName: String, definition: Map[String, BigInt]) extends NoTargetAnnotation
 
   case class EnumDefChiselAnnotation(typeName: String, definition: Map[String, BigInt]) extends ChiselAnnotation {
     override def toFirrtl: Annotation = EnumDefAnnotation(typeName, definition)


### PR DESCRIPTION
This PR depends on chipsalliance/firrtl#2397, which will make chipsalliance/firrtl#2397 not to reverse depend on chisel. 
### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [ ] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [ ] Did you state the API impact?
- [ ] Did you specify the code generation impact?
- [ ] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement
<!--   - code refactoring                   -->

#### API Impact

move apis to firrtl(maybe need deprecate them?)

#### Backend Code Generation Impact

none

#### Desired Merge Strategy
- Squash: The PR will be squashed and merged (choose this if you have no preference.

#### Release Notes

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.3.x`, [small] API extension: `3.4.x`, API modification or big change: `3.5.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
