### PR TITLE
Overload getVerilogString to accept arguments

### DIFF
--- a/src/main/scala/chisel3/verilog.scala
+++ b/src/main/scala/chisel3/verilog.scala
@@ -4,7 +4,29 @@ import chisel3.stage.ChiselStage
 import firrtl.AnnotationSeq
 
 object getVerilogString {
+
+  /**
+    * Returns a string containing the Verilog for the module specified by
+    * the target.
+    *
+    * @param gen the module to be converted to Verilog
+    * @return a string containing the Verilog for the module specified by
+    *         the target
+    */
   def apply(gen: => RawModule): String = ChiselStage.emitVerilog(gen)
+
+  /**
+    * Returns a string containing the Verilog for the module specified by
+    * the target accepting arguments and annotations
+    *
+    * @param gen the module to be converted to Verilog
+    * @param args arguments to be passed to the compiler
+    * @param annotations annotations to be passed to the compiler
+    * @return a string containing the Verilog for the module specified by
+    *         the target
+    */
+  def apply(gen: => RawModule, args: Array[String] = Array.empty, annotations: AnnotationSeq = Seq.empty): String =
+    (new ChiselStage).emitVerilog(gen, args, annotations)
 }
 
 object emitVerilog {

--- a/src/test/scala/chiselTests/Module.scala
+++ b/src/test/scala/chiselTests/Module.scala
@@ -18,6 +18,8 @@ class SimpleIO extends Bundle {
 
 class PlusOne extends Module {
   val io = IO(new SimpleIO)
+  val myReg = RegInit(0.U(8.W))
+  dontTouch(myReg)
   io.out := io.in + 1.asUInt
 }
 
@@ -267,6 +269,13 @@ class ModuleSpec extends ChiselPropSpec with Utils {
   property("getVerilogString(new PlusOne() should produce a valid Verilog string") {
     val s = getVerilogString(new PlusOne())
     assert(s.contains("assign io_out = io_in + 32'h1"))
+    assert(s.contains("RANDOMIZE_REG_INIT"))
+  }
+
+  property("getVerilogString(new PlusOne() should produce a valid Verilog string with arguments") {
+    val s = getVerilogString(new PlusOne(), Array("--emission-options=disableRegisterRandomization"))
+    assert(s.contains("assign io_out = io_in + 32'h1"))
+    assert(!s.contains("RANDOMIZE_REG_INIT"))
   }
 
   property("emitVerilog((new PlusOne()..) shall produce a valid Verilog file in a subfolder") {


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
- new feature/API

#### API Impact

This PR overloads `getVerilogString` to be able to accept arguments and annotations like `emitVerilog`.

#### Backend Code Generation Impact

No impact.

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
- Rebase: You will rebase the PR onto master and it will be merged with a merge commit.

#### Release Notes

Make `getVerilogString` be able to accept arguments and annotations.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
