### PR TITLE
[docs] Improve tieoff Bundle to 0

### DIFF
--- a/docs/src/cookbooks/cookbook.md
+++ b/docs/src/cookbooks/cookbook.md
@@ -88,13 +88,14 @@ you are tying off, you can use `chiselTypeOf`:
 
 ```scala mdoc:silent:reset
 import chisel3._
+import chisel3.stage.ChiselStage
 
 class MyBundle extends Bundle {
   val foo = UInt(4.W)
   val bar = Vec(4, UInt(1.W))
 }
 
-class Foo(typ: Data) extends RawModule {
+class Foo(typ: MyBundle) extends RawModule {
   val bundleA = IO(Output(typ))
   val bundleB = IO(Output(typ))
   
@@ -107,9 +108,7 @@ class Foo(typ: Data) extends RawModule {
   bundleB := 0.U.asTypeOf(chiselTypeOf(bundleB)) 
 }
 
-class Bar extends RawModule {
-  val foo = Module(new Foo(new MyBundle()))
-}
+ChiselStage.emitVerilog(new Foo(new MyBundle))
 ```
 ### How do I create a Vec of Bools from a UInt?
 


### PR DESCRIPTION
Previously, the example had an extra wrapping module that led
to the interesting example getting optimized away.

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [NA] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

   - documentation

#### API Impact

None

#### Backend Code Generation Impact

None

#### Desired Merge Strategy

   - Squash

#### Release Notes

Improve Bundle tieoff to 0 cookbook example

### Reviewer Checklist (only modified by reviewer)
- [x] Did you add the appropriate labels?
- [x] Did you mark the proper milestone (Bug fix: `3.3.x`, [small] API extension: `3.4.x`, API modification or big change: `3.5.0`)?
- [x] Did you review?
- [x] Did you check whether all relevant Contributor checkboxes have been checked?
- [x] Did you mark as `Please Merge`?
