### PR TITLE
lazy val for width in BitSetFamily

### DIFF
--- a/src/main/scala/chisel3/util/BitPat.scala
+++ b/src/main/scala/chisel3/util/BitPat.scala
@@ -119,11 +119,12 @@ object BitPat {
   * "b10001".U === BitPat("b101??") // evaluates to false.B
   * }}}
   */
-sealed class BitPat(val value: BigInt, val mask: BigInt, override val width: Int) extends BitSet with SourceInfoDoc {
+sealed class BitPat(val value: BigInt, val mask: BigInt, w: Int) extends BitSet with SourceInfoDoc {
   val onSet = value & mask
   val offSet = ~value & mask
+  override lazy val width = w
 
-  def getWidth: Int = width
+  def getWidth: Int = w
   def apply(x: Int): BitPat = macro SourceInfoTransform.xArg
   def apply(x: Int, y: Int): BitPat = macro SourceInfoTransform.xyArg
   def === (that: UInt): Bool = macro SourceInfoTransform.thatArg

--- a/src/main/scala/chisel3/util/BitSet.scala
+++ b/src/main/scala/chisel3/util/BitSet.scala
@@ -4,10 +4,12 @@ package chisel3.util
 
 trait BitSetFamily { bsf =>
   val terms: Set[BitSet]
-  assert(terms.map(_.width).size < 1)
 
   // set width = 0 if terms is empty.
-  val width: Int = terms.headOption.map(_.width).getOrElse(0)
+  lazy val width: Int = {
+    assert(terms.map(_.width).size < 1)
+    terms.headOption.map(_.width).getOrElse(0)
+  }
 
   override def toString: String = terms.toSeq.sortBy((t: BitSet) => (t.onSet, t.offSet)).mkString("\n")
 
@@ -56,7 +58,7 @@ trait BitSet extends BitSetFamily { b =>
     new BitSet {
       val onSet:          BigInt = b.onSet & that.onSet
       val offSet:         BigInt = b.offSet & that.offSet
-      override val width: Int = b.width
+      override lazy val width: Int = b.width
     }
   }
 
@@ -65,7 +67,7 @@ trait BitSet extends BitSetFamily { b =>
     new BitSet {
       val onSet:          BigInt = b.onSet & ~that.onSet
       val offSet:         BigInt = b.offSet & ~that.offSet
-      override val width: Int = b.width
+      override lazy val width: Int = b.width
     }
   }
 


### PR DESCRIPTION
    This avoids early dereference into term: Set[BitSet] during
    initiation of a BitSet object, which will raise a Null
    dereference exception

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [ ] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [ ] Did you state the API impact?
- [ ] Did you specify the code generation impact?
- [ ] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
 - bug fix                            
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.3.x`, [small] API extension: `3.4.x`, API modification or big change: `3.5.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
