### PR TITLE
Optional clock param for memory ports

### DIFF
--- a/core/src/main/scala/chisel3/Mem.scala
+++ b/core/src/main/scala/chisel3/Mem.scala
@@ -91,7 +91,7 @@ sealed abstract class MemBase[T <: Data](val t: T, val length: BigInt)
   def apply(x: UInt, y: Clock): T = macro SourceInfoTransform.xyArg
 
   def do_apply(idx: UInt, clock: Clock)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T =
-    do_apply_impl(idx, Builder.forcedClock, MemPortDirection.INFER, false)
+    do_apply_impl(idx, clock, MemPortDirection.INFER, false)
 
   /** Creates a read accessor into the memory with dynamic addressing. See the
     * class documentation of the memory for more detailed information.

--- a/core/src/main/scala/chisel3/Mem.scala
+++ b/core/src/main/scala/chisel3/Mem.scala
@@ -108,10 +108,20 @@ sealed abstract class MemBase[T <: Data](val t: T, val length: BigInt)
   def do_read(idx: UInt, clock: Clock)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T =
     do_apply_impl(idx, clock, MemPortDirection.READ, false)
 
-  protected def do_apply_impl(idx: UInt, clock: Clock, dir: MemPortDirection, warn: Boolean)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T = {
+  protected def do_apply_impl(
+    idx:   UInt,
+    clock: Clock,
+    dir:   MemPortDirection,
+    warn:  Boolean
+  )(
+    implicit sourceInfo: SourceInfo,
+    compileOptions:      CompileOptions
+  ): T = {
     if (warn && clock != clockInst) {
-      Builder.warning("The clock used to initialize the memory is different than the one used to initialize the port. " +
-        "If this is intentional, please pass the clock explicitly when creating the port. This behavior will be an error in 3.6.0")
+      Builder.warning(
+        "The clock used to initialize the memory is different than the one used to initialize the port. " +
+          "If this is intentional, please pass the clock explicitly when creating the port. This behavior will be an error in 3.6.0"
+      )
     }
     makePort(sourceInfo, idx, dir, clock)
   }
@@ -127,10 +137,19 @@ sealed abstract class MemBase[T <: Data](val t: T, val length: BigInt)
   def write(idx: UInt, data: T, clock: Clock)(implicit compileOptions: CompileOptions): Unit =
     write_impl(idx, data, clock, false)
 
-  private def write_impl(idx: UInt, data: T, clock: Clock, warn: Boolean)(implicit compileOptions: CompileOptions): Unit = {
+  private def write_impl(
+    idx:   UInt,
+    data:  T,
+    clock: Clock,
+    warn:  Boolean
+  )(
+    implicit compileOptions: CompileOptions
+  ): Unit = {
     if (warn && clock != clockInst) {
-      Builder.warning("The clock used to initialize the memory is different than the one used to initialize the port. " +
-        "If this is intentional, please pass the clock explicitly when creating the port. This behavior will be an error in 3.6.0")
+      Builder.warning(
+        "The clock used to initialize the memory is different than the one used to initialize the port. " +
+          "If this is intentional, please pass the clock explicitly when creating the port. This behavior will be an error in 3.6.0"
+      )
     }
     implicit val sourceInfo = UnlocatableSourceInfo
     makePort(UnlocatableSourceInfo, idx, MemPortDirection.WRITE, clock) := data
@@ -146,23 +165,42 @@ sealed abstract class MemBase[T <: Data](val t: T, val length: BigInt)
     * @note this is only allowed if the memory's element data type is a Vec
     */
   def write(
-    idx: UInt,
+    idx:  UInt,
     data: T,
     mask: Seq[Bool]
   )(
     implicit evidence: T <:< Vec[_],
-    compileOptions: CompileOptions
+    compileOptions:    CompileOptions
   ): Unit =
     masked_write_impl(idx, data, mask, Builder.forcedClock, true)
 
-  def write(idx: UInt, data: T, mask: Seq[Bool], clock: Clock) (implicit evidence: T <:< Vec[_], compileOptions: CompileOptions): Unit =
+  def write(
+    idx:   UInt,
+    data:  T,
+    mask:  Seq[Bool],
+    clock: Clock
+  )(
+    implicit evidence: T <:< Vec[_],
+    compileOptions:    CompileOptions
+  ): Unit =
     masked_write_impl(idx, data, mask, clock, false)
 
