### PR TITLE
Deprecate ListLookup.

### DIFF
--- a/src/main/scala/chisel3/util/Lookup.scala
+++ b/src/main/scala/chisel3/util/Lookup.scala
@@ -26,6 +26,7 @@ import chisel3._
   * // Note: if given address 0.U, the above would hardware evaluate to List(10.U, 11.U, 12.U)
   * }}}
   */
+@deprecated("please switching to chisel3.util.experimental.decode API, this API will be removed in Chisel 3.6", "Chisel 3.5")
 object ListLookup {
   def apply[T <: Data](addr: UInt, default: List[T], mapping: Array[(BitPat, List[T])]): List[T] = {
     val map = mapping.map(m => (m._1 === addr, m._2))
@@ -47,6 +48,7 @@ object ListLookup {
   * @param mapping list of cases, where each entry consists of a [[chisel3.util.BitPat BitPat]] (compared against addr) and the
   *          output value if the BitPat matches
   */
+@deprecated("please switching to chisel3.util.experimental.decode API, this API will be removed in Chisel 3.6", "Chisel 3.5")
 object Lookup {
   def apply[T <: Bits](addr: UInt, default: T, mapping: Seq[(BitPat, T)]): T =
     ListLookup(addr, List(default), mapping.map(m => (m._1, List(m._2))).toArray).head


### PR DESCRIPTION
This API considers harmful and misleading to users.
Most of userd use this API as decoder, however this is a sequentially cascaded Mux without logic minimization, synthesizer won't aware of the ME(mutually exclusive) from this API, which provides a bad PPA for hardware designing.
Real decoder should be a minimizer+PLA which has been implemented in chisel3.util.experimental.decode.

My proposal is:
1. deprecating this API in Chisel 3.5
2. moving decoder API out of experimental at the last minor version of Chisel 3.5 
3. delete this API in Chisel 3.6.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [ ] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [ ] Did you state the API impact?
- [ ] Did you specify the code generation impact?
- [ ] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement
- code cleanup

#### API Impact
deprecate chisel3.utils.ListLookup

#### Backend Code Generation Impact
None

#### Desired Merge Strategy
- Squash: The PR will be squashed and merged (choose this if you have no preference.

#### Release Notes
chisel3.util.ListLookup is replaced by chisel3.util.experimental.decode

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.3.x`, [small] API extension: `3.4.x`, API modification or big change: `3.5.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
