### PR TITLE
refactor Queue.hasFlush: Boolean to Queue.flush: Option[Bool].

### DIFF
--- a/src/main/scala/chisel3/util/Decoupled.scala
+++ b/src/main/scala/chisel3/util/Decoupled.scala
@@ -315,7 +315,7 @@ object Queue
       deq
     } else {
       val q = Module(new Queue(chiselTypeOf(enq.bits), entries, pipe, flow, useSyncReadMem, flush.isDefined))
-      q.io.flush.foreach(_ := flush.getOrElse(false.B))
+      q.io.flush.zip(flush).foreach(f => f._1 := f._2)
       q.io.enq.valid := enq.valid // not using <> so that override is allowed
       q.io.enq.bits := enq.bits
       enq.ready := q.io.enq.ready


### PR DESCRIPTION
Using factory `Queue(..., hasFlush = true)` won't take effects, since in the `Queue.apply` API, `Queue` Module is not exposed, thus even user defines `hasFlush = true`, there is no place for them to give the `flush` signal.
This commit fix this, refactor `Queue.hasFlush: Boolean` to `Queue.flush: Option[Bool]`, makes user be able to pass the flush signal into `Queue` Module.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement
- bug fix

#### API Impact

change API Queue.apply API

#### Backend Code Generation Impact
None

#### Desired Merge Strategy
- Squash: The PR will be squashed and merged (choose this if you have no preference. 

#### Release Notes
None

### Reviewer Checklist (only modified by reviewer)
- [x] Did you add the appropriate labels?
- [x] Did you mark the proper milestone (Bug fix: `3.3.x`, [small] API extension: `3.4.x`, API modification or big change: `3.5.0`)?
- [x] Did you review?
- [x] Did you check whether all relevant Contributor checkboxes have been checked?
- [x] Did you mark as `Please Merge`?


