### PR TITLE
Make truthtable being able to accept unknown input width.

### DIFF
--- a/src/main/scala/chisel3/util/experimental/decode/TruthTable.scala
+++ b/src/main/scala/chisel3/util/experimental/decode/TruthTable.scala
@@ -31,10 +31,14 @@ object TruthTable {
 
   /** Convert a table and default output into a [[TruthTable]]. */
   def apply(table: Iterable[(BitPat, BitPat)], default: BitPat, sort: Boolean = true): TruthTable = {
-    require(table.map(_._1.getWidth).toSet.size == 1, "input width not equal.")
+    val inputWidth = table.map(_._1.getWidth).max
     require(table.map(_._2.getWidth).toSet.size == 1, "output width not equal.")
     val outputWidth = table.map(_._2.getWidth).head
-    val mergedTable = table
+    val mergedTable = table.map {
+      case (in, out) =>
+        // pad input signals.
+        (BitPat.dontCare(inputWidth - in.getWidth) ## in, out)
+    }
       .groupBy(_._1.toString)
       .map {
         case (key, values) =>

--- a/src/main/scala/chisel3/util/experimental/decode/TruthTable.scala
+++ b/src/main/scala/chisel3/util/experimental/decode/TruthTable.scala
@@ -35,9 +35,10 @@ object TruthTable {
     require(table.map(_._2.getWidth).toSet.size == 1, "output width not equal.")
     val outputWidth = table.map(_._2.getWidth).head
     val mergedTable = table.map {
-      case (in, out) =>
-        // pad input signals.
-        (BitPat.dontCare(inputWidth - in.getWidth) ## in, out)
+      // pad input signals if necessary
+      case (in, out) if inputWidth > in.width =>
+        (BitPat.dontCare(inputWidth - in.width) ## in, out)
+      case (in, out) => (in, out)
     }
       .groupBy(_._1.toString)
       .map {

--- a/src/main/scala/chisel3/util/experimental/decode/TruthTable.scala
+++ b/src/main/scala/chisel3/util/experimental/decode/TruthTable.scala
@@ -37,7 +37,7 @@ object TruthTable {
     val mergedTable = table.map {
       // pad input signals if necessary
       case (in, out) if inputWidth > in.width =>
-        (BitPat.dontCare(inputWidth - in.width) ## in, out)
+        (BitPat.N(inputWidth - in.width) ## in, out)
       case (in, out) => (in, out)
     }
       .groupBy(_._1.toString)

--- a/src/test/scala/chiselTests/util/experimental/TruthTableSpec.scala
+++ b/src/test/scala/chiselTests/util/experimental/TruthTableSpec.scala
@@ -80,4 +80,28 @@ class TruthTableSpec extends AnyFlatSpec {
     }
     assert(chisel3.stage.ChiselStage.emitChirrtl(new Foo) == chisel3.stage.ChiselStage.emitChirrtl(new Foo))
   }
+  "TruthTable" should "accept unknown input width" in {
+    val t = TruthTable(
+      Seq(
+        BitPat(0.U) -> BitPat.dontCare(1),
+        BitPat(1.U) -> BitPat.dontCare(1),
+        BitPat(2.U) -> BitPat.dontCare(1),
+        BitPat(3.U) -> BitPat.dontCare(1),
+        BitPat(4.U) -> BitPat.dontCare(1),
+        BitPat(5.U) -> BitPat.dontCare(1),
+        BitPat(6.U) -> BitPat.dontCare(1),
+        BitPat(7.U) -> BitPat.dontCare(1)
+      ),
+      BitPat.N(1)
+    )
+    assert(t.toString contains "000->?")
+    assert(t.toString contains "001->?")
+    assert(t.toString contains "010->?")
+    assert(t.toString contains "011->?")
+    assert(t.toString contains "100->?")
+    assert(t.toString contains "101->?")
+    assert(t.toString contains "110->?")
+    assert(t.toString contains "111->?")
+    assert(t.toString contains "     0")
+  }
 }


### PR DESCRIPTION
During the migration to RC.
I encountered this issue: sometime input or output width are unknown.
I originally think the input to decoder was a set of MicroOp, which is certainly a known width. in RC CSR, it shows the usage as an address decoder. I think it's reasonable to have an input unknown width.
However in the output side, the result of decode logic is always a control logic, padding it is an anti-pattern design.
So, this PR makes TruthTable accepting an unknown width to fit to the use cases like RC CSR.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [ ] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [ ] Did you state the API impact?
- [ ] Did you specify the code generation impact?
- [ ] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement
- bug fix

#### API Impact
TruthTable will accept unknown width input now.
#### Backend Code Generation Impact
None

#### Desired Merge Strategy
- Squash: The PR will be squashed and merged (choose this if you have no preference.

#### Release Notes
TruthTable will accept unknown width input now.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
