### PR TITLE
Fix unidoc

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
         uses: coursier/cache-action@v5
       - name: Documentation (Scala 2.12 only)
         if: startsWith(matrix.scala, '2.12')
-        run: sbt ++${{ matrix.scala }} docs/mdoc
+        run: sbt ++${{ matrix.scala }} docs/mdoc unidoc
       - name: Test
         run: sbt ++${{ matrix.scala }} test
       - name: Binary compatibility

--- a/build.sbt
+++ b/build.sbt
@@ -218,7 +218,13 @@ lazy val chisel = (project in file(".")).
           }
         s"https://github.com/chipsalliance/chisel3/tree/$branch€{FILE_PATH_EXT}#L€{FILE_LINE}"
       }
-    )
+    ) ++
+    // Suppress compiler plugin for source files in core
+    // We don't need this in regular compile because we just don't add the chisel3-plugin to core's scalacOptions
+    // This works around an issue where unidoc uses the exact same arguments for all source files.
+    // This is probably fundamental to how ScalaDoc works so there may be no solution other than this workaround.
+    // See https://github.com/sbt/sbt-unidoc/issues/107
+    (core / Compile / sources).value.map("-P:chiselplugin:INTERNALskipFile:" + _)
   )
 
 // tests elaborating and executing/formally verifying a Chisel circuit with chiseltest

