### PR TITLE
Optimize memory use of naming prefixes

### DIFF
--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -108,11 +108,10 @@ private[chisel3] trait HasId extends InstanceId {
   // Contains the seed computed automatically by the compiler plugin
   private var auto_seed: Option[String] = None
 
-  // Prefix at time when this class is constructed
-  private val construction_prefix: Prefix = Builder.getPrefix
-
-  // Prefix when the latest [[suggestSeed]] or [[autoSeed]] is called
-  private var prefix_seed: Prefix = Nil
+  // Prefix for use in naming
+  // - Defaults to prefix at time when object is created
+  // - Overridden when [[suggestSeed]] or [[autoSeed]] is called
+  private var naming_prefix: Prefix = Builder.getPrefix
 
   // Post-seed hooks called to carry the suggested seeds to other candidates as needed
   private var suggest_postseed_hooks: List[String => Unit] = Nil
@@ -137,7 +136,7 @@ private[chisel3] trait HasId extends InstanceId {
   private[chisel3] def forceAutoSeed(seed: String): this.type = {
     auto_seed = Some(seed)
     for (hook <- auto_postseed_hooks.reverse) { hook(seed) }
-    prefix_seed = Builder.getPrefix
+    naming_prefix = Builder.getPrefix
     this
   }
 
@@ -153,7 +152,7 @@ private[chisel3] trait HasId extends InstanceId {
     */
   def suggestName(seed: => String): this.type = {
     if (suggested_seed.isEmpty) suggested_seed = Some(seed)
-    prefix_seed = Builder.getPrefix
+    naming_prefix = Builder.getPrefix
     for (hook <- suggest_postseed_hooks.reverse) { hook(seed) }
     this
   }
@@ -189,12 +188,12 @@ private[chisel3] trait HasId extends InstanceId {
     }
 
     if (hasSeed) {
-      Some(buildName(seedOpt.get, prefix_seed.reverse))
+      Some(buildName(seedOpt.get, naming_prefix.reverse))
     } else {
       defaultSeed.map { default =>
         defaultPrefix match {
-          case Some(p) => buildName(default, p :: construction_prefix.reverse)
-          case None    => buildName(default, construction_prefix.reverse)
+          case Some(p) => buildName(default, p :: naming_prefix.reverse)
+          case None    => buildName(default, naming_prefix.reverse)
         }
       }
     }
@@ -222,6 +221,8 @@ private[chisel3] trait HasId extends InstanceId {
       val candidate_name = _computeName(prefix, Some(default)).get
       val available_name = namespace.name(candidate_name)
       setRef(Ref(available_name))
+      // Clear naming prefix to free memory
+      naming_prefix = Nil
     }
 
   private var _ref: Option[Arg] = None


### PR DESCRIPTION
* Use a single field instead of two in HasId (4-bytes per HasId)
* Set the prefix to Nil after setting ref to free up memory

Draft PR for now because I'm having a bit of trouble measuring a memory improvement from this (perhaps I should write a synthetic benchmark), but analytically, it is easy to see how it should be beneficial.

This also has minor bug potential because the behavior of `_computeName` will change if someone calls it after `forceName` is called on a `HasId`. Auditing the code, that doesn't happen, but it might be worth having `_computeName` get the name from the `_ref` if it's available or perhaps error if called when it shouldn't be.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [ ] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [ ] Did you state the API impact?
- [ ] Did you specify the code generation impact?
- [ ] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
