### PR TITLE
Micro-optimize String building in _computeName

### DIFF
--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -183,7 +183,10 @@ private[chisel3] trait HasId extends InstanceId {
       */
     def buildName(seed: String, prefix: Prefix): String = {
       val builder = new StringBuilder()
-      prefix.foreach(builder ++= _ + "_")
+      prefix.foreach { p =>
+        builder ++= p
+        builder += '_'
+      }
       builder ++= seed
       builder.toString
     }


### PR DESCRIPTION
This is very much a micro-optimization, but I was looking at Flamegraphs and noticed 2 `StringBuilders` when there should only be 1. The String concatenation before adding to the String builder results in an unnecessary String copy. This is peanuts compared to most of the object creation going on in Chisel, but it is noticeable in a Flamegraph so I figured I'd fix it.

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [NA] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

  - performance improvement

#### API Impact

No impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

 - Squash

#### Release Notes

Micro-optimize performance of computing names of signals

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
