### PR TITLE
Issue errors on out-of-range extracts when width is known

### DIFF
--- a/core/src/main/scala/chisel3/Bits.scala
+++ b/core/src/main/scala/chisel3/Bits.scala
@@ -107,6 +107,12 @@ sealed abstract class Bits(private[chisel3] val width: Width) extends Element wi
       (((value >> castToInt(x, "Index")) & 1) == 1).asBool
     }.getOrElse {
       requireIsHardware(this, "bits to be indexed")
+
+      widthOption match {
+        case Some(w) if x >= w => Builder.error(s"High index $x is out of range [0, ${w - 1}]")
+        case _                 =>
+      }
+
       pushOp(DefPrim(sourceInfo, Bool(), BitsExtractOp, this.ref, ILit(x), ILit(x)))
     }
   }
@@ -160,6 +166,13 @@ sealed abstract class Bits(private[chisel3] val width: Width) extends Element wi
       ((value >> y) & ((BigInt(1) << w) - 1)).asUInt(w.W)
     }.getOrElse {
       requireIsHardware(this, "bits to be sliced")
+
+      widthOption match {
+        case Some(w) if y >= w => Builder.error(s"High and low indices $x and $y are both out of range [0, ${w - 1}]")
+        case Some(w) if x >= w => Builder.error(s"High index $x is out of range [0, ${w - 1}]")
+        case _                 =>
+      }
+
       pushOp(DefPrim(sourceInfo, UInt(Width(w)), BitsExtractOp, this.ref, ILit(x), ILit(y)))
     }
   }

--- a/src/test/scala/chiselTests/UIntOps.scala
+++ b/src/test/scala/chiselTests/UIntOps.scala
@@ -199,6 +199,24 @@ class UIntOpsSpec extends ChiselPropSpec with Matchers with Utils {
     a[Exception] should be thrownBy extractCause[Exception] { ChiselStage.elaborate(new BadBoolConversion) }
   }
 
+  property("Out-of-bounds extraction from known-width UInts") {
+    a[ChiselException] should be thrownBy extractCause[ChiselException] {
+      ChiselStage.elaborate(new RawModule {
+        val u = IO(Input(UInt(2.W)))
+        u(2, 1)
+      })
+    }
+  }
+
+  property("Out-of-bounds single-bit extraction from known-width UInts") {
+    a[ChiselException] should be thrownBy extractCause[ChiselException] {
+      ChiselStage.elaborate(new RawModule {
+        val u = IO(Input(UInt(2.W)))
+        u(2)
+      })
+    }
+  }
+
   property("UIntOps should elaborate") {
     ChiselStage.elaborate { new UIntOps }
   }


### PR DESCRIPTION
Firrtl will catch this later on, but better to error early if possible.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

Improved error reporting

#### API Impact

None, if you consider Chisel + Firrtl together: the same error would've been generated downstream.

#### Backend Code Generation Impact

N/A

#### Desired Merge Strategy

- Squash: The PR will be squashed and merged (choose this if you have no preference.

#### Release Notes

Out-of-bounds bit and field extracts from UInts of known width now issue errors earlier in compilation.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
