### PR TITLE
Use `0` instead of `?` to represent "not in ON set" in the results of QMC minimizer

### DIFF
--- a/src/main/scala/chisel3/util/experimental/decode/QMCMinimizer.scala
+++ b/src/main/scala/chisel3/util/experimental/decode/QMCMinimizer.scala
@@ -222,7 +222,7 @@ object QMCMinimizer extends Minimizer {
 
     // for all outputs
     val minimized = (0 until m).flatMap(i => {
-      val outputBp = BitPat("b" + "?" * (m - i - 1) + "1" + "?" * i)
+      val outputBp = BitPat("b" + "0" * (m - i - 1) + "1" + "0" * i)
 
       // Minterms, implicants that makes the output to be 1
       val mint: Seq[Implicant] = table.table.filter { case (_, t) => t.mask.testBit(i) && t.value.testBit(i) }.keys.map(toImplicant).toSeq
@@ -287,7 +287,7 @@ object QMCMinimizer extends Minimizer {
         tb.copy(table = tb.table.map { case (k, v) =>
           if (k == t._1) {
             def ones(bitPat: BitPat) = bitPat.rawString.zipWithIndex.collect{case ('1', x) => x}
-            (k, BitPat("b" + (0 until v.getWidth).map(i => if ((ones(v) ++ ones(t._2)).contains(i)) "1" else "?").mkString))
+            (k, BitPat("b" + (0 until v.getWidth).map(i => if ((ones(v) ++ ones(t._2)).contains(i)) "1" else "0").mkString))
           } else (k, v)
         })
       } else {


### PR DESCRIPTION
This PR changes the symbol which represent "not in ON set" in the results of QMC minimizer from `?` to `0`. The current behavior is correct when using minimizer alone and aligned with the behavior of espresso minimizer.
This PR does not change the behavior of the `decode` api nor verilog codes generated by it because the assumpsion made in QMC previously (`0` and `?` are treated the same way) about the `pla` api is correct and `decode` always use `pla` to generate actual hardware.


### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [ ] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [ ] Did you state the API impact?
- [ ] Did you specify the code generation impact?
- [ ] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
- bug fix
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

#### Backend Code Generation Impact

Does this change any generated Verilog?
No.
<!-- How does it change it or in what circumstances would it?  -->

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
- Squash: The PR will be squashed and merged
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.3.x`, [small] API extension: `3.4.x`, API modification or big change: `3.5.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
