### PR TITLE
Micro-optimize Namespace.name

### DIFF
--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -35,7 +35,7 @@ private[chisel3] class Namespace(keywords: Set[String]) {
     // TODO what character set does FIRRTL truly support? using ANSI C for now
     def legalStart(c: Char) = (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_'
     def legal(c:      Char) = legalStart(c) || (c >= '0' && c <= '9')
-    val res = s.filter(legal)
+    val res = if (s.forall(legal)) s else s.filter(legal)
     val headOk = (!res.isEmpty) && (leadingDigitOk || legalStart(res.head))
     if (headOk) res else s"_$res"
   }
@@ -45,12 +45,9 @@ private[chisel3] class Namespace(keywords: Set[String]) {
   // leadingDigitOk is for use in fields of Records
   def name(elem: String, leadingDigitOk: Boolean = false): String = {
     val sanitized = sanitize(elem, leadingDigitOk)
-    if (this contains sanitized) {
-      name(rename(sanitized))
-    } else {
-      names(sanitized) = 1
-      sanitized
-    }
+    val result = if (this.contains(sanitized)) rename(sanitized) else sanitized
+    names(result) = 1
+    result
   }
 }
 


### PR DESCRIPTION
* During sanitize, only filter the String if needed
* Do not recurse on name, saving an unnecessary call to sanitize

Filtering a String unconditionally builds a new `String` (actually a `StringBuilder` and a `String`), so this saves that allocation in the common case with a `forall` (which early outs on failing the predicate).

Also the recursion on `Namespace.name` which was presumably to keep the code DRY actually resulted in calling `sanitize` twice for every call that collided in the `Namespace`.

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [NA] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

  - performance improvement 

#### API Impact

No impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

 - Squash

#### Release Notes

Speed up naming of signals

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
