### PR TITLE
[docs] Update versioning appendix to include 3.5

### DIFF
--- a/docs/src/appendix/versioning.md
+++ b/docs/src/appendix/versioning.md
@@ -17,19 +17,23 @@ Historically, due to a mistake in versioning with chisel-iotesters as well as so
 the compatible versions of Chisel-related projects has not been obvious.
 We are taking steps to improve the situation by bringing the major versions more in line (the `B` part in `A.B.C`),
 but the inconsistencies remain in previously published versions.
+Beginning with Chisel 3.5, the major versions for all projects are aligned on `A.5`).
 
 Please use the following table to determine which versions of the related projects are compatible.
 In particular, versions of projects in this table were compiled against the version of any dependencies listed in the same row.
 For example, `chisel-iotesters` version 1.4 was compiled against `chisel3` version 3.3.
 
-| chisel3 | chiseltest | chisel-iotesters | firrtl | treadle | diagrammer | firrtl-interpreter<sup>2</sup> |
-| ------- | ---------- | ---------------- | ------ | ------- | ---------- | ----- |
-| 3.4     | 0.3        | 1.5              | 1.4    | 1.3     | 1.3        | 1.4 |
-| 3.3     | 0.2        | 1.4              | 1.3    | 1.2     | 1.2        | 1.3 |
-| 3.2     | 0.1<sup>1</sup>  | 1.3        | 1.2    | 1.1     | 1.1        | 1.2 |
-| 3.1     | -          | 1.2              | 1.1    | 1.0     | 1.0        | 1.1 |
-| 3.0     | -          | 1.1              | 1.0    | -<sup>3</sup> | -    | 1.0 |
+| chisel3 | chiseltest      | chisel-iotesters<sup>3</sup> | firrtl | treadle | diagrammer | firrtl-interpreter<sup>2</sup> |
+| ------- | ----------      | ----------------             | ------ | ------- | ---------- | ----- |
+| 3.5     | 0.5<sup>4</sup> | 2.5<sup>5</sup>              | 1.5    | 1.5<sup>4</sup> | 1.5<sup>4</sup> | - |
+| 3.4     | 0.3             | 1.5                          | 1.4    | 1.3     | 1.3        | 1.4 |
+| 3.3     | 0.2             | 1.4                          | 1.3    | 1.2     | 1.2        | 1.3 |
+| 3.2     | 0.1<sup>1</sup> | 1.3                          | 1.2    | 1.1     | 1.1        | 1.2 |
+| 3.1     | -               | 1.2                          | 1.1    | 1.0     | 1.0        | 1.1 |
+| 3.0     | -               | 1.1                          | 1.0    | -       | -          | 1.0 |
 
 <sup>1</sup> chiseltest 0.1 was published under artifact name [chisel-testers2](https://search.maven.org/search?q=a:chisel-testers2_2.12) (0.2 was published under both artifact names)    
-<sup>2</sup> Replaced by Treadle, in maintenance mode only since version 1.1    
-<sup>3</sup> Treadle was preceded by the firrtl-interpreter    
+<sup>2</sup> Replaced by Treadle, in maintenance mode only since version 1.1, final version is 1.4    
+<sup>3</sup> Replaced by chiseltest, final version is 2.5    
+<sup>4</sup> chiseltest, treadle, and diagrammer skipped X.4 to have a consistent major version with Chisel    
+<sup>5</sup> chisel-iotesters skipped from 1.5 to 2.5 to have a consistent major version with Chisel    


### PR DESCRIPTION
Marked for backport so that this info is available on current website (especially since 3.5.0-RC1 has been released).

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [NA] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

- documentation        


#### API Impact

No impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

   - Squash

#### Release Notes


### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.3.x`, [small] API extension: `3.4.x`, API modification or big change: `3.5.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
