### PR TITLE
Fix bundle elements performance regression

### DIFF
--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -1208,7 +1208,9 @@ abstract class Bundle(implicit compileOptions: CompileOptions) extends Record {
     * }}}
     */
   final lazy val elements: SeqMap[String, Data] = {
-    val hardwareFields = _elementsImpl.flatMap {
+    // _elementsImpl is a method, only call it once
+    val elementsImpl = _elementsImpl
+    val hardwareFields = elementsImpl.flatMap {
       case (name, data: Data) =>
         if (data.isSynthesizable) {
           Some(s"$name: $data")
@@ -1241,7 +1243,7 @@ abstract class Bundle(implicit compileOptions: CompileOptions) extends Record {
     if (hardwareFields.nonEmpty) {
       throw ExpectedChiselTypeException(s"Bundle: $this contains hardware fields: " + hardwareFields.mkString(","))
     }
-    VectorMap(_elementsImpl.toSeq.flatMap {
+    VectorMap(elementsImpl.toSeq.flatMap {
       case (name, data: Data) =>
         Some(name -> data)
       case (name, Some(data: Data)) =>

--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -1207,10 +1207,19 @@ abstract class Bundle(implicit compileOptions: CompileOptions) extends Record {
     *   assert(uint === "h12345678".U) // This will pass
     * }}}
     */
-  final lazy val elements: SeqMap[String, Data] = {
+  final lazy val elements: SeqMap[String, Data] =
     // _elementsImpl is a method, only call it once
-    val elementsImpl = _elementsImpl
-    val hardwareFields = elementsImpl.flatMap {
+    _elementsImpl match {
+      // Those not using plugin-generated _elementsImpl use the old reflective implementation
+      case oldElements: VectorMap[_, _] => oldElements.asInstanceOf[VectorMap[String, Data]]
+      // Plugin-generated _elementsImpl are incomplete and need some processing
+      case rawElements => _processRawElements(rawElements)
+    }
+
+  // The compiler plugin is imperfect at picking out elements statically so we process at runtime
+  // checking for errors and filtering out mistakes
+  private def _processRawElements(rawElements: Iterable[(String, Any)]): SeqMap[String, Data] = {
+    val hardwareFields = rawElements.flatMap {
       case (name, data: Data) =>
         if (data.isSynthesizable) {
           Some(s"$name: $data")
@@ -1243,7 +1252,7 @@ abstract class Bundle(implicit compileOptions: CompileOptions) extends Record {
     if (hardwareFields.nonEmpty) {
       throw ExpectedChiselTypeException(s"Bundle: $this contains hardware fields: " + hardwareFields.mkString(","))
     }
-    VectorMap(elementsImpl.toSeq.flatMap {
+    VectorMap(rawElements.toSeq.flatMap {
       case (name, data: Data) =>
         Some(name -> data)
       case (name, Some(data: Data)) =>
@@ -1253,15 +1262,17 @@ abstract class Bundle(implicit compileOptions: CompileOptions) extends Record {
       case ((an, a), (bn, b)) => (a._id > b._id) || ((a eq b) && (an > bn))
     }: _*)
   }
-  /*
-   * This method will be overwritten by the Chisel-Plugin
+
+  /* The old, reflective implementation of Bundle.elements
+   * This method is optionally overwritten by the compiler plugin for much better performance
    */
   protected def _elementsImpl: Iterable[(String, Any)] = {
     val nameMap = LinkedHashMap[String, Data]()
     for (m <- getPublicFields(classOf[Bundle])) {
       getBundleField(m) match {
         case Some(d: Data) =>
-          // Checking for chiselType is done in elements method
+          requireIsChiselType(d)
+
           if (nameMap contains m.getName) {
             require(nameMap(m.getName) eq d)
           } else {


### PR DESCRIPTION
I previously measured that https://github.com/chipsalliance/chisel3/pull/2306 improved the performance of Chisel3 on a typical large SiFive design by 16%, more careful measurements show that number to actually be **30%**.

**However,** this benefit only comes if the user uses the scalacOption `-P:chiselplugin:genBundleElements` which tells the Chisel compiler plugin to generate `Bundle.elements`. I then tried this typical large SiFive design without that scalacOption and I found Chisel to run 21% **slower**. Considering most users will bump to 3.5.1 and won't apply that new scalacOption immediately (if they ever do), this slowdown is unacceptable.

This PR changes 2 small things:
1. Only call _elementsImpl once in Bundle.elements -- this mitigates most of the slowdown but not all of it. It also speed up the case when folks are using `-P:chiselplugin:genBundleElements` (although probably a very small amount). 
2. Make the reflective `_elementsImpl` use the exact old implementation of `Bundle.elements`, `Bundle.elements` then matches on the output of `_elementsImpl` and just returns immediately when its the reflective implementation.

This appears to fully mitigate the slowdown.

I tested this on SiFive designs as well as by disabling Bundle.elements generation in the chisel3 tests and running `sbt test`.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

No release notes necessary because this feature is not yet released.

#### Type of Improvement

 - bug fix       
 - performance improvement 

#### API Impact

No impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

 - Squash

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