--- a/plugin/src/main/scala/chisel3/internal/plugin/BundleComponent.scala
+++ b/plugin/src/main/scala/chisel3/internal/plugin/BundleComponent.scala
@@ -26,14 +26,10 @@ private[plugin] class BundleComponent(val global: Global, arguments: ChiselPlugi
       // instead we just check the version and if its an early Scala version, the plugin does nothing
       val scalaVersion = scala.util.Properties.versionNumberString.split('.')
       val scalaVersionOk = scalaVersion(0).toInt == 2 && scalaVersion(1).toInt >= 12
-      if (scalaVersionOk && arguments.useBundlePlugin) {
+      if (scalaVersionOk) {
         unit.body = new MyTypingTransformer(unit).transform(unit.body)
       } else {
-        val reason = if (!scalaVersionOk) {
-          s"invalid Scala version '${scala.util.Properties.versionNumberString}'"
-        } else {
-          s"not enabled via '${arguments.useBundlePluginFullOpt}'"
-        }
+        val reason = s"invalid Scala version '${scala.util.Properties.versionNumberString}'"
         // Enable this with scalacOption '-Ylog:chiselbundlephase'
         global.log(s"Skipping BundleComponent on account of $reason.")
       }

--- a/plugin/src/main/scala/chisel3/internal/plugin/BundleComponent.scala
+++ b/plugin/src/main/scala/chisel3/internal/plugin/BundleComponent.scala
@@ -22,16 +22,8 @@ private[plugin] class BundleComponent(val global: Global, arguments: ChiselPlugi
   private class BundlePhase(prev: Phase) extends StdPhase(prev) {
     override def name: String = phaseName
     def apply(unit: CompilationUnit): Unit = {
-      // This plugin doesn't work on Scala 2.11 nor Scala 3. Rather than complicate the sbt build flow,
-      // instead we just check the version and if its an early Scala version, the plugin does nothing
-      val scalaVersion = scala.util.Properties.versionNumberString.split('.')
-      val scalaVersionOk = scalaVersion(0).toInt == 2 && scalaVersion(1).toInt >= 12
-      if (scalaVersionOk) {
+      if (ChiselPlugin.runComponent(global, arguments)(unit)) {
         unit.body = new MyTypingTransformer(unit).transform(unit.body)
-      } else {
-        val reason = s"invalid Scala version '${scala.util.Properties.versionNumberString}'"
-        // Enable this with scalacOption '-Ylog:chiselbundlephase'
-        global.log(s"Skipping BundleComponent on account of $reason.")
       }
     }
   }

--- a/plugin/src/main/scala/chisel3/internal/plugin/ChiselComponent.scala
+++ b/plugin/src/main/scala/chisel3/internal/plugin/ChiselComponent.scala
@@ -11,7 +11,7 @@ import scala.tools.nsc.transform.TypingTransformers
 
 // The component of the chisel plugin. Not sure exactly what the difference is between
 //   a Plugin and a PluginComponent.
-class ChiselComponent(val global: Global) extends PluginComponent with TypingTransformers {
+class ChiselComponent(val global: Global, arguments: ChiselPluginArguments) extends PluginComponent with TypingTransformers {
   import global._
   val runsAfter: List[String] = List[String]("typer")
   val phaseName: String = "chiselcomponent"
@@ -19,10 +19,7 @@ class ChiselComponent(val global: Global) extends PluginComponent with TypingTra
   class ChiselComponentPhase(prev: Phase) extends StdPhase(prev) {
     override def name: String = phaseName
     def apply(unit: CompilationUnit): Unit = {
-      // This plugin doesn't work on Scala 2.11 nor Scala 3. Rather than complicate the sbt build flow,
-      // instead we just check the version and if its an early Scala version, the plugin does nothing
-      val scalaVersion = scala.util.Properties.versionNumberString.split('.')
-      if (scalaVersion(0).toInt == 2 && scalaVersion(1).toInt >= 12) {
+      if (ChiselPlugin.runComponent(global, arguments)(unit)) {
         unit.body = new MyTypingTransformer(unit).transform(unit.body)
       }
     }

--- a/plugin/src/main/scala/chisel3/internal/plugin/ChiselPlugin.scala
+++ b/plugin/src/main/scala/chisel3/internal/plugin/ChiselPlugin.scala
@@ -7,14 +7,18 @@ import nsc.Global
 import nsc.plugins.{Plugin, PluginComponent}
 import scala.reflect.internal.util.NoPosition
 
-private[plugin] case class ChiselPluginArguments(var useBundlePlugin: Boolean = true) {
+private[plugin] case class ChiselPluginArguments() {
   def useBundlePluginOpt = "useBundlePlugin"
-  def useBundlePluginFullOpt = s"-P:chiselplugin:$useBundlePluginOpt"
+  def useBundlePluginFullOpt = s"-P:${ChiselPlugin.name}:$useBundlePluginOpt"
+}
+
+object ChiselPlugin {
+  val name = "chiselplugin"
 }
 
 // The plugin to be run by the Scala compiler during compilation of Chisel code
 class ChiselPlugin(val global: Global) extends Plugin {
-  val name = "chiselplugin"
+  val name = ChiselPlugin.name
   val description = "Plugin for Chisel 3 Hardware Description Language"
   private val arguments = ChiselPluginArguments()
   val components: List[PluginComponent] = List[PluginComponent](

--- a/plugin/src/main/scala/chisel3/internal/plugin/ChiselPlugin.scala
+++ b/plugin/src/main/scala/chisel3/internal/plugin/ChiselPlugin.scala
@@ -6,14 +6,40 @@ import scala.tools.nsc
 import nsc.Global
 import nsc.plugins.{Plugin, PluginComponent}
 import scala.reflect.internal.util.NoPosition
+import scala.collection.mutable
 
-private[plugin] case class ChiselPluginArguments() {
+private[plugin] case class ChiselPluginArguments(val skipFiles: mutable.HashSet[String] = mutable.HashSet.empty) {
   def useBundlePluginOpt = "useBundlePlugin"
   def useBundlePluginFullOpt = s"-P:${ChiselPlugin.name}:$useBundlePluginOpt"
+
+  // Annoying because this shouldn't be used by users
+  def skipFilePluginOpt = "INTERNALskipFile:"
+  def skipFilePluginFullOpt = s"-P:${ChiselPlugin.name}:$skipFilePluginOpt"
 }
 
 object ChiselPlugin {
   val name = "chiselplugin"
+
+  // Also logs why the compoennt was not run
+  private[plugin] def runComponent(global: Global, arguments: ChiselPluginArguments)(unit: global.CompilationUnit): Boolean = {
+    // This plugin doesn't work on Scala 2.11 nor Scala 3. Rather than complicate the sbt build flow,
+    // instead we just check the version and if its an early Scala version, the plugin does nothing
+    val scalaVersion = scala.util.Properties.versionNumberString.split('.')
+    val scalaVersionOk = scalaVersion(0).toInt == 2 && scalaVersion(1).toInt >= 12
+    val skipFile = arguments.skipFiles(unit.source.file.path)
+    if (scalaVersionOk && !skipFile) {
+      true
+    } else {
+      val reason = if (!scalaVersionOk) {
+        s"invalid Scala version '${scala.util.Properties.versionNumberString}'"
+      } else {
+        s"file skipped via '${arguments.skipFilePluginFullOpt}'"
+      }
+      // Enable this with scalacOption '-Ylog:chiselbundlephase'
+      global.log(s"Skipping BundleComponent on account of $reason.")
+      false
+    }
+  }
 }
 
 // The plugin to be run by the Scala compiler during compilation of Chisel code
@@ -22,7 +48,7 @@ class ChiselPlugin(val global: Global) extends Plugin {
   val description = "Plugin for Chisel 3 Hardware Description Language"
   private val arguments = ChiselPluginArguments()
   val components: List[PluginComponent] = List[PluginComponent](
-    new ChiselComponent(global),
+    new ChiselComponent(global, arguments),
     new BundleComponent(global, arguments)
   )
 
@@ -30,6 +56,12 @@ class ChiselPlugin(val global: Global) extends Plugin {
     for (option <- options) {
       if (option == arguments.useBundlePluginOpt) {
         val msg = s"'${arguments.useBundlePluginFullOpt}' is now default behavior, you can stop using the scalacOption."
+        global.reporter.warning(NoPosition, msg)
+      } else if (option.startsWith(arguments.skipFilePluginOpt)) {
+        val filename = option.stripPrefix(arguments.skipFilePluginOpt)
+        arguments.skipFiles += filename
+        // Be annoying and warn because users are not supposed to use this
+        val msg = s"Option -P:${ChiselPlugin.name}:$option should only be used for internal chisel3 compiler purposes!"
         global.reporter.warning(NoPosition, msg)
       } else {
         error(s"Option not understood: '$option'")


### PR DESCRIPTION
Unidoc was apparently not running in CI and it was broken by https://github.com/chipsalliance/chisel3/pull/2277. The issue isn't that #2277 is broken, it's that it exposed the fact that `unidoc` actually runs the same scalacOptions on all of the files being built into 1 doc. This is a problem because Chisel3 `core` needs to not have the compiler plugin run on it, while the downstream `chisel` project does. This is a hacky solution, but it's the best I have, see https://github.com/sbt/sbt-unidoc/issues/107.

Note that this has 3 useful commits. There is a little of refactoring of how the plugin skips components (a component is a Scalac compiler phase).

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [NA] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [NA] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

  - bug fix        
  - documentation       

#### API Impact

This adds an argument to the chisel3 plugin `-P:chiselplugin:INTERNALskipFile:<filename>`, note this is only intended to be used for internal `unidoc` generation.

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

  - Rebase
  
#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.3.x`, [small] API extension: `3.4.x`, API modification or big change: `3.5.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
