### PR TITLE
Add scanLeftOr and scanRightOr utilies

### DIFF
--- a/integration-tests/src/test/scala/chiselTests/util/experimental/algorithm/Bitwise.scala
+++ b/integration-tests/src/test/scala/chiselTests/util/experimental/algorithm/Bitwise.scala
@@ -2,13 +2,12 @@
 
 import chisel3._
 import chisel3.util._
-import chisel3.experimental.util.algorithm._
 import chiseltest._
 import chiseltest.formal._
 import org.scalatest.flatspec.AnyFlatSpec
 import scala.math.min
 
-class scanLeftOrTestModule(width: Int) extends Module {
+class ScanLeftOrTestModule(width: Int) extends Module {
   val input = IO(Input(UInt(width.W)))
 
   var lsb = false.B
@@ -24,7 +23,7 @@ class scanLeftOrTestModule(width: Int) extends Module {
   assert(testee === ref)
 }
 
-class scanRightOrTestModule(width: Int) extends Module {
+class ScanRightOrTestModule(width: Int) extends Module {
   val input = IO(Input(UInt(width.W)))
 
   val ref = Reverse(scanLeftOr(Reverse(input)))
@@ -34,15 +33,15 @@ class scanRightOrTestModule(width: Int) extends Module {
 }
 
 class scanOrTest extends AnyFlatSpec with ChiselScalatestTester with Formal {
-  "scanLeftOr" should "correctly computes" in {
+  "scanLeftOr" should "compute correctly" in {
     for(i <- 1 to 16) {
-      verify(new scanLeftOrTestModule(i), Seq(BoundedCheck(1)))
+      verify(new ScanLeftOrTestModule(i), Seq(BoundedCheck(1)))
     }
   }
 
-  "scanRightOr" should "correctly computes" in {
+  "scanRightOr" should "compute correctly" in {
     for(i <- 1 to 16) {
-      verify(new scanRightOrTestModule(i), Seq(BoundedCheck(1)))
+      verify(new ScanRightOrTestModule(i), Seq(BoundedCheck(1)))
     }
   }
 }

--- a/integration-tests/src/test/scala/chiselTests/util/experimental/algorithm/Bitwise.scala
+++ b/integration-tests/src/test/scala/chiselTests/util/experimental/algorithm/Bitwise.scala
@@ -8,28 +8,7 @@ import chiseltest.formal._
 import org.scalatest.flatspec.AnyFlatSpec
 import scala.math.min
 
-// Copied from rocket-core
-object RocketImpl {
-  // Fill 1s from low bits to high bits
-  def leftOR(x: UInt): UInt = leftOR(x, x.getWidth, x.getWidth)
-  def leftOR(x: UInt, width: Integer, cap: Integer = 999999): UInt = {
-    val stop = min(width, cap)
-    def helper(s: Int, x: UInt): UInt =
-      if (s >= stop) x else helper(s+s, x | (x << s)(width-1,0))
-    helper(1, x)(width-1, 0)
-  }
-
-  // Fill 1s form high bits to low bits
-  def rightOR(x: UInt): UInt = rightOR(x, x.getWidth, x.getWidth)
-  def rightOR(x: UInt, width: Integer, cap: Integer = 999999): UInt = {
-    val stop = min(width, cap)
-    def helper(s: Int, x: UInt): UInt =
-      if (s >= stop) x else helper(s+s, x | (x >> s))
-    helper(1, x)(width-1, 0)
-  }
-}
-
-class LSBOrTestModule(width: Int) extends Module {
+class scanLeftOrTestModule(width: Int) extends Module {
   val input = IO(Input(UInt(width.W)))
 
   var lsb = false.B
@@ -39,35 +18,31 @@ class LSBOrTestModule(width: Int) extends Module {
     cur
   }
   val ref = VecInit(vec).asUInt
-  val rocketRef = RocketImpl.leftOR(input)
 
-  val testee = LSBOr(input)
+  val testee = scanLeftOr(input)
 
   assert(testee === ref)
-  assert(testee === rocketRef)
 }
 
-class MSBOrTestModule(width: Int) extends Module {
+class scanRightOrTestModule(width: Int) extends Module {
   val input = IO(Input(UInt(width.W)))
 
-  val ref = Reverse(LSBOr(Reverse(input)))
-  val rocketRef = RocketImpl.rightOR(input)
-  val testee = MSBOr(input)
+  val ref = Reverse(scanLeftOr(Reverse(input)))
+  val testee = scanRightOr(input)
 
   assert(testee === ref)
-  assert(testee === rocketRef)
 }
 
-class LSBMSBOrTest extends AnyFlatSpec with ChiselScalatestTester with Formal {
-  "LSBOr" should "correctly computes" in {
+class scanOrTest extends AnyFlatSpec with ChiselScalatestTester with Formal {
+  "scanLeftOr" should "correctly computes" in {
     for(i <- 1 to 16) {
-      verify(new LSBOrTestModule(i), Seq(BoundedCheck(1)))
+      verify(new scanLeftOrTestModule(i), Seq(BoundedCheck(1)))
     }
   }
 
-  "MSBOr" should "correctly computes" in {
+  "scanRightOr" should "correctly computes" in {
     for(i <- 1 to 16) {
-      verify(new MSBOrTestModule(i), Seq(BoundedCheck(1)))
+      verify(new scanRightOrTestModule(i), Seq(BoundedCheck(1)))
     }
   }
 }

--- a/integration-tests/src/test/scala/chiselTests/util/experimental/algorithm/Bitwise.scala
+++ b/integration-tests/src/test/scala/chiselTests/util/experimental/algorithm/Bitwise.scala
@@ -1,0 +1,45 @@
+import chisel3._
+import chisel3.util._
+import chisel3.experimental.util.algorithm._
+import chiseltest._
+import chiseltest.formal._
+import org.scalatest.flatspec.AnyFlatSpec
+
+class LSBOrTestModule(width: Int) extends Module {
+  val input = IO(Input(UInt(width.W)))
+
+  var lsb = false.B
+  val vec = for(b <- input.asBools) yield {
+    val cur = b || lsb
+    lsb = cur
+    cur
+  }
+  val ref = VecInit(vec).asUInt
+
+  val testee = LSBOr(input)
+
+  assert(testee === ref)
+}
+
+class MSBOrTestModule(width: Int) extends Module {
+  val input = IO(Input(UInt(width.W)))
+
+  val ref = Reverse(LSBOr(Reverse(input)))
+  val testee = MSBOr(input)
+
+  assert(testee === ref)
+}
+
+class LSBMSBOrTest extends AnyFlatSpec with ChiselScalatestTester with Formal {
+  "LSBOr" should "correctly computes" in {
+    for(i <- 1 to 16) {
+      verify(new LSBOrTestModule(i), Seq(BoundedCheck(1)))
+    }
+  }
+
+  "MSBOr" should "correctly computes" in {
+    for(i <- 1 to 16) {
+      verify(new MSBOrTestModule(i), Seq(BoundedCheck(1)))
+    }
+  }
+}

--- a/integration-tests/src/test/scala/chiselTests/util/experimental/algorithm/Bitwise.scala
+++ b/integration-tests/src/test/scala/chiselTests/util/experimental/algorithm/Bitwise.scala
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import chisel3._
 import chisel3.util._
 import chisel3.experimental.util.algorithm._

--- a/integration-tests/src/test/scala/chiselTests/util/experimental/algorithm/Bitwise.scala
+++ b/integration-tests/src/test/scala/chiselTests/util/experimental/algorithm/Bitwise.scala
@@ -6,6 +6,28 @@ import chisel3.experimental.util.algorithm._
 import chiseltest._
 import chiseltest.formal._
 import org.scalatest.flatspec.AnyFlatSpec
+import scala.math.min
+
+// Copied from rocket-core
+object RocketImpl {
+  // Fill 1s from low bits to high bits
+  def leftOR(x: UInt): UInt = leftOR(x, x.getWidth, x.getWidth)
+  def leftOR(x: UInt, width: Integer, cap: Integer = 999999): UInt = {
+    val stop = min(width, cap)
+    def helper(s: Int, x: UInt): UInt =
+      if (s >= stop) x else helper(s+s, x | (x << s)(width-1,0))
+    helper(1, x)(width-1, 0)
+  }
+
+  // Fill 1s form high bits to low bits
+  def rightOR(x: UInt): UInt = rightOR(x, x.getWidth, x.getWidth)
+  def rightOR(x: UInt, width: Integer, cap: Integer = 999999): UInt = {
+    val stop = min(width, cap)
+    def helper(s: Int, x: UInt): UInt =
+      if (s >= stop) x else helper(s+s, x | (x >> s))
+    helper(1, x)(width-1, 0)
+  }
+}
 
 class LSBOrTestModule(width: Int) extends Module {
   val input = IO(Input(UInt(width.W)))
@@ -17,19 +39,23 @@ class LSBOrTestModule(width: Int) extends Module {
     cur
   }
   val ref = VecInit(vec).asUInt
+  val rocketRef = RocketImpl.leftOR(input)
 
   val testee = LSBOr(input)
 
   assert(testee === ref)
+  assert(testee === rocketRef)
 }
 
 class MSBOrTestModule(width: Int) extends Module {
   val input = IO(Input(UInt(width.W)))
 
   val ref = Reverse(LSBOr(Reverse(input)))
+  val rocketRef = RocketImpl.rightOR(input)
   val testee = MSBOr(input)
 
   assert(testee === ref)
+  assert(testee === rocketRef)
 }
 
 class LSBMSBOrTest extends AnyFlatSpec with ChiselScalatestTester with Formal {

--- a/src/main/scala/chisel3/experimental/util/algorithm/Bitwise.scala
+++ b/src/main/scala/chisel3/experimental/util/algorithm/Bitwise.scala
@@ -25,6 +25,7 @@ object scanLeftOr {
     helper(1, data)(width - 1, 0)
   }
 }
+/** Map each bits to logical or of itself and all bits with higher index. 
   * Here `scanRight` means "start at the right and look to the left, where right is the highest index", a common operation on arrays and lists.
   * This is consistent with the `right` as in "shift right" performed on bits, which means "start at the left (most significant bit) and move to the right".
   * @example {{{

--- a/src/main/scala/chisel3/experimental/util/algorithm/Bitwise.scala
+++ b/src/main/scala/chisel3/experimental/util/algorithm/Bitwise.scala
@@ -4,42 +4,43 @@ package chisel3.experimental.util.algorithm
 
 import chisel3._
 
-/** Map each bits to logical or of itself and all bits less siginificant than it.
+/** Map each bits to logical or of itself and all bits with lower index.
+  * Here 'left' means 'with lower index', as in arrays and lists, not to be confused with the 'left' as in 'shift left'
   * @example {{{
-  * LSBOr("b00001000".U) // Returns "b11111000".U
-  * LSBOr("b00010100".U) // Returns "b11111100".U
-  * LSBOr("b00000000".U) // Returns "b00000000".U
+  * scanLeftOr("b00001000".U) // Returns "b11111000".U
+  * scanLeftOr("b00010100".U) // Returns "b11111100".U
+  * scanLeftOr("b00000000".U) // Returns "b00000000".U
   * }}}
-  * This circuit seems to be high fan out, but synthesis tool should handle this.
   */
-object LSBOr {
+object scanLeftOr {
   def apply(data: UInt): UInt = {
     val width = data.widthOption match {
       case Some(w) => w
-      case None    => throw new IllegalArgumentException("Cannot call LSBOr on data with unknown width.")
+      case None    => throw new IllegalArgumentException("Cannot call scanLeftOr on data with unknown width.")
     }
-    VecInit(Seq.tabulate(width) { i: Int =>
-      VecInit(data.asBools().dropRight(width - i - 1)).asUInt().orR()
-    }).asUInt()
+
+    def helper(s: Int, x: UInt): UInt =
+      if (s >= width) x else helper(s + s, x | (x << s)(width - 1, 0))
+    helper(1, data)(width - 1, 0)
   }
 }
 
-/** Map each bits to logical or of itself and all bits more siginificant than it.
+/** Map each bits to logical or of itself and all bits with higher index.
+  * Here 'right' means 'with higher index', as in arrays and lists, not to be confused with the 'right' as in 'shift right'
   * @example {{{
-  * MSBOr("b00001000".U) // Returns "b00001111".U
-  * MSBOr("b00010100".U) // Returns "b00011111".U
-  * MSBOr("b00000000".U) // Returns "b00000000".U
+  * scanRightOr("b00001000".U) // Returns "b00001111".U
+  * scanRightOr("b00010100".U) // Returns "b00011111".U
+  * scanRightOr("b00000000".U) // Returns "b00000000".U
   * }}}
-  * This circuit seems to be high fan out, but synthesis tool should handle this.
   */
-object MSBOr {
+object scanRightOr {
   def apply(data: UInt): UInt = {
     val width = data.widthOption match {
       case Some(w) => w
-      case None    => throw new IllegalArgumentException("Cannot call MSBOr on data with unknown width.")
+      case None    => throw new IllegalArgumentException("Cannot call scanRightOr on data with unknown width.")
     }
-    VecInit(Seq.tabulate(width) { i: Int =>
-      VecInit(data.asBools().drop(i)).asUInt().orR()
-    }).asUInt()
+    def helper(s: Int, x: UInt): UInt =
+      if (s >= width) x else helper(s + s, x | (x >> s))
+    helper(1, data)(width - 1, 0)
   }
 }

--- a/src/main/scala/chisel3/experimental/util/algorithm/Bitwise.scala
+++ b/src/main/scala/chisel3/experimental/util/algorithm/Bitwise.scala
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
-package chisel3.experimental.util.algorithm
+package chisel3.util
 
 import chisel3._
 
-/** Map each bits to logical or of itself and all bits with lower index.
-  * Here `scanLeft` means "start at the left and look to the right, where left is the lowest index", a common operation on arrays and lists.
-  * This is consistent with the `left` as in "shift left" performed on bits, which means "start at the right (least significant bit) and move to the left".
+/** Map each bit to the logical OR of itself and all bits with lower index
+  *
+  * Here `scanLeft` means "start from the left and iterate to the right, where left is the lowest index", a common operation on arrays and lists.
   * @example {{{
   * scanLeftOr("b00001000".U(8.W)) // Returns "b11111000".U
   * scanLeftOr("b00010100".U(8.W)) // Returns "b11111100".U
@@ -25,9 +25,10 @@ object scanLeftOr {
     helper(1, data)(width - 1, 0)
   }
 }
-/** Map each bits to logical or of itself and all bits with higher index. 
-  * Here `scanRight` means "start at the right and look to the left, where right is the highest index", a common operation on arrays and lists.
-  * This is consistent with the `right` as in "shift right" performed on bits, which means "start at the left (most significant bit) and move to the right".
+
+/** Map each bit to the logical OR of itself and all bits with higher index
+  *
+  * Here `scanRight` means "start from the right and iterate to the left, where right is the highest index", a common operation on arrays and lists.
   * @example {{{
   * scanRightOr("b00001000".U) // Returns "b00001111".U
   * scanRightOr("b00010100".U) // Returns "b00011111".U

--- a/src/main/scala/chisel3/experimental/util/algorithm/Bitwise.scala
+++ b/src/main/scala/chisel3/experimental/util/algorithm/Bitwise.scala
@@ -5,11 +5,12 @@ package chisel3.experimental.util.algorithm
 import chisel3._
 
 /** Map each bits to logical or of itself and all bits with lower index.
-  * Here 'left' means 'with lower index', as in arrays and lists, not to be confused with the 'left' as in 'shift left'
+  * Here `scanLeft` means "start at the left and look to the right, where left is the lowest index", a common operation on arrays and lists.
+  * This is consistent with the `left` as in "shift left" performed on bits, which means "start at the right (least significant bit) and move to the left".
   * @example {{{
-  * scanLeftOr("b00001000".U) // Returns "b11111000".U
-  * scanLeftOr("b00010100".U) // Returns "b11111100".U
-  * scanLeftOr("b00000000".U) // Returns "b00000000".U
+  * scanLeftOr("b00001000".U(8.W)) // Returns "b11111000".U
+  * scanLeftOr("b00010100".U(8.W)) // Returns "b11111100".U
+  * scanLeftOr("b00000000".U(8.W)) // Returns "b00000000".U
   * }}}
   */
 object scanLeftOr {
@@ -24,9 +25,8 @@ object scanLeftOr {
     helper(1, data)(width - 1, 0)
   }
 }
-
-/** Map each bits to logical or of itself and all bits with higher index.
-  * Here 'right' means 'with higher index', as in arrays and lists, not to be confused with the 'right' as in 'shift right'
+  * Here `scanRight` means "start at the right and look to the left, where right is the highest index", a common operation on arrays and lists.
+  * This is consistent with the `right` as in "shift right" performed on bits, which means "start at the left (most significant bit) and move to the right".
   * @example {{{
   * scanRightOr("b00001000".U) // Returns "b00001111".U
   * scanRightOr("b00010100".U) // Returns "b00011111".U

--- a/src/main/scala/chisel3/experimental/util/algorithm/Bitwise.scala
+++ b/src/main/scala/chisel3/experimental/util/algorithm/Bitwise.scala
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package chisel3.experimental.util.algorithm
 
 import chisel3._
@@ -8,6 +10,7 @@ import chisel3._
   * LSBOr("b00010100".U) // Returns "b11111100".U
   * LSBOr("b00000000".U) // Returns "b00000000".U
   * }}}
+  * This circuit seems to be high fan out, but synthesis tool should handle this.
   */
 object LSBOr {
   def apply(data: UInt): UInt = VecInit(Seq.tabulate(data.getWidth) { i: Int =>
@@ -21,6 +24,7 @@ object LSBOr {
   * MSBOr("b00010100".U) // Returns "b00011111".U
   * MSBOr("b00000000".U) // Returns "b00000000".U
   * }}}
+  * This circuit seems to be high fan out, but synthesis tool should handle this.
   */
 object MSBOr {
   def apply(data: UInt): UInt = VecInit(Seq.tabulate(data.getWidth) { i: Int =>

--- a/src/main/scala/chisel3/experimental/util/algorithm/Bitwise.scala
+++ b/src/main/scala/chisel3/experimental/util/algorithm/Bitwise.scala
@@ -13,9 +13,15 @@ import chisel3._
   * This circuit seems to be high fan out, but synthesis tool should handle this.
   */
 object LSBOr {
-  def apply(data: UInt): UInt = VecInit(Seq.tabulate(data.getWidth) { i: Int =>
-    VecInit(data.asBools().dropRight(data.getWidth - i - 1)).asUInt().orR()
-  }).asUInt()
+  def apply(data: UInt): UInt = {
+    val width = data.widthOption match {
+      case Some(w) => w
+      case None    => throw new IllegalArgumentException("Cannot call LSBOr on data with unknown width.")
+    }
+    VecInit(Seq.tabulate(width) { i: Int =>
+      VecInit(data.asBools().dropRight(width - i - 1)).asUInt().orR()
+    }).asUInt()
+  }
 }
 
 /** Map each bits to logical or of itself and all bits more siginificant than it.
@@ -27,7 +33,13 @@ object LSBOr {
   * This circuit seems to be high fan out, but synthesis tool should handle this.
   */
 object MSBOr {
-  def apply(data: UInt): UInt = VecInit(Seq.tabulate(data.getWidth) { i: Int =>
-    VecInit(data.asBools().drop(i)).asUInt().orR()
-  }).asUInt()
+  def apply(data: UInt): UInt = {
+    val width = data.widthOption match {
+      case Some(w) => w
+      case None    => throw new IllegalArgumentException("Cannot call MSBOr on data with unknown width.")
+    }
+    VecInit(Seq.tabulate(width) { i: Int =>
+      VecInit(data.asBools().drop(i)).asUInt().orR()
+    }).asUInt()
+  }
 }

--- a/src/main/scala/chisel3/experimental/util/algorithm/Bitwise.scala
+++ b/src/main/scala/chisel3/experimental/util/algorithm/Bitwise.scala
@@ -1,0 +1,29 @@
+package chisel3.experimental.util.algorithm
+
+import chisel3._
+
+/** Map each bits to logical or of itself and all bits less siginificant than it.
+  * @example {{{
+  * LSBOr("b00001000".U) // Returns "b11111000".U
+  * LSBOr("b00010100".U) // Returns "b11111100".U
+  * LSBOr("b00000000".U) // Returns "b00000000".U
+  * }}}
+  */
+object LSBOr {
+  def apply(data: UInt): UInt = VecInit(Seq.tabulate(data.getWidth) { i: Int =>
+    VecInit(data.asBools().dropRight(data.getWidth - i - 1)).asUInt().orR()
+  }).asUInt()
+}
+
+/** Map each bits to logical or of itself and all bits more siginificant than it.
+  * @example {{{
+  * MSBOr("b00001000".U) // Returns "b00001111".U
+  * MSBOr("b00010100".U) // Returns "b00011111".U
+  * MSBOr("b00000000".U) // Returns "b00000000".U
+  * }}}
+  */
+object MSBOr {
+  def apply(data: UInt): UInt = VecInit(Seq.tabulate(data.getWidth) { i: Int =>
+    VecInit(data.asBools().drop(i)).asUInt().orR()
+  }).asUInt()
+}


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement
new feature/API

#### API Impact
Add utility `LSBOr` and `MSBOr` similar to rocket-chip's `leftOr` and `rightOr`. These functions are generally very useful and can be used to implementing other useful utilities such as bitfield arbitration

#### Backend Code Generation Impact
N/A

#### Desired Merge Strategy
Rebase

#### Release Notes
Add experimental utility `LSBOr` and `MSBOr`.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