-  private def masked_write_impl(idx: UInt, data: T, mask: Seq[Bool], clock: Clock, warn: Boolean) (implicit evidence: T <:< Vec[_], compileOptions: CompileOptions): Unit = {
+  private def masked_write_impl(
+    idx:   UInt,
+    data:  T,
+    mask:  Seq[Bool],
+    clock: Clock,
+    warn:  Boolean
+  )(
+    implicit evidence: T <:< Vec[_],
+    compileOptions:    CompileOptions
+  ): Unit = {
     implicit val sourceInfo = UnlocatableSourceInfo
     if (warn && clock != clockInst) {
-      Builder.warning("The clock used to initialize the memory is different than the one used to initialize the port. " +
-        "If this is intentional, please pass the clock explicitly when creating the port. This behavior will be an error in 3.6.0")
+      Builder.warning(
+        "The clock used to initialize the memory is different than the one used to initialize the port. " +
+          "If this is intentional, please pass the clock explicitly when creating the port. This behavior will be an error in 3.6.0"
+      )
     }
     val accessor = makePort(sourceInfo, idx, MemPortDirection.WRITE, clock).asInstanceOf[Vec[Data]]
     val dataVec = data.asInstanceOf[Vec[Data]]
@@ -178,9 +216,9 @@ sealed abstract class MemBase[T <: Data](val t: T, val length: BigInt)
 
   private def makePort(
     sourceInfo: SourceInfo,
-    idx: UInt,
-    dir: MemPortDirection,
-    clock: Clock
+    idx:        UInt,
+    dir:        MemPortDirection,
+    clock:      Clock
   )(
     implicit compileOptions: CompileOptions
   ): T = {
@@ -290,7 +328,15 @@ sealed class SyncReadMem[T <: Data] private (t: T, n: BigInt, val readUnderWrite
   def read(x: UInt, y: Bool, z: Clock): T = macro SourceInfoTransform.xyzArg
 
   /** @group SourceInfoTransformMacro */
-  def do_read(addr: UInt, enable: Bool, clock: Clock, warn: Boolean)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T = {
+  def do_read(
+    addr:   UInt,
+    enable: Bool,
+    clock:  Clock,
+    warn:   Boolean
+  )(
+    implicit sourceInfo: SourceInfo,
+    compileOptions:      CompileOptions
+  ): T = {
     val a = Wire(UInt())
     a := DontCare
     var port: Option[T] = None
@@ -301,13 +347,13 @@ sealed class SyncReadMem[T <: Data] private (t: T, n: BigInt, val readUnderWrite
     port.get
   }
 
-  /** @group SourceInfoTransformMacro*/
+  /** @group SourceInfoTransformMacro */
   override def do_read(idx: UInt, clock: Clock)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T =
     do_read(addr = idx, enable = true.B, clock, false)
 
-  /** @group SourceInfoTransformMacro*/
+  /** @group SourceInfoTransformMacro */
   def do_read(idx: UInt, en: Bool)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T =
-    do_read(addr=idx, enable = en, Builder.forcedClock, true)
+    do_read(addr = idx, enable = en, Builder.forcedClock, true)
   // note: we implement do_read(addr) for SyncReadMem in terms of do_read(addr, en) in order to ensure that
   //       `mem.read(addr)` will always behave the same as `mem.read(addr, true.B)`
 }

--- a/core/src/main/scala/chisel3/Mem.scala
+++ b/core/src/main/scala/chisel3/Mem.scala
@@ -56,6 +56,7 @@ sealed abstract class MemBase[T <: Data](val t: T, val length: BigInt)
     with SourceInfoDoc {
   _parent.foreach(_.addId(this))
 
+  private val clockInst: Clock = Builder.forcedClock
   // REVIEW TODO: make accessors (static/dynamic, read/write) combinations consistent.
 
   /** Creates a read accessor into the memory with static addressing. See the
@@ -63,16 +64,16 @@ sealed abstract class MemBase[T <: Data](val t: T, val length: BigInt)
     */
   def apply(x: BigInt): T = macro SourceInfoTransform.xArg
 
+  /** @group SourceInfoTransformMacro */
+  def do_apply(idx: BigInt)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T = {
+    require(idx >= 0 && idx < length)
+    apply(idx.asUInt, Builder.forcedClock)
+  }
+
   /** Creates a read accessor into the memory with static addressing. See the
     * class documentation of the memory for more detailed information.
     */
   def apply(x: Int): T = macro SourceInfoTransform.xArg
-
-  /** @group SourceInfoTransformMacro */
-  def do_apply(idx: BigInt)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T = {
-    require(idx >= 0 && idx < length)
-    apply(idx.asUInt)
-  }
 
   /** @group SourceInfoTransformMacro */
   def do_apply(idx: Int)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T =
@@ -85,7 +86,12 @@ sealed abstract class MemBase[T <: Data](val t: T, val length: BigInt)
 
   /** @group SourceInfoTransformMacro */
   def do_apply(idx: UInt)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T =
-    makePort(sourceInfo, idx, MemPortDirection.INFER)
+    do_apply_impl(idx, Builder.forcedClock, MemPortDirection.INFER, true)
+
+  def apply(x: UInt, y: Clock): T = macro SourceInfoTransform.xyArg
+
+  def do_apply(idx: UInt, clock: Clock)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T =
+    do_apply_impl(idx, Builder.forcedClock, MemPortDirection.INFER, false)
 
   /** Creates a read accessor into the memory with dynamic addressing. See the
     * class documentation of the memory for more detailed information.
@@ -94,16 +100,40 @@ sealed abstract class MemBase[T <: Data](val t: T, val length: BigInt)
 
   /** @group SourceInfoTransformMacro */
   def do_read(idx: UInt)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T =
-    makePort(sourceInfo, idx, MemPortDirection.READ)
+    do_apply_impl(idx, Builder.forcedClock, MemPortDirection.READ, true)
+
+  def read(x: UInt, y: Clock): T = macro SourceInfoTransform.xyArg
+
+  /** @group SourceInfoTransformMacro */
+  def do_read(idx: UInt, clock: Clock)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T =
+    do_apply_impl(idx, clock, MemPortDirection.READ, false)
+
+  protected def do_apply_impl(idx: UInt, clock: Clock, dir: MemPortDirection, warn: Boolean)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T = {
+    if (warn && clock != clockInst) {
+      Builder.warning("The clock used to initialize the memory is different than the one used to initialize the port. " +
+        "If this is intentional, please pass the clock explicitly when creating the port. This behavior will be an error in 3.6.0")
+    }
+    makePort(sourceInfo, idx, dir, clock)
+  }
 
   /** Creates a write accessor into the memory.
     *
     * @param idx memory element index to write into
     * @param data new data to write
     */
-  def write(idx: UInt, data: T)(implicit compileOptions: CompileOptions): Unit = {
+  def write(idx: UInt, data: T)(implicit compileOptions: CompileOptions): Unit =
+    write_impl(idx, data, Builder.forcedClock, true)
+
+  def write(idx: UInt, data: T, clock: Clock)(implicit compileOptions: CompileOptions): Unit =
+    write_impl(idx, data, clock, false)
+
+  private def write_impl(idx: UInt, data: T, clock: Clock, warn: Boolean)(implicit compileOptions: CompileOptions): Unit = {
+    if (warn && clock != clockInst) {
+      Builder.warning("The clock used to initialize the memory is different than the one used to initialize the port. " +
+        "If this is intentional, please pass the clock explicitly when creating the port. This behavior will be an error in 3.6.0")
+    }
     implicit val sourceInfo = UnlocatableSourceInfo
-    makePort(UnlocatableSourceInfo, idx, MemPortDirection.WRITE) := data
+    makePort(UnlocatableSourceInfo, idx, MemPortDirection.WRITE, clock) := data
   }
 
   /** Creates a masked write accessor into the memory.
@@ -116,15 +146,25 @@ sealed abstract class MemBase[T <: Data](val t: T, val length: BigInt)
     * @note this is only allowed if the memory's element data type is a Vec
     */
   def write(
-    idx:  UInt,
+    idx: UInt,
     data: T,
     mask: Seq[Bool]
   )(
     implicit evidence: T <:< Vec[_],
-    compileOptions:    CompileOptions
-  ): Unit = {
+    compileOptions: CompileOptions
+  ): Unit =
+    masked_write_impl(idx, data, mask, Builder.forcedClock, true)
+
+  def write(idx: UInt, data: T, mask: Seq[Bool], clock: Clock) (implicit evidence: T <:< Vec[_], compileOptions: CompileOptions): Unit =
+    masked_write_impl(idx, data, mask, clock, false)
+
+  private def masked_write_impl(idx: UInt, data: T, mask: Seq[Bool], clock: Clock, warn: Boolean) (implicit evidence: T <:< Vec[_], compileOptions: CompileOptions): Unit = {
     implicit val sourceInfo = UnlocatableSourceInfo
-    val accessor = makePort(sourceInfo, idx, MemPortDirection.WRITE).asInstanceOf[Vec[Data]]
+    if (warn && clock != clockInst) {
+      Builder.warning("The clock used to initialize the memory is different than the one used to initialize the port. " +
+        "If this is intentional, please pass the clock explicitly when creating the port. This behavior will be an error in 3.6.0")
+    }
+    val accessor = makePort(sourceInfo, idx, MemPortDirection.WRITE, clock).asInstanceOf[Vec[Data]]
     val dataVec = data.asInstanceOf[Vec[Data]]
     if (accessor.length != dataVec.length) {
       Builder.error(s"Mem write data must contain ${accessor.length} elements (found ${dataVec.length})")
@@ -138,8 +178,9 @@ sealed abstract class MemBase[T <: Data](val t: T, val length: BigInt)
 
   private def makePort(
     sourceInfo: SourceInfo,
-    idx:        UInt,
-    dir:        MemPortDirection
+    idx: UInt,
+    dir: MemPortDirection,
+    clock: Clock
   )(
     implicit compileOptions: CompileOptions
   ): T = {
@@ -147,7 +188,7 @@ sealed abstract class MemBase[T <: Data](val t: T, val length: BigInt)
     val i = Vec.truncateIndex(idx, length)(sourceInfo, compileOptions)
 
     val port = pushCommand(
-      DefMemPort(sourceInfo, t.cloneTypeFull, Node(this), dir, i.ref, Builder.forcedClock.ref)
+      DefMemPort(sourceInfo, t.cloneTypeFull, Node(this), dir, i.ref, clock.ref)
     ).id
     // Bind each element of port to being a MemoryPort
     port.bind(MemoryPortBinding(Builder.forcedUserModule, Builder.currentWhen))
@@ -246,21 +287,27 @@ sealed class SyncReadMem[T <: Data] private (t: T, n: BigInt, val readUnderWrite
     extends MemBase[T](t, n) {
   def read(x: UInt, en: Bool): T = macro SourceInfoTransform.xEnArg
 
+  def read(x: UInt, y: Bool, z: Clock): T = macro SourceInfoTransform.xyzArg
+
   /** @group SourceInfoTransformMacro */
-  def do_read(addr: UInt, enable: Bool)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T = {
+  def do_read(addr: UInt, enable: Bool, clock: Clock, warn: Boolean)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T = {
     val a = Wire(UInt())
     a := DontCare
     var port: Option[T] = None
     when(enable) {
       a := addr
-      port = Some(super.do_read(a))
+      port = Some(super.do_apply_impl(a, clock, MemPortDirection.READ, warn))
     }
     port.get
   }
 
-  /** @group SourceInfoTransformMacro */
-  override def do_read(idx: UInt)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions) =
-    do_read(addr = idx, enable = true.B)
+  /** @group SourceInfoTransformMacro*/
+  override def do_read(idx: UInt, clock: Clock)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T =
+    do_read(addr = idx, enable = true.B, clock, false)
+
+  /** @group SourceInfoTransformMacro*/
+  def do_read(idx: UInt, en: Bool)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T =
+    do_read(addr=idx, enable = en, Builder.forcedClock, true)
   // note: we implement do_read(addr) for SyncReadMem in terms of do_read(addr, en) in order to ensure that
   //       `mem.read(addr)` will always behave the same as `mem.read(addr, true.B)`
 }

--- a/core/src/main/scala/chisel3/Mem.scala
+++ b/core/src/main/scala/chisel3/Mem.scala
@@ -336,7 +336,7 @@ sealed class SyncReadMem[T <: Data] private (t: T, n: BigInt, val readUnderWrite
   def do_read(idx: UInt, en: Bool)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T =
     do_read(idx, en, Builder.forcedClock, true)
 
-  def read(x: UInt, y: Bool, z: Clock): T = macro SourceInfoTransform.xyzArg
+  def read(idx: UInt, en: Bool, clock: Clock): T = macro SourceInfoTransform.xyzArg
 
   /** @group SourceInfoTransformMacro */
   def do_read(idx: UInt, en: Bool, clock: Clock)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T =

--- a/core/src/main/scala/chisel3/Mem.scala
+++ b/core/src/main/scala/chisel3/Mem.scala
@@ -357,16 +357,16 @@ sealed class SyncReadMem[T <: Data] private (t: T, n: BigInt, val readUnderWrite
 
   /** @group SourceInfoTransformMacro */
   def do_read(idx: UInt, en: Bool)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T =
-    do_read(idx, en, Builder.forcedClock, true)
+    _read_impl(idx, en, Builder.forcedClock, true)
 
   def read(idx: UInt, en: Bool, clock: Clock): T = macro SourceInfoTransform.xyzArg
 
   /** @group SourceInfoTransformMacro */
   def do_read(idx: UInt, en: Bool, clock: Clock)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T =
-    do_read(idx, en, clock, false)
+    _read_impl(idx, en, clock, false)
 
   /** @group SourceInfoTransformMacro */
-  def do_read(
+  private def _read_impl(
     addr:   UInt,
     enable: Bool,
     clock:  Clock,

--- a/core/src/main/scala/chisel3/Mem.scala
+++ b/core/src/main/scala/chisel3/Mem.scala
@@ -102,6 +102,11 @@ sealed abstract class MemBase[T <: Data](val t: T, val length: BigInt)
   def do_read(idx: UInt)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T =
     do_apply_impl(idx, Builder.forcedClock, MemPortDirection.READ, true)
 
+  /** Creates a read accessor into the memory with dynamic addressing.
+    * Takes a clock parameter to bind a clock that may be different
+    * from the implicit clock. See the class documentation of the memory
+    * for more detailed information.
+    */
   def read(x: UInt, y: Clock): T = macro SourceInfoTransform.xyArg
 
   /** @group SourceInfoTransformMacro */
@@ -134,6 +139,13 @@ sealed abstract class MemBase[T <: Data](val t: T, val length: BigInt)
   def write(idx: UInt, data: T)(implicit compileOptions: CompileOptions): Unit =
     write_impl(idx, data, Builder.forcedClock, true)
 
+  /** Creates a write accessor into the memory with a clock
+    * that may be different from the implicit clock.
+    *
+    * @param idx memory element index to write into
+    * @param data new data to write
+    * @param clock clock to bind to this accessor
+    */
   def write(idx: UInt, data: T, clock: Clock)(implicit compileOptions: CompileOptions): Unit =
     write_impl(idx, data, clock, false)
 
@@ -174,6 +186,17 @@ sealed abstract class MemBase[T <: Data](val t: T, val length: BigInt)
   ): Unit =
     masked_write_impl(idx, data, mask, Builder.forcedClock, true)
 
+  /** Creates a masked write accessor into the memory with a clock
+    * that may be different from the implicit clock.
+    *
+    * @param idx memory element index to write into
+    * @param data new data to write
+    * @param mask write mask as a Seq of Bool: a write to the Vec element in
+    * memory is only performed if the corresponding mask index is true. 
+    * @param clock clock to bind to this accessor
+    * 
+    * @note this is only allowed if the memory's element data type is a Vec
+    */
   def write(
     idx:   UInt,
     data:  T,

--- a/core/src/main/scala/chisel3/Mem.scala
+++ b/core/src/main/scala/chisel3/Mem.scala
@@ -192,9 +192,9 @@ sealed abstract class MemBase[T <: Data](val t: T, val length: BigInt)
     * @param idx memory element index to write into
     * @param data new data to write
     * @param mask write mask as a Seq of Bool: a write to the Vec element in
-    * memory is only performed if the corresponding mask index is true. 
+    * memory is only performed if the corresponding mask index is true.
     * @param clock clock to bind to this accessor
-    * 
+    *
     * @note this is only allowed if the memory's element data type is a Vec
     */
   def write(

--- a/macros/src/main/scala/chisel3/internal/sourceinfo/SourceInfoTransform.scala
+++ b/macros/src/main/scala/chisel3/internal/sourceinfo/SourceInfoTransform.scala
@@ -200,6 +200,10 @@ class SourceInfoTransform(val c: Context) extends AutoSourceTransform {
     q"$thisObj.$doFuncTerm($x, $y)($implicitSourceInfo, $implicitCompileOptions)"
   }
 
+  def xyzArg(x: c.Tree, y: c.Tree, z: c.Tree): c.Tree = {
+    q"$thisObj.$doFuncTerm($x, $y, $z)($implicitSourceInfo, $implicitCompileOptions)"
+  }
+
   def xEnArg(x: c.Tree, en: c.Tree): c.Tree = {
     q"$thisObj.$doFuncTerm($x, $en)($implicitSourceInfo, $implicitCompileOptions)"
   }

--- a/macros/src/main/scala/chisel3/internal/sourceinfo/SourceInfoTransform.scala
+++ b/macros/src/main/scala/chisel3/internal/sourceinfo/SourceInfoTransform.scala
@@ -200,8 +200,8 @@ class SourceInfoTransform(val c: Context) extends AutoSourceTransform {
     q"$thisObj.$doFuncTerm($x, $y)($implicitSourceInfo, $implicitCompileOptions)"
   }
 
-  def xyzArg(x: c.Tree, y: c.Tree, z: c.Tree): c.Tree = {
-    q"$thisObj.$doFuncTerm($x, $y, $z)($implicitSourceInfo, $implicitCompileOptions)"
+  def xyzArg(idx: c.Tree, en: c.Tree, clock: c.Tree): c.Tree = {
+    q"$thisObj.$doFuncTerm($idx, $en, $clock)($implicitSourceInfo, $implicitCompileOptions)"
   }
 
   def xEnArg(x: c.Tree, en: c.Tree): c.Tree = {

--- a/src/test/scala/chiselTests/MultiClockSpec.scala
+++ b/src/test/scala/chiselTests/MultiClockSpec.scala
@@ -148,49 +148,49 @@ class MultiClockSpec extends ChiselFlatSpec with Utils {
   }
 
   "Differing clocks at memory and write accessor instantiation" should "warn" in {
-      class modMemWriteDifferingClock extends Module {
-        val myClock = IO(Input(Clock()))
-        val mem = withClock(myClock) { Mem(4, UInt(8.W)) }
-        mem(1.U) := 1.U
-      }
+    class modMemWriteDifferingClock extends Module {
+      val myClock = IO(Input(Clock()))
+      val mem = withClock(myClock) { Mem(4, UInt(8.W)) }
+      mem(1.U) := 1.U
+    }
     val (logMemWriteDifferingClock, _) = grabLog(ChiselStage.elaborate(new modMemWriteDifferingClock))
-    logMemWriteDifferingClock should include ("memory is different")
+    logMemWriteDifferingClock should include("memory is different")
 
-      class modSyncReadMemWriteDifferingClock extends Module {
-        val myClock = IO(Input(Clock()))
-        val mem = withClock(myClock) { SyncReadMem(4, UInt(8.W)) }
-        mem.write(1.U, 1.U)
-      }
+    class modSyncReadMemWriteDifferingClock extends Module {
+      val myClock = IO(Input(Clock()))
+      val mem = withClock(myClock) { SyncReadMem(4, UInt(8.W)) }
+      mem.write(1.U, 1.U)
+    }
     val (logSyncReadMemWriteDifferingClock, _) = grabLog(ChiselStage.elaborate(new modSyncReadMemWriteDifferingClock))
-    logSyncReadMemWriteDifferingClock should include ("memory is different")
+    logSyncReadMemWriteDifferingClock should include("memory is different")
   }
 
   "Differing clocks at memory and read accessor instantiation" should "warn" in {
-      class modMemReadDifferingClock extends Module {
-        val myClock = IO(Input(Clock()))
-        val mem = withClock(myClock) { Mem(4, UInt(8.W)) }
-        val readVal = mem.read(0.U)
-      }
+    class modMemReadDifferingClock extends Module {
+      val myClock = IO(Input(Clock()))
+      val mem = withClock(myClock) { Mem(4, UInt(8.W)) }
+      val readVal = mem.read(0.U)
+    }
     val (logMemReadDifferingClock, _) = grabLog(ChiselStage.elaborate(new modMemReadDifferingClock))
-    logMemReadDifferingClock should include ("memory is different")
+    logMemReadDifferingClock should include("memory is different")
 
-      class modSyncReadMemReadDifferingClock extends Module {
-        val myClock = IO(Input(Clock()))
-        val mem = withClock(myClock) { SyncReadMem(4, UInt(8.W)) }
-        val readVal = mem.read(0.U)
-      }
+    class modSyncReadMemReadDifferingClock extends Module {
+      val myClock = IO(Input(Clock()))
+      val mem = withClock(myClock) { SyncReadMem(4, UInt(8.W)) }
+      val readVal = mem.read(0.U)
+    }
     val (logSyncReadMemReadDifferingClock, _) = grabLog(ChiselStage.elaborate(new modSyncReadMemReadDifferingClock))
-    logSyncReadMemReadDifferingClock should include ("memory is different")
+    logSyncReadMemReadDifferingClock should include("memory is different")
   }
 
   "Passing clock parameter to memory port instantiation" should "not warn" in {
-      class modMemPortClock extends Module {
-        val myClock = IO(Input(Clock()))
-        val mem = Mem(4, UInt(8.W))
-        val port0 = mem(0.U, myClock)
-      }
+    class modMemPortClock extends Module {
+      val myClock = IO(Input(Clock()))
+      val mem = Mem(4, UInt(8.W))
+      val port0 = mem(0.U, myClock)
+    }
     val (logMemPortClock, _) = grabLog(ChiselStage.elaborate(new modMemPortClock))
-      (logMemPortClock should not).include("memory is different")
+    (logMemPortClock should not).include("memory is different")
 
     class modSyncReadMemPortClock extends Module {
       val myClock = IO(Input(Clock()))
@@ -198,33 +198,25 @@ class MultiClockSpec extends ChiselFlatSpec with Utils {
       val port0 = mem(0.U, myClock)
     }
     val (logSyncReadMemPortClock, _) = grabLog(ChiselStage.elaborate(new modSyncReadMemPortClock))
-      (logSyncReadMemPortClock should not).include("memory is different")
+    (logSyncReadMemPortClock should not).include("memory is different")
   }
 
   "Passing clock parameter to memory write accessor" should "not warn" in {
-      class modMemWriteClock extends Module {
-        val myClock = IO(Input(Clock()))
-        val mem = Mem(4, UInt(8.W))
-        mem.write(0.U, 0.U, myClock)
-      }
-    val (logMemWriteClock, _) = grabLog(ChiselStage.elaborate(new modMemWriteClock))
-      (logMemWriteClock should not).include("memory is different")
-
     class modMemWriteClock extends Module {
       val myClock = IO(Input(Clock()))
       val mem = Mem(4, UInt(8.W))
       mem.write(0.U, 0.U, myClock)
     }
     val (logMemWriteClock, _) = grabLog(ChiselStage.elaborate(new modMemWriteClock))
-      (logMemWriteClock should not).include("memory is different")
+    (logMemWriteClock should not).include("memory is different")
 
-      class modSyncReadMemWriteClock extends Module {
-        val myClock = IO(Input(Clock()))
-        val mem = SyncReadMem(4, UInt(8.W))
-        mem.write(0.U, 0.U, myClock)
-      }
+    class modSyncReadMemWriteClock extends Module {
+      val myClock = IO(Input(Clock()))
+      val mem = SyncReadMem(4, UInt(8.W))
+      mem.write(0.U, 0.U, myClock)
+    }
     val (logSyncReadMemWriteClock, _) = grabLog(ChiselStage.elaborate(new modSyncReadMemWriteClock))
-      (logSyncReadMemWriteClock should not).include("memory is different")
+    (logSyncReadMemWriteClock should not).include("memory is different")
   }
 
   "Passing clock parameter to memory read accessor" should "not warn" in {
@@ -234,15 +226,15 @@ class MultiClockSpec extends ChiselFlatSpec with Utils {
       val readVal = mem.read(0.U, myClock)
     }
     val (logMemReadClock, _) = grabLog(ChiselStage.elaborate(new modMemReadClock))
-      (logMemReadClock should not).include("memory is different")
+    (logMemReadClock should not).include("memory is different")
 
-      class modSyncReadMemReadClock extends Module {
-        val myClock = IO(Input(Clock()))
-        val mem = SyncReadMem(4, UInt(8.W))
-        val readVal = mem.read(0.U, myClock)
-      }
+    class modSyncReadMemReadClock extends Module {
+      val myClock = IO(Input(Clock()))
+      val mem = SyncReadMem(4, UInt(8.W))
+      val readVal = mem.read(0.U, myClock)
+    }
     val (logSyncReadMemReadClock, _) = grabLog(ChiselStage.elaborate(new modSyncReadMemReadClock))
-      (logSyncReadMemReadClock should not).include("memory is different")
+    (logSyncReadMemReadClock should not).include("memory is different")
   }
 
   "withReset" should "scope the reset of registers" in {

--- a/src/test/scala/chiselTests/MultiClockSpec.scala
+++ b/src/test/scala/chiselTests/MultiClockSpec.scala
@@ -133,7 +133,7 @@ class MultiClockSpec extends ChiselFlatSpec with Utils {
     class MyModuleMemInstClock extends Module {
       val myClock = IO(Input(Clock()))
 
-      val mem = withClock(myClock) {Mem(4, UInt(8.W))}
+      val mem = withClock(myClock) { Mem(4, UInt(8.W)) }
       val port0 = mem(0.U)
     }
 
@@ -147,25 +147,25 @@ class MultiClockSpec extends ChiselFlatSpec with Utils {
     class MyModuleNoWarn extends Module {
       val myClock = IO(Input(Clock()))
 
-      val mem = withClock(myClock) {Mem(4, UInt(8.W))}
+      val mem = withClock(myClock) { Mem(4, UInt(8.W)) }
       val port0 = mem(0.U, myClock)
     }
 
     val (logMemInst, _) = grabLog(ChiselStage.elaborate(new MyModuleMemInstClock))
-    logMemInst should include ("memory is different")
+    logMemInst should include("memory is different")
 
     val (logPortInst, _) = grabLog(ChiselStage.elaborate(new MyModulePortInstClock))
-    logPortInst should not include ("memory is different")
+    (logPortInst should not).include("memory is different")
 
     val (logNoWarn, _) = grabLog(ChiselStage.elaborate(new MyModuleNoWarn))
-    logNoWarn should not include ("memory is different")
+    (logNoWarn should not).include("memory is different")
   }
 
   "Differing clocks at sync memory and port instantiation" should "warn" in {
     class MyModuleMemInstClock extends Module {
       val myClock = IO(Input(Clock()))
 
-      val mem = withClock(myClock) {SyncReadMem(4, UInt(8.W))}
+      val mem = withClock(myClock) { SyncReadMem(4, UInt(8.W)) }
       val port0 = mem(0.U)
       mem(1.U) := 1.U
     }
@@ -181,19 +181,19 @@ class MultiClockSpec extends ChiselFlatSpec with Utils {
     class MyModuleExplicitClk extends Module {
       val myClock = IO(Input(Clock()))
 
-      val mem = withClock(myClock) {SyncReadMem(4, UInt(8.W))}
+      val mem = withClock(myClock) { SyncReadMem(4, UInt(8.W)) }
       val port0 = mem(0.U, myClock)
       mem(1.U, myClock) := 1.U
     }
 
     val (logMemInst, _) = grabLog(ChiselStage.elaborate(new MyModuleMemInstClock))
-    logMemInst should include ("memory is different")
+    logMemInst should include("memory is different")
 
     val (logPortInst, _) = grabLog(ChiselStage.elaborate(new MyModulePortInstClock))
-    logPortInst should not include ("memory is different")
+    (logPortInst should not).include("memory is different")
 
     val (logExplicitClk, _) = grabLog(ChiselStage.elaborate(new MyModuleExplicitClk))
-    logExplicitClk should not include ("memory is different")
+    (logExplicitClk should not).include("memory is different")
   }
 
   "withReset" should "scope the reset of registers" in {


### PR DESCRIPTION
Warn if clock at memory instantiation differs from clock bound at port creation, add tests to MultiClockSpec

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!-- - performance improvement  -->
<!--   - documentation                      -->
  - code refactoring                  
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
   - new feature/API                   
 
#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->
Apply functions for creating read/write accessors to Mem and SyncReadMem have an optional parameter `clock`. If this parameter is not passed, the clock for the port is inferred from the context. If the clock passed to the ports (implicit or otherwise) does not match the clock at memory instantiation, a warning is issued. 

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
No impact
<!-- How does it change it or in what circumstances would it?  -->

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
- Squash: The PR will be squashed and merged (choose this if you have no preference.
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
`Mem` and `SyncReadMem` read/write ports accept an optional parameter `clock` for binding a clock that is different from the implicit clock in the current context. 

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.3.x`, [small] API extension: `3.4.x`, API modification or big change: `3.5.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
