### PR TITLE
Fix Decoder bug for constant 0 and DC

### DIFF
--- a/integration-tests/src/test/scala/chiselTests/util/experimental/minimizer/MinimizerSpec.scala
+++ b/integration-tests/src/test/scala/chiselTests/util/experimental/minimizer/MinimizerSpec.scala
@@ -272,4 +272,39 @@ trait MinimizerSpec extends AnyFlatSpec with ChiselScalatestTester with Formal {
       BitPat(s"b${Seq(N, X, X, X, X, X, X, X, X, A2_X, A1_X, IMM_X, DW_X, FN_X, N, M_X, X, X, X, X, X, X, X, CSR_X, X, X, X, X).reduce(_ + _)}")
     ))
   }
+
+  "output is 0" should "pass" in {
+    minimizerTest(TruthTable.fromString(
+      """00->0
+        |01->?
+        |10->0
+        |11->0
+        |    ?
+        |""".stripMargin
+
+    ))
+  }
+  "output is 1" should "pass" in {
+    minimizerTest(TruthTable.fromString(
+      """00->1
+        |01->?
+        |10->1
+        |11->1
+        |    ?
+        |""".stripMargin
+
+    ))
+  }
+  // I know this seems to be crazy, but if user is crazy as well...
+  "output is dont care" should "pass" in {
+    minimizerTest(TruthTable.fromString(
+      """00->?
+        |01->?
+        |10->?
+        |11->?
+        |    ?
+        |""".stripMargin
+
+    ))
+  }
 }

--- a/src/main/scala/chisel3/util/experimental/decode/EspressoMinimizer.scala
+++ b/src/main/scala/chisel3/util/experimental/decode/EspressoMinimizer.scala
@@ -57,11 +57,20 @@ object EspressoMinimizer extends Minimizer with LazyLogging {
     def readTable(espressoTable: String) = {
       def bitPat(espresso: String): BitPat = BitPat("b" + espresso.replace('-', '?'))
 
-      espressoTable
+      val out = espressoTable
         .split("\n")
         .filterNot(_.startsWith("."))
         .map(_.split(' '))
         .map(row => bitPat(row(0)) -> bitPat(row(1)))
+      // special case for 0 and DontCare, if output is not couple to input
+      if (out.isEmpty)
+        Array(
+          (
+            BitPat(s"b${"?" * table.inputWidth}"),
+            BitPat(s"b${"0" * table.outputWidth}")
+          )
+        )
+      else out
     }
 
     val input = writeTable(table)


### PR DESCRIPTION
### Minimal Reproducible Tests
Should be optimized to 0
```
00->0
01->?
10->0
11->0
    ?
```
Should be optimized to `DontCare`
```
00->?
01->?
10->?
11->?
    ?
```

### Reason of this bug
QMC will optimize to empty for case 0 and case `DontCare`, since it only cares `ON set`.
Espresso by default(`-of`) will return `ON set` as well, so it will also be empty on these two cases.
Espresso will also return another result by `-ofd`(However that's the return which PLA cannot consume).
```
.type fd
.i 2
.o 1
.p 1
01 2
.end
```
So this behavior is because `PLA`, which is the circuit backend of these logic minimizer, only consumes `ON set`.
Both QMC and espresso algorithm are optimizing to a PLA, which means `?` and `0` will finally land to 'OFF set'. This will have a correct behavior for PLA. 
This seems less optimized: circuit result should be `DontCare`, but not `0`, however, if the minimizer backend is PLA, it cannot be a `DontCare`. 
So when user using `Minimizer` output decoder, they be get less optimized result.(Maybe we should private `Minimizer`?)
 
### Two options to resolve 
1. Throw an exception if a TruthTable encountered a constant 0 or don't care result. This won't break compatibility, but need user handle empty TruthTable exception on their own. In this case A potential bug will be figured out during elaboration: 
*some control logic is not coupling to decode input(instruction or microOp)*, rather than tie 0, it will result an error similar to `unconnected signal` since, essentially, this control signal is not driven. 

2. Return `0.U`.
I thought this is bad, but since the backend is PLA: we can only return 0 to PLA to have a better logic. This does fix the issue. But won't trap the 'unconnected signal' error.

### So the problem becomes:
Should we return `0.U` directly? The current implementation of this PR is return `0.U` directly.
Or throw this error to user. It may be able to figure out some corner bug, but unexperienced user might happy with this.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement
- bug fix

#### API Impact
none

#### Backend Code Generation Impact

none

#### Desired Merge Strategy

- Squash: The PR will be squashed and merged (choose this if you have no preference.

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
