### PR TITLE
FillInterleaved documentation: order of elements was backwards in Seq example

### DIFF
--- a/src/main/scala/chisel3/util/Bitwise.scala
+++ b/src/main/scala/chisel3/util/Bitwise.scala
@@ -14,7 +14,7 @@ import chisel3._
   * FillInterleaved(2, "b1 0 0 1".U)  // equivalent to "b11 00 00 11".U
   * FillInterleaved(2, myUIntWire)  // dynamic interleaved fill
   *
-  * FillInterleaved(2, Seq(true.B, false.B, false.B, false.B))  // equivalent to "b11 00 00 00".U
+  * FillInterleaved(2, Seq(false.B, false.B, false.B, true.B))  // equivalent to "b11 00 00 00".U
   * FillInterleaved(2, Seq(true.B, false.B, false.B, true.B))  // equivalent to "b11 00 00 11".U
   * }}}
   */


### PR DESCRIPTION
### Contributor Checklist
- [X] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [X] Did you delete any extraneous printlns/debugging code?
- [X] Did you specify the type of improvement?
- [X] Did you add appropriate documentation in `docs/src`?
- [X] Did you state the API impact?
- [X] Did you specify the code generation impact?
- [X] Did you request a desired merge strategy?
- [X] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement
- documentation

#### API Impact
no functional change

#### Backend Code Generation Impact
no generation change

#### Desired Merge Strategy
- Squash: The PR will be squashed and merged (choose this if you have no preference.

#### Release Notes
FillInterleaved documentation: order of elements was backwards in Seq example

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
