### PR TITLE
Update supported val modifiers for @public

### DIFF
--- a/macros/src/main/scala/chisel3/internal/InstantiableMacro.scala
+++ b/macros/src/main/scala/chisel3/internal/InstantiableMacro.scala
@@ -18,19 +18,21 @@ private[chisel3] object instantiableMacro {
       //  function and the argument to the generated implicit class.
       val resultStats = stats.flatMap { stat =>
         stat match {
-          case hasPublic: ValOrDefDef if hasPublic.mods.annotations.toString.contains("new public()") => hasPublic match {
-            case aDef: DefDef =>
-              c.error(aDef.pos, s"Cannot mark a def as @public")
-              Nil
-            // For now, we only omit protected/private vals
-            case aVal: ValDef if aVal.mods.hasFlag(c.universe.Flag.PRIVATE) || aVal.mods.hasFlag(c.universe.Flag.PROTECTED) =>
-              c.error(aVal.pos, s"Cannot mark a private or protected val as @public")
-              Nil
-            case aVal: ValDef =>
-              extensions += atPos(aVal.pos)(q"def ${aVal.name} = ___module._lookup(_.${aVal.name})")
-              if(aVal.name.toString == aVal.children.last.toString) Nil else Seq(aVal)
-            case other => Seq(other)
-          }
+          case hasPublic: ValOrDefDef if hasPublic.mods.annotations.toString.contains("new public()") =>
+            hasPublic match {
+              case aDef: DefDef =>
+                c.error(aDef.pos, s"Cannot mark a def as @public")
+                Nil
+              // For now, we only omit protected/private vals
+              case aVal: ValDef
+                  if aVal.mods.hasFlag(c.universe.Flag.PRIVATE) || aVal.mods.hasFlag(c.universe.Flag.PROTECTED) =>
+                c.error(aVal.pos, s"Cannot mark a private or protected val as @public")
+                Nil
+              case aVal: ValDef =>
+                extensions += atPos(aVal.pos)(q"def ${aVal.name} = ___module._lookup(_.${aVal.name})")
+                if (aVal.name.toString == aVal.children.last.toString) Nil else Seq(aVal)
+              case other => Seq(other)
+            }
           case other => Seq(other)
         }
       }

--- a/macros/src/main/scala/chisel3/internal/InstantiableMacro.scala
+++ b/macros/src/main/scala/chisel3/internal/InstantiableMacro.scala
@@ -16,21 +16,24 @@ private[chisel3] object instantiableMacro {
       // Note the triple `_` prefixing `module` is to avoid conflicts if a user marks a 'val module'
       //  with @public; in this case, the lookup code is ambiguous between the generated `def module`
       //  function and the argument to the generated implicit class.
-      val resultStats = stats.flatMap {
-        case x @ q"@public val $tpname: $tpe = $name" if tpname.toString() == name.toString() =>
-          extensions += atPos(x.pos)(q"def $tpname = ___module._lookup(_.$tpname)")
-          Nil
-        case x @ q"@public val $tpname: $tpe = $_" =>
-          extensions += atPos(x.pos)(q"def $tpname = ___module._lookup(_.$tpname)")
-          Seq(x)
-        case x @ q"@public val $tpname: $tpe" =>
-          extensions += atPos(x.pos)(q"def $tpname = ___module._lookup(_.$tpname)")
-          Seq(x)
-        case x @ q"@public lazy val $tpname: $tpe = $_" =>
-          extensions += atPos(x.pos)(q"def $tpname = ___module._lookup(_.$tpname)")
-          Seq(x)
-        case other =>
-          Seq(other)
+      val resultStats = stats.flatMap { stat =>
+        stat match {
+          case hasPublic: ValOrDefDef if hasPublic.mods.annotations.toString.contains("new public()") => hasPublic match {
+            case aDef: DefDef =>
+              c.error(aDef.pos, s"Cannot mark a def as @public")
+              Nil
+            // For now, we only omit protected/private vals
+            case aVal: ValDef if aVal.mods.hasFlag(c.universe.Flag.PRIVATE) || aVal.mods.hasFlag(c.universe.Flag.PROTECTED) =>
+              c.error(aVal.pos, s"Cannot mark a private or protected val as @public")
+              Nil
+            case aVal: ValDef if aVal.name.toString.contains("ADAM") => c.abort(aVal.pos, s"$aVal"); Nil
+            case aVal: ValDef =>
+              extensions += atPos(aVal.pos)(q"def ${aVal.name} = ___module._lookup(_.${aVal.name})")
+              if(aVal.name.toString == aVal.children.last.toString) Nil else Seq(aVal)
+            case other => Seq(other)
+          }
+          case other => Seq(other)
+        }
       }
       (resultStats, extensions)
     }

--- a/macros/src/main/scala/chisel3/internal/InstantiableMacro.scala
+++ b/macros/src/main/scala/chisel3/internal/InstantiableMacro.scala
@@ -26,7 +26,6 @@ private[chisel3] object instantiableMacro {
             case aVal: ValDef if aVal.mods.hasFlag(c.universe.Flag.PRIVATE) || aVal.mods.hasFlag(c.universe.Flag.PROTECTED) =>
               c.error(aVal.pos, s"Cannot mark a private or protected val as @public")
               Nil
-            case aVal: ValDef if aVal.name.toString.contains("ADAM") => c.abort(aVal.pos, s"$aVal"); Nil
             case aVal: ValDef =>
               extensions += atPos(aVal.pos)(q"def ${aVal.name} = ___module._lookup(_.${aVal.name})")
               if(aVal.name.toString == aVal.children.last.toString) Nil else Seq(aVal)

--- a/src/test/scala/chiselTests/experimental/hierarchy/InstanceSpec.scala
+++ b/src/test/scala/chiselTests/experimental/hierarchy/InstanceSpec.scala
@@ -303,7 +303,11 @@ class InstanceSpec extends ChiselFunSpec with Utils {
         val value = 10
         val overriddenVal = 10
       }
-      @instantiable class SubClass() extends SupClass {
+      trait SupTrait {
+        def x: Int
+        def y: Int
+      }
+      @instantiable class SubClass() extends SupClass with SupTrait {
         // This errors
         //@public private val privateVal = 10
         // This errors
@@ -312,6 +316,8 @@ class InstanceSpec extends ChiselFunSpec with Utils {
         @public final val finalVal = 12
         @public lazy val lazyValue = 12
         @public val value = value
+        @public final override lazy val x: Int = 3
+        @public override final lazy val y: Int = 4
       }
     }
   }

--- a/src/test/scala/chiselTests/experimental/hierarchy/InstanceSpec.scala
+++ b/src/test/scala/chiselTests/experimental/hierarchy/InstanceSpec.scala
@@ -309,6 +309,7 @@ class InstanceSpec extends ChiselFunSpec with Utils {
         // This errors
         //@public protected val protectedVal = 10
         @public override val overriddenVal = 12
+        @public final val finalVal = 12
         @public lazy val lazyValue = 12
         @public val value = value
       }

--- a/src/test/scala/chiselTests/experimental/hierarchy/InstanceSpec.scala
+++ b/src/test/scala/chiselTests/experimental/hierarchy/InstanceSpec.scala
@@ -298,6 +298,21 @@ class InstanceSpec extends ChiselFunSpec with Utils {
       annos should contain(MarkAnnotation("~Top|Top/i:HasEither>x".rt, "xright"))
       annos should contain(MarkAnnotation("~Top|Top/i:HasEither>y".rt, "yleft"))
     }
+    it("3.12: should properly support val modifiers") {
+      class SupClass extends Module {
+        val value = 10
+        val overriddenVal = 10
+      }
+      @instantiable class SubClass() extends SupClass {
+        // This errors
+        //@public private val privateVal = 10
+        // This errors
+        //@public protected val protectedVal = 10
+        @public override val overriddenVal = 12
+        @public lazy val lazyValue = 12
+        @public val value = value
+      }
+    }
   }
   describe("4: toInstance") {
     it("4.0: should work on modules") {


### PR DESCRIPTION
### Contributor Checklist

- [N/A] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [N/A] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
  - bug fix
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->
Now supports more modifiers on the val's marked with `@public`, including `final` and `override`.


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
  - Squash: The PR will be squashed and merged (choose this if you have no preference.


#### Release Notes

Support more `val` modifiers like `final` and `override` for `@public`.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
