### PR TITLE
Warn BitPat with unknown Uint width

### DIFF
--- a/src/main/scala/chisel3/util/BitPat.scala
+++ b/src/main/scala/chisel3/util/BitPat.scala
@@ -2,11 +2,13 @@
 
 package chisel3.util
 
-import scala.language.experimental.macros
 import chisel3._
 import chisel3.internal.sourceinfo.{SourceInfo, SourceInfoTransform}
+import logger.LazyLogging
 
-object BitPat {
+import scala.language.experimental.macros
+
+object BitPat extends LazyLogging {
 
   private[chisel3] implicit val bitPatOrder = new Ordering[BitPat] {
     import scala.math.Ordered.orderingToOrdered
@@ -95,7 +97,15 @@ object BitPat {
     */
   def apply(x: UInt): BitPat = {
     require(x.isLit, s"$x is not a literal, BitPat.apply(x: UInt) only accepts literals")
-    val len = if (x.isWidthKnown) x.getWidth else 0
+    val len =
+      if (x.isWidthKnown) x.getWidth
+      else {
+        logger.warn(
+          s"""$x doesn't have a explicit width, the result width will be ${x.litValue.bitCount}.
+             |To eliminate this warning, please add width to $x.""".stripMargin
+        )
+        0
+      }
     apply("b" + x.litValue.toString(2).reverse.padTo(len, "0").reverse.mkString)
   }
 


### PR DESCRIPTION
This might cause alignment bug from user codes, print a runtime warning to warn this use case.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [ ] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [ ] Did you state the API impact?
- [ ] Did you specify the code generation impact?
- [ ] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

- new feature/API

#### API Impact
If user use `BitPat(0.U)` will receive a warning to ask them add explicit width to get rid of potential bugs.

#### Backend Code Generation Impact
None

#### Desired Merge Strategy
- Squash: The PR will be squashed and merged (choose this if you have no preference.

#### Release Notes
If user use `BitPat(0.U)` will receive a warning to ask them add explicit width to get rid of potential bugs.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
