### PR TITLE
Add `decodeAs` API to output decoded signals directly to a Bundle

### DIFF
--- a/src/main/scala/chisel3/util/experimental/decode/decoder.scala
+++ b/src/main/scala/chisel3/util/experimental/decode/decoder.scala
@@ -112,3 +112,19 @@ object decoder extends LazyLogging {
       )
     )
 }
+
+object decodeAs  {
+    /** Decode signals using a [[Bundle]] as the output
+      *
+      * @param b          the output bundle to be used as the decoded signal
+      * @param input      input signal that contains decode table input
+      * @param truthTable [[TruthTable]] to decode user input.
+      * @return bundle with the decode output.
+      *
+      * @note The bundle width must match the TruthTable width.
+      */
+    def apply[T <: Bundle](b: T, input: UInt, truthTable: TruthTable): T =
+    decoder(input, truthTable).asTypeOf(b)
+    def apply[T <: Bundle](minimizer: Minimizer, b: T, input: UInt, truthTable: TruthTable): T =
+    decoder(minimizer, input, truthTable).asTypeOf(b)
+}

--- a/src/main/scala/chisel3/util/experimental/decode/decoder.scala
+++ b/src/main/scala/chisel3/util/experimental/decode/decoder.scala
@@ -122,6 +122,28 @@ object decodeAs  {
       * @return bundle with the decode output.
       *
       * @note The bundle width must match the TruthTable width.
+      * @example
+      * {{{
+      * class OutputBundle extends Bundle {
+      *   val s1 = UInt(2.W)
+      *   val s2 = UInt(2.W)
+      *   val s3 = Bool()
+      * }
+      * val selector = "b001".U
+      * val signals = decodeAs(
+      *   (new OutputBundle),
+      *   selector,
+      *   TruthTable(
+      *     Array(
+      *     BitPat("b001")  -> BitPat(1.U(2.W)) ## BitPat(1.U(2.W)) ## BitPat.Y(),
+      *     BitPat("b?11")  -> BitPat(2.U(2.W)) ## BitPat(2.U(2.W)) ## BitPat.N(),
+      *     ),                 BitPat(0.U(2.W)) ## BitPat(0.U(2.W)) ## BitPat.dontCare(1) // Default values
+      *   )
+      * )
+      * val a = signals.s1 // Should be 1.U(2.W)
+      * val b = signals.s2 // Should be 1.U(2.W)
+      * val c = signals.s3 // Should be true.B
+      * }}}
       */
     def apply[T <: Bundle](b: T, input: UInt, truthTable: TruthTable): T =
     decoder(input, truthTable).asTypeOf(b)

--- a/src/test/scala/chiselTests/util/experimental/DecoderSpec.scala
+++ b/src/test/scala/chiselTests/util/experimental/DecoderSpec.scala
@@ -1,0 +1,52 @@
+package chiselTests.util.experimental
+
+import chisel3._
+import chiselTests._
+import chisel3.testers.BasicTester
+import chisel3.stage.ChiselStage
+import chisel3.util.BitPat
+import chisel3.util.experimental.decode.{TruthTable, decodeAs}
+// import org.scalatest.flatspec.AnyFlatSpec
+class OutputBundle extends Bundle {
+  val s1 = UInt(2.W)
+  val s2 = UInt(2.W)
+  val s3 = Bool()
+}
+class DecodeAs extends Module {
+    val io = IO(new Bundle {
+        val i = Input(UInt(3.W))
+        val o = Output(new OutputBundle())
+    })
+
+    val signals = decodeAs(
+        (new OutputBundle),
+        io.i,
+        TruthTable(
+            Array(
+            BitPat("b001")  -> BitPat(1.U(2.W)) ## BitPat(2.U(2.W)) ## BitPat.Y(),
+            BitPat("b?11")  -> BitPat(2.U(2.W)) ## BitPat(3.U(2.W)) ## BitPat.Y(),
+            ),                 BitPat(0.U(2.W)) ## BitPat(0.U(2.W)) ## BitPat.N() // Default values
+        )
+    )
+    io.o := signals
+}
+
+class DecodeAsTester(i: String, o1: Int, o2: Int, o3: Boolean) extends BasicTester {
+  val dut = Module(new DecodeAs())
+  dut.io.i := i.U
+
+  assert(dut.io.o.s1 === o1.U)
+  assert(dut.io.o.s2 === o2.U)
+  assert(dut.io.o.s3 === o3.B)
+  stop()
+}
+
+class DecoderSpec extends ChiselPropSpec {
+    property("decoder should decodeAs to an existing bundle") {
+        assertTesterPasses{ new DecodeAsTester("b001", 1, 2, true) }
+    }
+
+    property("decoder should decodeAs to an existing bundle with default values") {
+        assertTesterPasses{ new DecodeAsTester("b101", 0, 0, false) }
+    }
+}


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
- new feature/API

#### API Impact

This PR adds a new `decodeAs` function to decoder allowing the signal decode output to go directly to a Bundle.

#### Backend Code Generation Impact

No Verilog output impact.

#### Desired Merge Strategy
- Squash: The PR will be squashed and merged (choose this if you have no preference.

#### Release Notes

Added a new `decodeAs` function to decoder allowing the signal decode output to go directly to a Bundle.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.3.x`, [small] API extension: `3.4.x`, API modification or big change: `3.5.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
