### PR TITLE
Use var List instead of ListBuffer to save memory

### DIFF
--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -115,10 +115,10 @@ private[chisel3] trait HasId extends InstanceId {
   private var prefix_seed: Prefix = Nil
 
   // Post-seed hooks called to carry the suggested seeds to other candidates as needed
-  private val suggest_postseed_hooks = scala.collection.mutable.ListBuffer.empty[String => Unit]
+  private var suggest_postseed_hooks: List[String => Unit] = Nil
 
   // Post-seed hooks called to carry the auto seeds to other candidates as needed
-  private val auto_postseed_hooks = scala.collection.mutable.ListBuffer.empty[String => Unit]
+  private var auto_postseed_hooks: List[String => Unit] = Nil
 
   /** Takes the last seed suggested. Multiple calls to this function will take the last given seed, unless
     * this HasId is a module port (see overridden method in Data.scala).
@@ -136,7 +136,7 @@ private[chisel3] trait HasId extends InstanceId {
   // Bypass the overridden behavior of autoSeed in [[Data]], apply autoSeed even to ports
   private[chisel3] def forceAutoSeed(seed: String): this.type = {
     auto_seed = Some(seed)
-    for (hook <- auto_postseed_hooks) { hook(seed) }
+    for (hook <- auto_postseed_hooks.reverse) { hook(seed) }
     prefix_seed = Builder.getPrefix
     this
   }
@@ -154,7 +154,7 @@ private[chisel3] trait HasId extends InstanceId {
   def suggestName(seed: => String): this.type = {
     if (suggested_seed.isEmpty) suggested_seed = Some(seed)
     prefix_seed = Builder.getPrefix
-    for (hook <- suggest_postseed_hooks) { hook(seed) }
+    for (hook <- suggest_postseed_hooks.reverse) { hook(seed) }
     this
   }
 
@@ -211,8 +211,8 @@ private[chisel3] trait HasId extends InstanceId {
 
   private[chisel3] def hasAutoSeed: Boolean = auto_seed.isDefined
 
-  private[chisel3] def addSuggestPostnameHook(hook: String => Unit): Unit = suggest_postseed_hooks += hook
-  private[chisel3] def addAutoPostnameHook(hook:    String => Unit): Unit = auto_postseed_hooks += hook
+  private[chisel3] def addSuggestPostnameHook(hook: String => Unit): Unit = suggest_postseed_hooks ::= hook
+  private[chisel3] def addAutoPostnameHook(hook:    String => Unit): Unit = auto_postseed_hooks ::= hook
 
   // Uses a namespace to convert suggestion into a true name
   // Will not do any naming if the reference already assigned.


### PR DESCRIPTION
This reduces memory use of every HasId by 64 bytes.

Every instance of HasId (including all Data) had 2 ListBuffer vals for
recording post-naming hooks, yet this feature is almost never used.
These are now vars of type List which allows the common case of Nil to
add no incremental memory use per instance of HasId.

I measured the 64 byte memory reduction with [JAMM](https://github.com/jbellis/jamm) (published as `io.github.stephankoelle:jamm:0.4.1`). JAMM reports that a ListBuffer uses 32 bytes of shallow memory. They use 48 bytes deep but looking at the code, the 4 vars inside of them are `Nil`, `null`, `false`, and `0` so the deep memory use is structurally shared.

I also measured this to reduce memory consumption of our Chisel generator of a large design from 5 GiB to 4.2 GiB. Not bad for only a few lines of change!

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

  - performance improvement      


#### API Impact

No impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

 - Squash

#### Release Notes

Reduce memory use of every `HasId` (includes `Data`) by 64 bytes

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
