### PR TITLE
Lookupable: add Either version

### DIFF
--- a/core/src/main/scala/chisel3/experimental/hierarchy/Lookupable.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/Lookupable.scala
@@ -381,24 +381,24 @@ object Lookupable {
       ret.map { x: B => lookupable.instanceLookup[A](_ => x, instance) }
     }
   }
-  implicit def lookupEither[B, Beta](
+  implicit def lookupEither[L, R](
     implicit sourceInfo: SourceInfo,
     compileOptions:      CompileOptions,
-    lookupableB:         Lookupable[B],
-    lookupableBeta:      Lookupable[Beta]
-  ) = new Lookupable[Either[B, Beta]] {
-    type C = Either[lookupableB.C, lookupableBeta.C]
-    def definitionLookup[A](that: A => Either[B, Beta], definition: Definition[A]): C = {
+    lookupableL:         Lookupable[L],
+    lookupableR:         Lookupable[R]
+  ) = new Lookupable[Either[L, R]] {
+    type C = Either[lookupableL.C, lookupableR.C]
+    def definitionLookup[A](that: A => Either[L, R], definition: Definition[A]): C = {
       val ret = that(definition.proto)
-      ret.map { x: Beta => lookupableBeta.definitionLookup[A](_ => x, definition) }.left.map { x: B =>
-        lookupableB.definitionLookup[A](_ => x, definition)
+      ret.map { x: R => lookupableR.definitionLookup[A](_ => x, definition) }.left.map { x: L =>
+        lookupableL.definitionLookup[A](_ => x, definition)
       }
     }
-    def instanceLookup[A](that: A => Either[B, Beta], instance: Instance[A]): C = {
+    def instanceLookup[A](that: A => Either[L, R], instance: Instance[A]): C = {
       import instance._
       val ret = that(proto)
-      ret.map { x: Beta => lookupableBeta.instanceLookup[A](_ => x, instance) }.left.map { x: B =>
-        lookupableB.instanceLookup[A](_ => x, instance)
+      ret.map { x: R => lookupableR.instanceLookup[A](_ => x, instance) }.left.map { x: L =>
+        lookupableL.instanceLookup[A](_ => x, instance)
       }
     }
   }

--- a/core/src/main/scala/chisel3/experimental/hierarchy/Lookupable.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/Lookupable.scala
@@ -18,8 +18,8 @@ import chisel3.internal.{throwException, AggregateViewBinding, Builder, ChildBin
   * Sealed.
   */
 @implicitNotFound(
-  "@public is only legal within a class marked @instantiable and only on vals of type" +
-    " Data, BaseModule, IsInstantiable, IsLookupable, or Instance[_], or in an Iterable or Option"
+  "@public is only legal within a class or trait marked @instantiable, and only on vals of type" +
+    " Data, BaseModule, IsInstantiable, IsLookupable, or Instance[_], or in an Iterable, Option, or Either"
 )
 trait Lookupable[-B] {
   type C // Return type of the lookup

--- a/core/src/main/scala/chisel3/experimental/hierarchy/Lookupable.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/Lookupable.scala
@@ -381,6 +381,27 @@ object Lookupable {
       ret.map { x: B => lookupable.instanceLookup[A](_ => x, instance) }
     }
   }
+  implicit def lookupEither[B, Beta](
+    implicit sourceInfo: SourceInfo,
+    compileOptions:      CompileOptions,
+    lookupableB:         Lookupable[B],
+    lookupableBeta:      Lookupable[Beta]
+  ) = new Lookupable[Either[B, Beta]] {
+    type C = Either[lookupableB.C, lookupableBeta.C]
+    def definitionLookup[A](that: A => Either[B, Beta], definition: Definition[A]): C = {
+      val ret = that(definition.proto)
+      ret.map { x: Beta => lookupableBeta.definitionLookup[A](_ => x, definition) }.left.map { x: B =>
+        lookupableB.definitionLookup[A](_ => x, definition)
+      }
+    }
+    def instanceLookup[A](that: A => Either[B, Beta], instance: Instance[A]): C = {
+      import instance._
+      val ret = that(proto)
+      ret.map { x: Beta => lookupableBeta.instanceLookup[A](_ => x, instance) }.left.map { x: B =>
+        lookupableB.instanceLookup[A](_ => x, instance)
+      }
+    }
+  }
   implicit def lookupIsInstantiable[B <: IsInstantiable](
     implicit sourceInfo: SourceInfo,
     compileOptions:      CompileOptions

--- a/src/test/scala/chiselTests/experimental/hierarchy/DefinitionSpec.scala
+++ b/src/test/scala/chiselTests/experimental/hierarchy/DefinitionSpec.scala
@@ -319,6 +319,16 @@ class DefinitionSpec extends ChiselFunSpec with Utils {
       val (_, annos) = getFirrtlAndAnnos(new Top)
       annos should contain(MarkAnnotation("~Top|ConcreteHasBlah".mt, "10"))
     }
+    it("3.11: should work on eithers") {
+      class Top() extends Module {
+        val i = Definition(new HasEither())
+        i.x.map(x => mark(x, "xright")).left.map(x => mark(x, "xleft"))
+        i.y.map(x => mark(x, "yright")).left.map(x => mark(x, "yleft"))
+      }
+      val (_, annos) = getFirrtlAndAnnos(new Top)
+      annos should contain(MarkAnnotation("~Top|HasEither>x".rt, "xright"))
+      annos should contain(MarkAnnotation("~Top|HasEither>y".rt, "yleft"))
+    }
   }
   describe("4: toDefinition") {
     it("4.0: should work on modules") {

--- a/src/test/scala/chiselTests/experimental/hierarchy/Examples.scala
+++ b/src/test/scala/chiselTests/experimental/hierarchy/Examples.scala
@@ -195,6 +195,11 @@ object Examples {
     @public val x: Option[UInt] = Some(Wire(UInt(3.W)))
   }
   @instantiable
+  class HasEither() extends Module {
+    @public val x: Either[Bool, UInt] = Right(Wire(UInt(3.W)).suggestName("x"))
+    @public val y: Either[Bool, UInt] = Left(Wire(Bool()).suggestName("y"))
+  }
+  @instantiable
   class HasVec() extends Module {
     @public val x = VecInit(1.U, 2.U, 3.U)
   }

--- a/src/test/scala/chiselTests/experimental/hierarchy/InstanceSpec.scala
+++ b/src/test/scala/chiselTests/experimental/hierarchy/InstanceSpec.scala
@@ -230,6 +230,7 @@ class InstanceSpec extends ChiselFunSpec with Utils {
       val (_, annos) = getFirrtlAndAnnos(new Top)
       annos should contain(MarkAnnotation("~Top|Top/i:HasOption>x".rt, "x"))
     }
+
     it("3.6: should work on vecs") {
       class Top() extends Module {
         val i = Instance(Definition(new HasVec()))
@@ -287,6 +288,16 @@ class InstanceSpec extends ChiselFunSpec with Utils {
       }
       val (_, annos) = getFirrtlAndAnnos(new Top)
       annos should contain(MarkAnnotation("~Top|Top/i:HasPublicConstructorArgs>x".rt, "10"))
+    }
+    it("3.11: should work on eithers") {
+      class Top() extends Module {
+        val i = Instance(Definition(new HasEither()))
+        i.x.map(x => mark(x, "xright")).left.map(x => mark(x, "xleft"))
+        i.y.map(x => mark(x, "yright")).left.map(x => mark(x, "yleft"))
+      }
+      val (_, annos) = getFirrtlAndAnnos(new Top)
+      annos should contain(MarkAnnotation("~Top|Top/i:HasEither>x".rt, "xright"))
+      annos should contain(MarkAnnotation("~Top|Top/i:HasEither>y".rt, "yleft"))
     }
   }
   describe("4: toInstance") {


### PR DESCRIPTION
### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
 - new feature/API   

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

Adds a LookupableEither implicit, such that one can have `Either`s inside Instances and Definitions that can be looked up.

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

No change on generated verilog.

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
  - Squash: The PR will be squashed and merged (choose this if you have no preference.
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

Lookupable: Add an Either version

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [x] Did you mark the proper milestone (Bug fix: `3.3.x`, [small] API extension: `3.4.x`, API modification or big change: `3.5.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
