### PR TITLE
Better name in ChiselTest for getting the value of Data (peek())

### DIFF
--- a/core/src/main/scala/chisel3/Data.scala
+++ b/core/src/main/scala/chisel3/Data.scala
@@ -665,6 +665,12 @@ abstract class Data extends HasId with NamedComponent with SourceInfoDoc {
    */
   def litValue: BigInt = litOption.get
 
+  /**
+    * Returns the value as BitInt
+    * @return
+    */
+  def toBigInt: BigInt = litOption.get
+
   @deprecated("Calling this function with an empty argument list is invalid in Scala 3. Use the form without parentheses instead", "Chisel 3.5")
   def litValue(dummy: Int*): BigInt = litValue
 

--- a/src/test/scala/chiselTests/LiteralExtractorSpec.scala
+++ b/src/test/scala/chiselTests/LiteralExtractorSpec.scala
@@ -30,6 +30,20 @@ class LiteralExtractorSpec extends ChiselFlatSpec {
     assert(-2.25.F(2.BP).litValue === BigInt("-1001", 2))
   }
 
+  "toBigInt" should "return the literal value" in {
+    assert(0.U.toBigInt === BigInt(0))
+    assert(1.U.toBigInt === BigInt(1))
+    assert(42.U.toBigInt === BigInt(42))
+    assert(42.U.toBigInt === 42.U.litValue)
+
+    assert(0.S.toBigInt === BigInt(0))
+    assert(-1.S.toBigInt === BigInt(-1))
+    assert(-42.S.toBigInt === BigInt(-42))
+
+    assert(true.B.toBigInt === BigInt(1))
+    assert(false.B.toBigInt === BigInt(0))
+  }
+
   "litToBoolean" should "return the literal value" in {
     assert(true.B.litToBoolean === true)
     assert(false.B.litToBoolean === false)


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
  - new feature/API       

#### API Impact

Additional API to have a better name in ChiselTest. See also: https://github.com/ucb-bar/chisel-testers2/issues/298

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
  - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.3.x`, [small] API extension: `3.4.x`, API modification or big change: `3.5.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
