### PR TITLE
reduceTree() now operates on Seq

### DIFF
--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -327,11 +327,11 @@ sealed class Vec[T <: Data] private[chisel3] (gen: => T, val length: Int)
   def do_reduceTree(redOp: (T, T) => T, layerOp: (T) => T = (x: T) => x)
                    (implicit sourceInfo: SourceInfo, compileOptions: CompileOptions) : T = {
     require(!isEmpty, "Cannot apply reduction on a vec of size 0")
-    var curLayer = this
+    var curLayer : Seq[T] = this
     while (curLayer.length > 1) {
-      curLayer = VecInit(curLayer.grouped(2).map( x =>
+      curLayer = curLayer.grouped(2).map( x =>
         if (x.length == 1) layerOp(x(0)) else redOp(x(0), x(1))
-      ).toSeq)
+      ).toSeq
     }
     curLayer(0)
   }


### PR DESCRIPTION
preserves input/output information of the type being reduced.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.3.x`, [small] API extension: `3.4.x`, API modification or big change: `3.5.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
