### PR TITLE
Make Tuple2 Lookupable

### DIFF
--- a/core/src/main/scala/chisel3/experimental/hierarchy/Lookupable.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/Lookupable.scala
@@ -19,7 +19,7 @@ import chisel3.internal.{throwException, AggregateViewBinding, Builder, ChildBin
   */
 @implicitNotFound(
   "@public is only legal within a class or trait marked @instantiable, and only on vals of type" +
-    " Data, BaseModule, IsInstantiable, IsLookupable, or Instance[_], or in an Iterable, Option, or Either"
+    " Data, BaseModule, IsInstantiable, IsLookupable, or Instance[_], or in an Iterable, Option, Either, or Tuple2"
 )
 trait Lookupable[-B] {
   type C // Return type of the lookup

--- a/core/src/main/scala/chisel3/experimental/hierarchy/Lookupable.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/Lookupable.scala
@@ -402,6 +402,28 @@ object Lookupable {
       }
     }
   }
+
+  implicit def lookupTuple2[X, Y](
+    implicit sourceInfo: SourceInfo,
+    compileOptions:      CompileOptions,
+    lookupableX:         Lookupable[X],
+    lookupableY:         Lookupable[Y]
+  ) = new Lookupable[(X, Y)] {
+    type C = (lookupableX.C, lookupableY.C)
+    def definitionLookup[A](that: A => (X, Y), definition: Definition[A]): C = {
+      val ret = that(definition.proto)
+      (
+        lookupableX.definitionLookup[A](_ => ret._1, definition),
+        lookupableY.definitionLookup[A](_ => ret._2, definition)
+      )
+    }
+    def instanceLookup[A](that: A => (X, Y), instance: Instance[A]): C = {
+      import instance._
+      val ret = that(proto)
+      (lookupableX.instanceLookup[A](_ => ret._1, instance), lookupableY.instanceLookup[A](_ => ret._2, instance))
+    }
+  }
+
   implicit def lookupIsInstantiable[B <: IsInstantiable](
     implicit sourceInfo: SourceInfo,
     compileOptions:      CompileOptions

--- a/src/test/scala/chiselTests/experimental/hierarchy/DefinitionSpec.scala
+++ b/src/test/scala/chiselTests/experimental/hierarchy/DefinitionSpec.scala
@@ -329,6 +329,16 @@ class DefinitionSpec extends ChiselFunSpec with Utils {
       annos should contain(MarkAnnotation("~Top|HasEither>x".rt, "xright"))
       annos should contain(MarkAnnotation("~Top|HasEither>y".rt, "yleft"))
     }
+    it("3.12: should work on tuple2") {
+      class Top() extends Module {
+        val i = Definition(new HasTuple2())
+        mark(i.xy._1, "x")
+        mark(i.xy._2, "y")
+      }
+      val (_, annos) = getFirrtlAndAnnos(new Top)
+      annos should contain(MarkAnnotation("~Top|HasTuple2>x".rt, "x"))
+      annos should contain(MarkAnnotation("~Top|HasTuple2>y".rt, "y"))
+    }
   }
   describe("4: toDefinition") {
     it("4.0: should work on modules") {

--- a/src/test/scala/chiselTests/experimental/hierarchy/Examples.scala
+++ b/src/test/scala/chiselTests/experimental/hierarchy/Examples.scala
@@ -200,6 +200,12 @@ object Examples {
     @public val y: Either[Bool, UInt] = Left(Wire(Bool()).suggestName("y"))
   }
   @instantiable
+  class HasTuple2() extends Module {
+    val x = Wire(UInt(3.W))
+    val y = Wire(Bool())
+    @public val xy = (x, y)
+  }
+  @instantiable
   class HasVec() extends Module {
     @public val x = VecInit(1.U, 2.U, 3.U)
   }

--- a/src/test/scala/chiselTests/experimental/hierarchy/InstanceSpec.scala
+++ b/src/test/scala/chiselTests/experimental/hierarchy/InstanceSpec.scala
@@ -288,7 +288,7 @@ class InstanceSpec extends ChiselFunSpec with Utils {
       val (_, annos) = getFirrtlAndAnnos(new Top)
       annos should contain(MarkAnnotation("~Top|Top/i:HasPublicConstructorArgs>x".rt, "10"))
     }
-        it("3.11: should work on eithers") {
+    it("3.11: should work on eithers") {
       class Top() extends Module {
         val i = Instance(Definition(new HasEither()))
         i.x.map(x => mark(x, "xright")).left.map(x => mark(x, "xleft"))

--- a/src/test/scala/chiselTests/experimental/hierarchy/InstanceSpec.scala
+++ b/src/test/scala/chiselTests/experimental/hierarchy/InstanceSpec.scala
@@ -288,7 +288,7 @@ class InstanceSpec extends ChiselFunSpec with Utils {
       val (_, annos) = getFirrtlAndAnnos(new Top)
       annos should contain(MarkAnnotation("~Top|Top/i:HasPublicConstructorArgs>x".rt, "10"))
     }
-    it("3.11: should work on eithers") {
+        it("3.11: should work on eithers") {
       class Top() extends Module {
         val i = Instance(Definition(new HasEither()))
         i.x.map(x => mark(x, "xright")).left.map(x => mark(x, "xleft"))
@@ -298,7 +298,18 @@ class InstanceSpec extends ChiselFunSpec with Utils {
       annos should contain(MarkAnnotation("~Top|Top/i:HasEither>x".rt, "xright"))
       annos should contain(MarkAnnotation("~Top|Top/i:HasEither>y".rt, "yleft"))
     }
-    it("3.12: should properly support val modifiers") {
+    it("3.12: should work on tuple2") {
+      class Top() extends Module {
+        val i = Instance(Definition(new HasTuple2()))
+        mark(i.xy._1, "x")
+        mark(i.xy._2, "y")
+      }
+      val (_, annos) = getFirrtlAndAnnos(new Top)
+      annos should contain(MarkAnnotation("~Top|Top/i:HasTuple2>x".rt, "x"))
+      annos should contain(MarkAnnotation("~Top|Top/i:HasTuple2>y".rt, "y"))
+    }
+    
+    it("3.13: should properly support val modifiers") {
       class SupClass extends Module {
         val value = 10
         val overriddenVal = 10

--- a/src/test/scala/chiselTests/experimental/hierarchy/InstanceSpec.scala
+++ b/src/test/scala/chiselTests/experimental/hierarchy/InstanceSpec.scala
@@ -308,7 +308,7 @@ class InstanceSpec extends ChiselFunSpec with Utils {
       annos should contain(MarkAnnotation("~Top|Top/i:HasTuple2>x".rt, "x"))
       annos should contain(MarkAnnotation("~Top|Top/i:HasTuple2>y".rt, "y"))
     }
-    
+
     it("3.13: should properly support val modifiers") {
       class SupClass extends Module {
         val value = 10


### PR DESCRIPTION
### Contributor Checklist

- [N/A] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [N/A] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
 - new feature/API     
 - 
#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

Adds Tuple2 as something which is Lookupable (can be marked @public).

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

It doesnt change any verilog.

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
 - Squash: The PR will be squashed and merged (choose this if you have no preference. 
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

Make Tuple2 Lookupable

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
