### PR TITLE
Revert "Update sbt to 1.6.2"

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.2
+sbt.version=1.5.8


### PR DESCRIPTION
Reverts chipsalliance/chisel3#2377

I forgot we had this same issue with 1.6.1 (https://github.com/chipsalliance/chisel3/pull/2374)

See filed issue: https://github.com/sbt/sbt/issues/6838