### PR TITLE
Improve exception message for aliased bundle fields

### DIFF
--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -33,7 +33,7 @@ sealed abstract class Aggregate extends Data {
         case b: Bundle =>
           // show groups of names of fields with duplicate id's
           // The sorts make the displayed order of fields deterministic and matching the order of occurrence in the Bundle.
-          // it's a bit convoluted but happens rarely and makes error easier to understand for user
+          // It's a bit convoluted but happens rarely and makes the error message easier to understand
           val dupNames = duplicates.toSeq.sortBy(_._id).map { duplicate =>
             b.elements
               .collect { case x if x._2._id == duplicate._id => x }

--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -42,7 +42,7 @@ sealed abstract class Aggregate extends Data {
               .mkString("(", ",", ")")
           }.mkString(",")
           throw new AliasedAggregateFieldException(
-            s"Bundle ${b.getClass} contains aliased fields named ${dupNames}"
+            s"${b.className} contains aliased fields named ${dupNames}"
           )
         case _ =>
           throw new AliasedAggregateFieldException(

--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -30,7 +30,7 @@ sealed abstract class Aggregate extends Data {
     val duplicates = getElements.groupBy(identity).collect { case (x, elts) if elts.size > 1 => x }
     if (!duplicates.isEmpty) {
       this match {
-        case b: Bundle =>
+        case b: Record =>
           // show groups of names of fields with duplicate id's
           // The sorts make the displayed order of fields deterministic and matching the order of occurrence in the Bundle.
           // It's a bit convoluted but happens rarely and makes the error message easier to understand
@@ -42,11 +42,11 @@ sealed abstract class Aggregate extends Data {
               .mkString("(", ",", ")")
           }.mkString(",")
           throw new AliasedAggregateFieldException(
-            s"Bundle $this contains aliased fields named ${dupNames}"
+            s"Bundle ${b.getClass} contains aliased fields named ${dupNames}"
           )
         case _ =>
           throw new AliasedAggregateFieldException(
-            s"Aggregate $this contains aliased fields $duplicates ${duplicates.mkString(",")}"
+            s"Aggregate ${this.getClass} contains aliased fields $duplicates ${duplicates.mkString(",")}"
           )
       }
     }

--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -32,7 +32,7 @@ sealed abstract class Aggregate extends Data {
       this match {
         case b: Bundle =>
           // show groups of names of fields with duplicate id's
-          // sorts are to make order of fields shown, deterministic and matching order of occurrence in bundle
+          // The sorts make the displayed order of fields deterministic and matching the order of occurrence in the Bundle.
           // it's a bit convoluted but happens rarely and makes error easier to understand for user
           val dupNames = duplicates.toSeq.sortBy(_._id).map { duplicate =>
             b.elements

--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -29,7 +29,26 @@ sealed abstract class Aggregate extends Data {
     val resolvedDirection = SpecifiedDirection.fromParent(parentDirection, specifiedDirection)
     val duplicates = getElements.groupBy(identity).collect { case (x, elts) if elts.size > 1 => x }
     if (!duplicates.isEmpty) {
-      throw new AliasedAggregateFieldException(s"Aggregate $this contains aliased fields $duplicates")
+      this match {
+        case b: Bundle =>
+          // show groups of names of fields with duplicate id's
+          // sorts are to make order of fields shown, deterministic and matching order of occurrence in bundle
+          // it's a bit convoluted but happens rarely and makes error easier to understand for user
+          val dupNames = duplicates.toSeq.sortBy(_._id).map { duplicate =>
+            b.elements
+              .collect { case x if x._2._id == duplicate._id => x }
+              .toSeq.sortBy(_._2._id)
+              .map(_._1).reverse
+              .mkString("(", ",", ")")
+          }.mkString(",")
+          throw new AliasedAggregateFieldException(
+            s"Bundle $this contains aliased fields named ${dupNames}"
+          )
+        case _ =>
+          throw new AliasedAggregateFieldException(
+            s"Aggregate $this contains aliased fields $duplicates ${duplicates.mkString(",")}"
+          )
+      }
     }
     for (child <- getElements) {
       child.bind(ChildBinding(this), resolvedDirection)

--- a/src/test/scala/chiselTests/BundleSpec.scala
+++ b/src/test/scala/chiselTests/BundleSpec.scala
@@ -117,11 +117,13 @@ class BundleSpec extends ChiselFlatSpec with BundleSpecUtils with Utils {
         val io = IO(Output(new Bundle {
           val a = UInt(8.W)
           val b = a
+          val c = SInt(8.W)
+          val d = c
         }))
         io.a := 0.U
         io.b := 1.U
       } }
-    }).getMessage should include("aliased fields")
+    }).getMessage should include("contains aliased fields named (a,b),(c,d)")
   }
 
   "Bundles" should "not have bound hardware" in {

--- a/src/test/scala/chiselTests/BundleSpec.scala
+++ b/src/test/scala/chiselTests/BundleSpec.scala
@@ -111,15 +111,17 @@ class BundleSpec extends ChiselFlatSpec with BundleSpecUtils with Utils {
     }
   }
 
-  "Bundles" should "not have aliased fields" in {
+  "Bundles" should "with aliased fields, should show a helpful error message" in {
+    class AliasedBundle extends Bundle {
+      val a = UInt(8.W)
+      val b = a
+      val c = SInt(8.W)
+      val d = c
+    }
+
     (the[ChiselException] thrownBy extractCause[ChiselException] {
       ChiselStage.elaborate { new Module {
-        val io = IO(Output(new Bundle {
-          val a = UInt(8.W)
-          val b = a
-          val c = SInt(8.W)
-          val d = c
-        }))
+        val io = IO(Output(new AliasedBundle))
         io.a := 0.U
         io.b := 1.U
       } }


### PR DESCRIPTION
Improve exception message for aliased bundle fields
- Shows groups of field names that share a common id (i.e. aliased)
- Show, as much as possible, them in the order that fields appear in bundle
- Updated BundleSpec's relevant tests

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [NA] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

Improves error message

#### API Impact

None

#### Backend Code Generation Impact

None

#### Desired Merge Strategy

Squash

#### Release Notes

The exception thrown when a bundle contains aliased field will now show the field names of the
aliased fields.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.3.x`, [small] API extension: `3.4.x`, API modification or big change: `3.5.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
