### PR TITLE
Add instructions for updating branches from before Scalafmt

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,3 +14,68 @@
 
 6. Please make your PRs against the `master` branch. The project admins, when reviewing your PR, will decide which stable version (if any) your change should be backported to. The backports will be opened automatically on your behalf and you may need to do some cleanup, but focus first on your `master` PR.
 
+### Frequently Asked Questions
+
+#### How do I update PRs from before Scalafmt was applied?
+
+Just before the release of Chisel v3.5.0, we started using [Scalafmt](https://scalameta.org/scalafmt/) in this repository.
+Scalafmt is a code formatter; thus when it was applied in https://github.com/chipsalliance/chisel3/pull/2246 it caused a nearly 10,000 line diff.
+This introduces merge conflicts with almost every single branch from before that change.
+In some cases, it can be simple enough to just resolve any conflicts with a standard merge or rebase, but for some branches, this is too complicated.
+For such complex cases, we recommend the following procedure.
+
+##### Merge-based flow
+
+To make the following commands copy-pastable, we recommend exporting your branch name as an environment variable:
+
+```bash
+export MY_BRANCH=<name of your branch>
+```
+
+First, you should back up a copy of your branch in case anything goes wrong.
+
+```bash
+git branch $MY_BRANCH-backup
+```
+
+We also need to make sure that you have the upstream Chisel repo as a remote.
+
+```bash
+git remote add upstream https://github.com/chipsalliance/chisel3.git
+git fetch upstream
+```
+
+You can then run the following commands:
+
+```bash
+# Make sure your branch is checked out
+git checkout $MY_BRANCH
+
+# Merge with the commit just before Scalafmt was applied
+# It is possible you will have to resolve conflicts at this point
+git merge upstream/just-before-scalafmt
+# just-before-scalafmt is a branch that points to a commit, in case the branch gets deleted, you can instead run:
+# git branch just-before-scalafmt dd36f97a82746cec0b25b94651581fe799e24579
+# git merge just-before-scalafmt
+
+# Format everything using Scalafmt
+sbt scalafmtAll
+
+# Commit the reformatted code
+git commit -a -m 'Apply Scalafmt'
+
+# Now we need to merge our changes with just after Scalafmt as applied
+# Any conflicts are from our changes so we tell git to resolve conflicts by picking our changes
+git merge upstream/just-after-scalafmt -X ours
+# just-before-scalafmt is a branch that points to a commit, in case the branch gets deleted, you can instead run:
+# git branch just-after-scalafmt 3131c0daad41dea78bede4517669e376c41a325a
+# git merge just-after-scalafmt -X ours
+
+# Most conflicts from code formatting should be resolved, now you can merge master
+# There may still be some silly conflicts, but most should be avoided
+git merge upstream/master
+
+# Don't forget to push your changes!
+git push origin $MY_BRANCH
+```
+


### PR DESCRIPTION
This only includes a merge-based flow which will presumably be
squash-and-merged for any merged PRs. It is possible to do this with
rebasing but it is tricky and hard to describe in a fool-proof way.

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [NA] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

- documentation    

#### API Impact

No impact

#### Backend Code Generation Impact

No impact
#### Desired Merge Strategy

  - Squash

#### Release Notes


### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
