### PR TITLE
Hierarchy API: make `Mem`s lookupable

### DIFF
--- a/core/src/main/scala/chisel3/Mem.scala
+++ b/core/src/main/scala/chisel3/Mem.scala
@@ -246,6 +246,8 @@ sealed abstract class MemBase[T <: Data](val t: T, val length: BigInt)
   )(
     implicit compileOptions: CompileOptions
   ): T = {
+    require(Builder.currentModule == _parent,
+      s"cannot create a memory port in a different module (${Builder.currentModule.get.name}) than where the memory is (${_parent.get.name}).")
     requireIsHardware(idx, "memory port index")
     val i = Vec.truncateIndex(idx, length)(sourceInfo, compileOptions)
 
@@ -267,7 +269,7 @@ sealed abstract class MemBase[T <: Data](val t: T, val length: BigInt)
   * @note when multiple conflicting writes are performed on a Mem element, the
   * result is undefined (unlike Vec, where the last assignment wins)
   */
-sealed class Mem[T <: Data] private (t: T, length: BigInt) extends MemBase(t, length)
+sealed class Mem[T <: Data] private[chisel3] (t: T, length: BigInt) extends MemBase(t, length)
 
 object SyncReadMem {
 
@@ -345,7 +347,7 @@ object SyncReadMem {
   * @note when multiple conflicting writes are performed on a Mem element, the
   * result is undefined (unlike Vec, where the last assignment wins)
   */
-sealed class SyncReadMem[T <: Data] private (t: T, n: BigInt, val readUnderWrite: SyncReadMem.ReadUnderWrite)
+sealed class SyncReadMem[T <: Data] private[chisel3] (t: T, n: BigInt, val readUnderWrite: SyncReadMem.ReadUnderWrite)
     extends MemBase[T](t, n) {
 
   override def read(x: UInt): T = macro SourceInfoTransform.xArg

--- a/core/src/main/scala/chisel3/Mem.scala
+++ b/core/src/main/scala/chisel3/Mem.scala
@@ -246,10 +246,11 @@ sealed abstract class MemBase[T <: Data](val t: T, val length: BigInt)
   )(
     implicit compileOptions: CompileOptions
   ): T = {
-    require(
-      Builder.currentModule == _parent,
-      s"cannot create a memory port in a different module (${Builder.currentModule.get.name}) than where the memory is (${_parent.get.name})."
-    )
+    if (Builder.currentModule != _parent) {
+      throwException(
+        s"Cannot create a memory port in a different module (${Builder.currentModule.get.name}) than where the memory is (${_parent.get.name})."
+      )
+    }
     requireIsHardware(idx, "memory port index")
     val i = Vec.truncateIndex(idx, length)(sourceInfo, compileOptions)
 

--- a/core/src/main/scala/chisel3/Mem.scala
+++ b/core/src/main/scala/chisel3/Mem.scala
@@ -246,8 +246,10 @@ sealed abstract class MemBase[T <: Data](val t: T, val length: BigInt)
   )(
     implicit compileOptions: CompileOptions
   ): T = {
-    require(Builder.currentModule == _parent,
-      s"cannot create a memory port in a different module (${Builder.currentModule.get.name}) than where the memory is (${_parent.get.name}).")
+    require(
+      Builder.currentModule == _parent,
+      s"cannot create a memory port in a different module (${Builder.currentModule.get.name}) than where the memory is (${_parent.get.name})."
+    )
     requireIsHardware(idx, "memory port index")
     val i = Vec.truncateIndex(idx, length)(sourceInfo, compileOptions)
 

--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -102,7 +102,9 @@ object Module extends SourceInfoDoc {
   ): T = {
     val parent = Builder.currentModule
     val module: T = bc // bc is actually evaluated here
-    Builder.currentModule = parent
+    if (Builder.currentModule != parent) {
+      Builder.currentModule = parent
+    }
 
     module
   }

--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -229,6 +229,7 @@ package internal {
     // Private internal class to serve as a _parent for Data in cloned ports
     private[chisel3] class ModuleClone[T <: BaseModule](val getProto: T) extends PseudoModule with IsClone[T] {
       override def toString = s"ModuleClone(${getProto})"
+      // Do not call default addId function, which may modify a module that is already "closed"
       override def addId(d: HasId): Unit = ()
       def getPorts = _portsRecord
       // ClonePorts that hold the bound ports for this module
@@ -308,6 +309,7 @@ package internal {
       override def toString = s"DefinitionClone(${getProto})"
       // No addition components are generated
       private[chisel3] def generateComponent(): Option[Component] = None
+      // Do not call default addId function, which may modify a module that is already "closed"
       override def addId(d: HasId): Unit = ()
       // Necessary for toTarget to work
       private[chisel3] def initializeInParent(parentCompileOptions: CompileOptions): Unit = ()

--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -101,8 +101,8 @@ object Module extends SourceInfoDoc {
     compileOptions:      CompileOptions
   ): T = {
     val parent = Builder.currentModule
-
     val module: T = bc // bc is actually evaluated here
+    Builder.currentModule = parent
 
     module
   }
@@ -229,6 +229,7 @@ package internal {
     // Private internal class to serve as a _parent for Data in cloned ports
     private[chisel3] class ModuleClone[T <: BaseModule](val getProto: T) extends PseudoModule with IsClone[T] {
       override def toString = s"ModuleClone(${getProto})"
+      override def addId(d: HasId): Unit = ()
       def getPorts = _portsRecord
       // ClonePorts that hold the bound ports for this module
       // Used for setting the refs of both this module and the Record
@@ -307,6 +308,7 @@ package internal {
       override def toString = s"DefinitionClone(${getProto})"
       // No addition components are generated
       private[chisel3] def generateComponent(): Option[Component] = None
+      override def addId(d: HasId): Unit = ()
       // Necessary for toTarget to work
       private[chisel3] def initializeInParent(parentCompileOptions: CompileOptions): Unit = ()
       // Module name is the same as proto's module name

--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -102,9 +102,7 @@ object Module extends SourceInfoDoc {
   ): T = {
     val parent = Builder.currentModule
     val module: T = bc // bc is actually evaluated here
-    if (Builder.currentModule != parent) {
-      Builder.currentModule = parent
-    }
+    if (!parent.isEmpty) { Builder.currentModule = parent }
 
     module
   }

--- a/core/src/main/scala/chisel3/experimental/hierarchy/Lookupable.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/Lookupable.scala
@@ -349,7 +349,7 @@ object Lookupable {
     }
 
   private[chisel3] def cloneMemToContext[T <: MemBase[_]](
-    mem:    T,
+    mem:     T,
     context: BaseModule
   )(
     implicit sourceInfo: SourceInfo,
@@ -366,7 +366,8 @@ object Lookupable {
             Builder.currentModule = Some(mod)
             val newChild: T = mem match {
               case m: Mem[_] => new Mem(m.t.asInstanceOf[Data].cloneTypeFull, m.length).asInstanceOf[T]
-              case m: SyncReadMem[_] => new SyncReadMem(m.t.asInstanceOf[Data].cloneTypeFull, m.length, m.readUnderWrite).asInstanceOf[T]
+              case m: SyncReadMem[_] =>
+                new SyncReadMem(m.t.asInstanceOf[Data].cloneTypeFull, m.length, m.readUnderWrite).asInstanceOf[T]
             }
             Builder.currentModule = existingMod
             newChild.setRef(mem.getRef, true)

--- a/core/src/main/scala/chisel3/experimental/hierarchy/Lookupable.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/Lookupable.scala
@@ -19,7 +19,7 @@ import chisel3.internal.{throwException, AggregateViewBinding, Builder, ChildBin
   */
 @implicitNotFound(
   "@public is only legal within a class or trait marked @instantiable, and only on vals of type" +
-    " Data, BaseModule, IsInstantiable, IsLookupable, or Instance[_], or in an Iterable, Option, or Either"
+    " Data, BaseModule, Mem, IsInstantiable, IsLookupable, or Instance[_], or in an Iterable, Option, or Either"
 )
 trait Lookupable[-B] {
   type C // Return type of the lookup
@@ -345,6 +345,44 @@ object Lookupable {
           doLookupData(ret, instance.cache, ioMap, instance.getInnerDataContext)
         }
 
+      }
+    }
+
+  private[chisel3] def cloneMemToContext[T <: MemBase[_]](
+    mem:    T,
+    context: BaseModule
+  )(
+    implicit sourceInfo: SourceInfo,
+    compileOptions:      CompileOptions
+  ): T = {
+    mem._parent match {
+      case None => mem
+      case Some(parent) =>
+        val newParent = cloneModuleToContext(Proto(parent), context)
+        newParent match {
+          case Proto(p) if p == parent => mem
+          case Clone(mod: BaseModule) =>
+            val existingMod = Builder.currentModule
+            Builder.currentModule = Some(mod)
+            val newChild: T = mem match {
+              case m: Mem[_] => new Mem(m.t.asInstanceOf[Data].cloneTypeFull, m.length).asInstanceOf[T]
+              case m: SyncReadMem[_] => new SyncReadMem(m.t.asInstanceOf[Data].cloneTypeFull, m.length, m.readUnderWrite).asInstanceOf[T]
+            }
+            Builder.currentModule = existingMod
+            newChild.setRef(mem.getRef, true)
+            newChild
+        }
+    }
+  }
+
+  implicit def lookupMem[B <: MemBase[_]](implicit sourceInfo: SourceInfo, compileOptions: CompileOptions) =
+    new Lookupable[B] {
+      type C = B
+      def definitionLookup[A](that: A => B, definition: Definition[A]): C = {
+        cloneMemToContext(that(definition.proto), definition.getInnerDataContext.get)
+      }
+      def instanceLookup[A](that: A => B, instance: Instance[A]): C = {
+        cloneMemToContext(that(instance.proto), instance.getInnerDataContext.get)
       }
     }
 

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -258,6 +258,7 @@ private[chisel3] trait HasId extends InstanceId {
       (p._component, this) match {
         case (Some(c), _) => refName(c)
         case (None, d: Data) if d.topBindingOpt == Some(CrossModuleBinding) => _ref.get.localName
+        case (None, _: MemBase[Data]) => _ref.get.localName
         case (None, _) =>
           throwException(s"signalName/pathName should be called after circuit elaboration: $this, ${_parent}")
       }

--- a/src/test/scala/chiselTests/experimental/hierarchy/Annotations.scala
+++ b/src/test/scala/chiselTests/experimental/hierarchy/Annotations.scala
@@ -7,7 +7,8 @@ import chisel3.experimental.{annotate, BaseModule}
 import chisel3.{Data, MemBase}
 import chisel3.experimental.hierarchy.{Definition, Hierarchy, Instance}
 
-object Annotations {
+// These annotations exist purely for testing purposes
+private[hierarchy] object Annotations {
   case class MarkAnnotation(target: IsMember, tag: String) extends SingleTargetAnnotation[IsMember] {
     def duplicate(n: IsMember): Annotation = this.copy(target = n)
   }

--- a/src/test/scala/chiselTests/experimental/hierarchy/Annotations.scala
+++ b/src/test/scala/chiselTests/experimental/hierarchy/Annotations.scala
@@ -3,8 +3,8 @@
 package chiselTests.experimental.hierarchy
 
 import _root_.firrtl.annotations._
-import chisel3.experimental.{annotate, BaseModule}
-import chisel3.Data
+import chisel3.experimental.{BaseModule, annotate}
+import chisel3.{Data, MemBase}
 import chisel3.experimental.hierarchy.{Definition, Hierarchy, Instance}
 
 object Annotations {
@@ -19,7 +19,12 @@ object Annotations {
       extends chisel3.experimental.ChiselAnnotation {
     def toFirrtl = if (isAbsolute) MarkAnnotation(d.toAbsoluteTarget, tag) else MarkAnnotation(d.toTarget, tag)
   }
+  case class MarkChiselMemAnnotation[T <: Data](m: MemBase[T], tag: String, isAbsolute: Boolean)
+    extends chisel3.experimental.ChiselAnnotation {
+    def toFirrtl = if (isAbsolute) MarkAnnotation(m.toAbsoluteTarget, tag) else MarkAnnotation(m.toTarget, tag)
+  }
   def mark(d:                   Data, tag:         String): Unit = annotate(MarkChiselAnnotation(d, tag, false))
+  def mark[T <: Data](d:        MemBase[T], tag:   String): Unit = annotate(MarkChiselMemAnnotation(d, tag, false))
   def mark[B <: BaseModule](d:  Hierarchy[B], tag: String): Unit = annotate(MarkChiselHierarchyAnnotation(d, tag, true))
   def amark(d:                  Data, tag:         String): Unit = annotate(MarkChiselAnnotation(d, tag, true))
   def amark[B <: BaseModule](d: Hierarchy[B], tag: String): Unit = annotate(MarkChiselHierarchyAnnotation(d, tag, true))

--- a/src/test/scala/chiselTests/experimental/hierarchy/Annotations.scala
+++ b/src/test/scala/chiselTests/experimental/hierarchy/Annotations.scala
@@ -3,7 +3,7 @@
 package chiselTests.experimental.hierarchy
 
 import _root_.firrtl.annotations._
-import chisel3.experimental.{BaseModule, annotate}
+import chisel3.experimental.{annotate, BaseModule}
 import chisel3.{Data, MemBase}
 import chisel3.experimental.hierarchy.{Definition, Hierarchy, Instance}
 
@@ -20,7 +20,7 @@ object Annotations {
     def toFirrtl = if (isAbsolute) MarkAnnotation(d.toAbsoluteTarget, tag) else MarkAnnotation(d.toTarget, tag)
   }
   case class MarkChiselMemAnnotation[T <: Data](m: MemBase[T], tag: String, isAbsolute: Boolean)
-    extends chisel3.experimental.ChiselAnnotation {
+      extends chisel3.experimental.ChiselAnnotation {
     def toFirrtl = if (isAbsolute) MarkAnnotation(m.toAbsoluteTarget, tag) else MarkAnnotation(m.toTarget, tag)
   }
   def mark(d:                   Data, tag:         String): Unit = annotate(MarkChiselAnnotation(d, tag, false))

--- a/src/test/scala/chiselTests/experimental/hierarchy/DefinitionSpec.scala
+++ b/src/test/scala/chiselTests/experimental/hierarchy/DefinitionSpec.scala
@@ -329,6 +329,27 @@ class DefinitionSpec extends ChiselFunSpec with Utils {
       annos should contain(MarkAnnotation("~Top|HasEither>x".rt, "xright"))
       annos should contain(MarkAnnotation("~Top|HasEither>y".rt, "yleft"))
     }
+    it("3.12: should work on Mems/SyncReadMems") {
+      class Top() extends Module {
+        val i = Definition(new HasMems())
+        mark(i.mem, "Mem")
+        mark(i.syncReadMem, "SyncReadMem")
+      }
+      val (_, annos) = getFirrtlAndAnnos(new Top)
+      annos should contain(MarkAnnotation("~Top|HasMems>mem".rt, "Mem"))
+      annos should contain(MarkAnnotation("~Top|HasMems>syncReadMem".rt, "SyncReadMem"))
+    }
+    it ("3.13: should not create memory ports") {
+      class Top() extends Module {
+        val i = Definition(new HasMems())
+        i.mem(0) := 100.U // should be illegal!
+      }
+      val failure = intercept[IllegalArgumentException] {
+        getFirrtlAndAnnos(new Top)
+      }
+      assert(failure.getMessage ==
+        "requirement failed: cannot create a memory port in a different module (Top) than where the memory is (HasMems).")
+    }
   }
   describe("4: toDefinition") {
     it("4.0: should work on modules") {

--- a/src/test/scala/chiselTests/experimental/hierarchy/DefinitionSpec.scala
+++ b/src/test/scala/chiselTests/experimental/hierarchy/DefinitionSpec.scala
@@ -354,12 +354,12 @@ class DefinitionSpec extends ChiselFunSpec with Utils {
         val i = Definition(new HasMems())
         i.mem(0) := 100.U // should be illegal!
       }
-      val failure = intercept[IllegalArgumentException] {
+      val failure = intercept[ChiselException] {
         getFirrtlAndAnnos(new Top)
       }
       assert(
         failure.getMessage ==
-          "requirement failed: cannot create a memory port in a different module (Top) than where the memory is (HasMems)."
+          "Cannot create a memory port in a different module (Top) than where the memory is (HasMems)."
       )
     }
   }

--- a/src/test/scala/chiselTests/experimental/hierarchy/DefinitionSpec.scala
+++ b/src/test/scala/chiselTests/experimental/hierarchy/DefinitionSpec.scala
@@ -339,7 +339,7 @@ class DefinitionSpec extends ChiselFunSpec with Utils {
       annos should contain(MarkAnnotation("~Top|HasMems>mem".rt, "Mem"))
       annos should contain(MarkAnnotation("~Top|HasMems>syncReadMem".rt, "SyncReadMem"))
     }
-    it ("3.13: should not create memory ports") {
+    it("3.13: should not create memory ports") {
       class Top() extends Module {
         val i = Definition(new HasMems())
         i.mem(0) := 100.U // should be illegal!
@@ -347,8 +347,10 @@ class DefinitionSpec extends ChiselFunSpec with Utils {
       val failure = intercept[IllegalArgumentException] {
         getFirrtlAndAnnos(new Top)
       }
-      assert(failure.getMessage ==
-        "requirement failed: cannot create a memory port in a different module (Top) than where the memory is (HasMems).")
+      assert(
+        failure.getMessage ==
+          "requirement failed: cannot create a memory port in a different module (Top) than where the memory is (HasMems)."
+      )
     }
   }
   describe("4: toDefinition") {

--- a/src/test/scala/chiselTests/experimental/hierarchy/Examples.scala
+++ b/src/test/scala/chiselTests/experimental/hierarchy/Examples.scala
@@ -252,4 +252,10 @@ object Examples {
     val i10 = Instance(tpDef1)
     val i11 = Instance(tpDef1)
   }
+
+  @instantiable
+  class HasMems() extends Module {
+    @public val mem = Mem(8, UInt(32.W))
+    @public val syncReadMem = SyncReadMem(8, UInt(32.W))
+  }
 }

--- a/src/test/scala/chiselTests/experimental/hierarchy/InstanceSpec.scala
+++ b/src/test/scala/chiselTests/experimental/hierarchy/InstanceSpec.scala
@@ -320,6 +320,17 @@ class InstanceSpec extends ChiselFunSpec with Utils {
         @public override final lazy val y: Int = 4
       }
     }
+    it("3.13: should work with Mems/SyncReadMems") {
+      class Top() extends Module {
+        val i = Instance(Definition(new HasMems()))
+        mark(i.mem, "Mem")
+        mark(i.syncReadMem, "SyncReadMem")
+      }
+      val (_, annos) = getFirrtlAndAnnos(new Top)
+      annos.foreach{x => println(x.serialize)}
+      annos should contain(MarkAnnotation("~Top|Top/i:HasMems>mem".rt, "Mem"))
+      annos should contain(MarkAnnotation("~Top|Top/i:HasMems>syncReadMem".rt, "SyncReadMem"))
+    }
   }
   describe("4: toInstance") {
     it("4.0: should work on modules") {

--- a/src/test/scala/chiselTests/experimental/hierarchy/InstanceSpec.scala
+++ b/src/test/scala/chiselTests/experimental/hierarchy/InstanceSpec.scala
@@ -327,7 +327,7 @@ class InstanceSpec extends ChiselFunSpec with Utils {
         mark(i.syncReadMem, "SyncReadMem")
       }
       val (_, annos) = getFirrtlAndAnnos(new Top)
-      annos.foreach{x => println(x.serialize)}
+      annos.foreach { x => println(x.serialize) }
       annos should contain(MarkAnnotation("~Top|Top/i:HasMems>mem".rt, "Mem"))
       annos should contain(MarkAnnotation("~Top|Top/i:HasMems>syncReadMem".rt, "SyncReadMem"))
     }


### PR DESCRIPTION
### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [ ] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
- new feature/API

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->
`@public` can now be used on definitions/instances of `Mem`s and `SyncReadMem`s.

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
- Squash: The PR will be squashed and merged
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
