### PR TITLE
catch None.get in BitPat.apply(x: UInt): BitPat

### DIFF
--- a/src/main/scala/chisel3/util/BitPat.scala
+++ b/src/main/scala/chisel3/util/BitPat.scala
@@ -90,7 +90,7 @@ object BitPat {
     */
   def apply(x: UInt): BitPat = {
     val len = if (x.isWidthKnown) x.getWidth else 0
-    apply("b" + x.litValue.toString(2).reverse.padTo(len, "0").reverse.mkString)
+    apply("b" + x.litOption.getOrElse(throw new ChiselException(s"$x is not a literal, BitPat.apply(x: UInt) only accept literal")).toString(2).reverse.padTo(len, "0").reverse.mkString)
   }
 
   implicit class fromUIntToBitPatComparable(x: UInt) extends SourceInfoDoc {

--- a/src/main/scala/chisel3/util/BitPat.scala
+++ b/src/main/scala/chisel3/util/BitPat.scala
@@ -89,11 +89,9 @@ object BitPat {
     * @note the UInt must be a literal
     */
   def apply(x: UInt): BitPat = {
+    require(x.isLit, s"$x is not a literal, BitPat.apply(x: UInt) only accepts literals")
     val len = if (x.isWidthKnown) x.getWidth else 0
-    x.litOption match {
-      case Some(lit) => apply("b" + lit.toString(2).reverse.padTo(len, "0").reverse.mkString)
-      case None => throwException(s"$x is not a literal, BitPat.apply(x: UInt) only accepts literals")
-    }
+    apply("b" + x.litValue.toString(2).reverse.padTo(len, "0").reverse.mkString)
   }
 
   implicit class fromUIntToBitPatComparable(x: UInt) extends SourceInfoDoc {

--- a/src/main/scala/chisel3/util/BitPat.scala
+++ b/src/main/scala/chisel3/util/BitPat.scala
@@ -90,7 +90,10 @@ object BitPat {
     */
   def apply(x: UInt): BitPat = {
     val len = if (x.isWidthKnown) x.getWidth else 0
-    apply("b" + x.litOption.getOrElse(throw new ChiselException(s"$x is not a literal, BitPat.apply(x: UInt) only accept literal")).toString(2).reverse.padTo(len, "0").reverse.mkString)
+    x.litOption match {
+      case Some(lit) => apply("b" + lit.toString(2).reverse.padTo(len, "0").reverse.mkString)
+      case None => throwException(s"$x is not a literal, BitPat.apply(x: UInt) only accepts literals")
+    }
   }
 
   implicit class fromUIntToBitPatComparable(x: UInt) extends SourceInfoDoc {

--- a/src/test/scala/chiselTests/util/BitPatSpec.scala
+++ b/src/test/scala/chiselTests/util/BitPatSpec.scala
@@ -28,6 +28,14 @@ class BitPatSpec extends AnyFlatSpec with Matchers {
     (BitPat.Y(4) ## BitPat.dontCare(3) ## BitPat.N(2)).toString should be (s"BitPat(1111???00)")
   }
 
+  it should "throw when BitPat apply to a Hardware" in {
+    intercept[chisel3.internal.ChiselException]{
+      chisel3.stage.ChiselStage.emitChirrtl(new chisel3.Module {
+        BitPat(chisel3.Reg(chisel3.Bool()))
+      })
+    }
+  }
+
   it should "index and return new BitPat" in {
     val b = BitPat("b1001???")
     b(0) should be(BitPat.dontCare(1))

--- a/src/test/scala/chiselTests/util/BitPatSpec.scala
+++ b/src/test/scala/chiselTests/util/BitPatSpec.scala
@@ -29,7 +29,7 @@ class BitPatSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "throw when BitPat apply to a Hardware" in {
-    intercept[chisel3.internal.ChiselException]{
+    intercept[java.lang.IllegalArgumentException]{
       chisel3.stage.ChiselStage.emitChirrtl(new chisel3.Module {
         BitPat(chisel3.Reg(chisel3.Bool()))
       })


### PR DESCRIPTION
Resolves #2268, thanks @Tang-Haojin 
### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement
- bug fix

#### API Impact
None

#### Backend Code Generation Impact
None

#### Desired Merge Strategy
- Rebase: You will rebase the PR onto master and it will be merged with a merge commit.

#### Release Notes
None

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.3.x`, [small] API extension: `3.4.x`, API modification or big change: `3.5.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
