### PR TITLE
Add BitPat.fromEnum to convert values from ChiselEnum

### DIFF
--- a/src/main/scala/chisel3/util/BitPat.scala
+++ b/src/main/scala/chisel3/util/BitPat.scala
@@ -88,6 +88,13 @@ object BitPat {
     x.value.asUInt(x.getWidth.W)
   }
 
+    /** Creates a [[BitPat]] from a [[ChiselEnum]] literal.
+    *
+    * @param n the [[ChiselEnum]]
+    */
+  def fromEnum[T <: Data](n: T): UInt =
+    n.litValue.U((n.getWidth).W)
+
   /** Allows UInts to be used where a BitPat is expected, useful for when an
     * interface is defined with BitPats but not all cases need the partial
     * matching capability.

--- a/src/test/scala/chiselTests/util/BitPatSpec.scala
+++ b/src/test/scala/chiselTests/util/BitPatSpec.scala
@@ -3,9 +3,13 @@
 package chiselTests.util
 
 import chisel3.util.BitPat
+import chisel3.experimental.ChiselEnum
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
+object Enum extends ChiselEnum {
+  val VAL1, VAL2, VAL3 = Value
+}
 
 class BitPatSpec extends AnyFlatSpec with Matchers {
   behavior of classOf[BitPat].toString
@@ -48,5 +52,12 @@ class BitPatSpec extends AnyFlatSpec with Matchers {
     b(2, 0) should be(BitPat("b???"))
     b(4, 3) should be(BitPat("b01"))
     b(6, 6) should be(BitPat("b1"))
+  }
+
+  it should "convert to BitPat from ChiselEnum" in {
+    val b = BitPat(BitPat.fromEnum(Enum.VAL1))
+    val c = BitPat(BitPat.fromEnum(Enum.VAL3))
+    b should be(BitPat("b00"))
+    c should be(BitPat("b10"))
   }
 }


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
- new feature/API

#### API Impact

No impact to current API, the PR adds a new `fromEnum` function to BitPat generating BitPat from existing ChiselEnum values.

#### Backend Code Generation Impact

No change.

#### Desired Merge Strategy

- Squash: The PR will be squashed and merged (choose this if you have no preference.

#### Release Notes

This PR adds `BitPat.fromEnum` function enabling `BitPat` generation from existing `ChiselEnum` values.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.3.x`, [small] API extension: `3.4.x`, API modification or big change: `3.5.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
