### PR TITLE
[docs] Remove body from minimizing output bits recipe

### DIFF
--- a/docs/src/cookbooks/cookbook.md
+++ b/docs/src/cookbooks/cookbook.md
@@ -431,6 +431,9 @@ Unlike `Vecs` which represent a singular Chisel type and must have the same widt
 
 ```scala mdoc:verilog
 chisel3.stage.ChiselStage.emitVerilog(new CountBits(4))
+  // remove the body of the module by removing everything after ');'
+  .split("\\);")
+  .head + ");\n"
 ```
 
 ## Predictable Naming


### PR DESCRIPTION
Remove the body from the emitted Verilog. This was the original intent
of the example, and it avoids an issue where Jekyll was not able to
render the Markdown file due to Verilog concatenation looking like a
variable escape.

This works around an issue (see https://github.com/freechipsproject/www.chisel-lang.org/pull/216) where https://github.com/chipsalliance/chisel3/pull/2278 is not yet live on the website because Jekyll thinks Verilog concatenation in the code example is a variable escape. We could work around this in different ways, but @oharboe's original intent (see https://github.com/chipsalliance/chisel3/pull/2278#discussion_r762405572) was that the Verilog would just have the ports anyway

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [NA] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

  - documentation  
   
#### API Impact

No impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

  - Squash
  - 
#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.3.x`, [small] API extension: `3.4.x`, API modification or big change: `3.5.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
