### PR TITLE
Remove deprecation note from ListLookup

### DIFF
--- a/src/main/scala/chisel3/util/Lookup.scala
+++ b/src/main/scala/chisel3/util/Lookup.scala
@@ -7,10 +7,6 @@ import chisel3._
 /** For each element in a list, muxes (looks up) between cases (one per list element) based on a
   * common address.
   *
-  * @note This appears to be an odd, specialized operator that we haven't seen used much, and seems
-  *       to be a holdover from chisel2. This may be deprecated and removed, usage is not
-  *       recommended.
-  *
   * @param addr common select for cases, shared (same) across all list elements
   * @param default default value for each list element, should the address not match any case
   * @param mapping list of cases, where each entry consists of a [[chisel3.util.BitPat BitPath]] (compared against addr) and
@@ -37,10 +33,6 @@ object ListLookup {
 
 /** Muxes between cases based on whether an address matches any pattern for a case.
   * Similar to [[chisel3.util.MuxLookup MuxLookup]], but uses [[chisel3.util.BitPat BitPat]] for address comparison.
-  *
-  * @note This appears to be an odd, specialized operator that we haven't seen used much, and seems
-  *       to be a holdover from chisel2. This may be deprecated and removed, usage is not
-  *       recommended.
   *
   * @param addr address to select between cases
   * @param default default value should the address not match any case


### PR DESCRIPTION
The comment on `ListLookup` documentation does not reflect current use of the API. As seen, the it's a pattern in use for Decoders on multiple cores like:

- DinoCPU: https://github.com/jlpteaching/dinocpu/blob/124cc110410f7daae924301c1e33157f6b02d3d5/src/main/scala/components/control.scala#L50
- ChiselV: https://github.com/carlosedp/chiselv/blob/f73d654b2d50546d87e565ca4b152871d572fec8/src/main/scala/Decoder.scala#L29
- Chiselwatt: https://github.com/antonblanchard/chiselwatt/blob/c8336341125c146336b2ddfb104382733e08fc19/src/main/scala/Control.scala#L296

And many others.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

- documentation

#### API Impact

No impact, documentation change.

#### Backend Code Generation Impact

No impact.

#### Desired Merge Strategy

- Squash: The PR will be squashed and merged (choose this if you have no preference.

#### Release Notes

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.3.x`, [small] API extension: `3.4.x`, API modification or big change: `3.5.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
