### PR TITLE
Update REAMDE instructions for building projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,11 +113,18 @@ If you like a textbook to learn Chisel and also a bit of digital design in gener
 
 See [the setup instructions](SETUP.md) for how to set up your environment to build Chisel locally.
 
-When you're ready to build your own circuits in Chisel, **we recommend starting from the [Chisel Template](https://github.com/freechipsproject/chisel-template) repository**, which provides a pre-configured project, example design, and testbench. Follow the [chisel-template readme](https://github.com/freechipsproject/chisel-template) to get started.
+When you're ready to build your own circuits in Chisel, **we recommend starting from the [Chisel Template](https://github.com/freechipsproject/chisel-template) repository**, which provides a pre-configured project, example design, and testbench.
+Follow the [chisel-template README](https://github.com/freechipsproject/chisel-template) to get started.
 
-If you insist on setting up your own project, the magic SBT lines are:
+If you insist on setting up your own project from scratch, your project needs to depend on both the chisel3-plugin (Scalac plugin) and the chisel3 library.
+For example, in SBT this could be expressed as:
 ```scala
+// build.sbt
+scalaVersion := "2.12.13"
+addCompilerPlugin("edu.berkeley.cs" % "chisel3-plugin" % "3.4.4" cross CrossVersion.full)
 libraryDependencies += "edu.berkeley.cs" %% "chisel3" % "3.4.4"
+scalacOptions += "-Xsource:2.11"
+// We also recommend using chiseltest for writing unit tests 
 libraryDependencies += "edu.berkeley.cs" %% "chiseltest" % "0.3.4" % "test"
 ```
 ### Guide For New Contributors


### PR DESCRIPTION
Include plugin in instructions since it will be required in 3.5.
Also make sure the example actually works.

Needed `-Xsource:2.11` to compile normal Chisel using a structurally-typed IO Bundle. Also the chisel3 plugin is not published for 2.12.14 and 2.12.15 for chisel3 3.4.4 so we need to pin the Scala version as well.

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [NA] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [NA] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

 - documentation   

#### API Impact

No impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

  - Squash

#### Release Notes

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.3.x`, [small] API extension: `3.4.x`, API modification or big change: `3.5.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
