### PR TITLE
Enhance views to [sometimes] support dynamic indexing and implement FlatIO

### DIFF
--- a/core/src/main/scala/chisel3/Data.scala
+++ b/core/src/main/scala/chisel3/Data.scala
@@ -667,7 +667,7 @@ abstract class Data extends HasId with NamedComponent with SourceInfoDoc {
     topBindingOpt match {
       // DataView
       case Some(ViewBinding(target)) => reify(target).ref
-      case Some(AggregateViewBinding(viewMap, _)) =>
+      case Some(AggregateViewBinding(viewMap)) =>
         viewMap.get(this) match {
           case None => materializeWire() // FIXME FIRRTL doesn't have Aggregate Init expressions
           // This should not be possible because Element does the lookup in .topBindingOpt

--- a/core/src/main/scala/chisel3/Element.scala
+++ b/core/src/main/scala/chisel3/Element.scala
@@ -36,10 +36,15 @@ abstract class Element extends Data {
         case Some(litArg) => Some(ElementLitBinding(litArg))
         case _            => Some(DontCareBinding())
       }
-    case Some(b @ AggregateViewBinding(viewMap, _)) =>
+    // TODO Do we even need this? Looking up things in the AggregateViewBinding is fine
+    case Some(b @ AggregateViewBinding(viewMap)) =>
       viewMap.get(this) match {
-        case Some(elt) => Some(ViewBinding(elt))
-        case _         => throwException(s"Internal Error! $this missing from topBinding $b")
+        case Some(elt: Element) => Some(ViewBinding(elt))
+        // TODO We could generate a reduced AggregateViewBinding, but is there a point?
+        // Generating the new object would be somewhat slow, it's not clear if we should do this
+        //   matching anyway
+        case Some(data: Aggregate) => Some(b)
+        case _ => throwException(s"Internal Error! $this missing from topBinding $b")
       }
     case topBindingOpt => topBindingOpt
   }

--- a/core/src/main/scala/chisel3/internal/Binding.scala
+++ b/core/src/main/scala/chisel3/internal/Binding.scala
@@ -141,11 +141,16 @@ case class DontCareBinding() extends UnconstrainedBinding
 private[chisel3] case class ViewBinding(target: Element) extends UnconstrainedBinding
 
 /** Binding for Aggregate Views
-  * @param childMap Mapping from children of this view to each child's target
+  * @param childMap Mapping from children of this view to their respective targets
   * @param target Optional Data this Aggregate views if the view is total and the target is a Data
+  * @note For any Elements in the childMap, both key and value must be Elements
+  * @note The types of key and value need not match for the top Data in a total view of type
+  *       Aggregate
   */
-private[chisel3] case class AggregateViewBinding(childMap: Map[Data, Element], target: Option[Data])
-    extends UnconstrainedBinding
+private[chisel3] case class AggregateViewBinding(childMap: Map[Data, Data]) extends UnconstrainedBinding {
+  // Helper lookup function since types of Elements always match
+  def lookup(key: Element): Option[Element] = childMap.get(key).map(_.asInstanceOf[Element])
+}
 
 /** Binding for Data's returned from accessing an Instance/Definition members, if not readable/writable port */
 private[chisel3] case object CrossModuleBinding extends TopBinding {

--- a/docs/src/cookbooks/cookbook.md
+++ b/docs/src/cookbooks/cookbook.md
@@ -26,6 +26,7 @@ Please note that these examples make use of [Chisel's scala-style printing](../e
 * [How do I unpack a value ("reverse concatenation") like in Verilog?](#how-do-i-unpack-a-value-reverse-concatenation-like-in-verilog)
 * [How do I do subword assignment (assign to some bits in a UInt)?](#how-do-i-do-subword-assignment-assign-to-some-bits-in-a-uint)
 * [How do I create an optional I/O?](#how-do-i-create-an-optional-io)
+* [How do I create I/O without a prefix?](#how-do-i-create-io-without-a-prefix)
 * [How do I minimize the number of bits used in an output vector](#how-do-i-minimize-the-number-of-bits-used-in-an-output-vector)
 * Predictable Naming
   * [How do I get Chisel to name signals properly in blocks like when/withClockAndReset?](#how-do-i-get-chisel-to-name-signals-properly-in-blocks-like-whenwithclockandreset)
@@ -544,6 +545,50 @@ class ModuleWithOptionalIO(flag: Boolean) extends Module {
 
   out := in.getOrElse(false.B)
 }
+```
+
+### How do I create I/O without a prefix?
+
+In most cases, you can simply call `IO` multiple times:
+
+```scala mdoc:silent:reset
+import chisel3._
+
+class MyModule extends Module {
+  val in = IO(Input(UInt(8.W)))
+  val out = IO(Output(UInt(8.W)))
+
+  out := in +% 1.U
+}
+```
+
+```scala mdoc:verilog
+getVerilogString(new MyModule)
+```
+
+If you have a `Bundle` from which you would like to create ports without the
+normal `val` prefix, you can use `FlatIO`:
+
+```scala mdoc:silent:reset
+import chisel3._
+import chisel3.experimental.FlatIO
+
+class MyBundle extends Bundle {
+  val foo = Input(UInt(8.W))
+  val bar = Output(UInt(8.W))
+}
+
+class MyModule extends Module {
+  val io = FlatIO(new MyBundle)
+
+  io.bar := io.foo +% 1.U
+}
+```
+
+Note that `io_` is nowhere to be seen!
+
+```scala mdoc:verilog
+getVerilogString(new MyModule)
 ```
 
 ### How do I minimize the number of bits used in an output vector?

--- a/src/test/scala/chiselTests/experimental/DataViewTargetSpec.scala
+++ b/src/test/scala/chiselTests/experimental/DataViewTargetSpec.scala
@@ -125,9 +125,7 @@ class DataViewTargetSpec extends ChiselFlatSpec {
     val pairs = annos.collect { case DummyAnno(t, idx) => (idx, t.toString) }.sortBy(_._1)
     val expected = Seq(
       0 -> "~MyParent|MyChild>out.foo",
-      // The child of the view that was itself an Aggregate got split because 1:1 is lacking here
-      1 -> "~MyParent|MyChild>out.foo[0]",
-      1 -> "~MyParent|MyChild>out.foo[1]",
+      1 -> "~MyParent|MyChild>out.foo",
       2 -> "~MyParent|MyParent/inst:MyChild>out.foo",
       3 -> "~MyParent|MyParent/inst:MyChild>out"
     )

--- a/src/test/scala/chiselTests/experimental/FlatIOSpec.scala
+++ b/src/test/scala/chiselTests/experimental/FlatIOSpec.scala
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiselTests.experimental
+
+import chisel3._
+import chisel3.util.Valid
+import chisel3.stage.ChiselStage.emitChirrtl
+import chisel3.experimental.FlatIO
+import chiselTests.ChiselFlatSpec
+
+class FlatIOSpec extends ChiselFlatSpec {
+  behavior.of("FlatIO")
+
+  it should "create ports without a prefix" in {
+    class MyModule extends RawModule {
+      val io = FlatIO(new Bundle {
+        val in = Input(UInt(8.W))
+        val out = Output(UInt(8.W))
+      })
+      io.out := io.in
+    }
+    val chirrtl = emitChirrtl(new MyModule)
+    chirrtl should include("input in : UInt<8>")
+    chirrtl should include("output out : UInt<8>")
+    chirrtl should include("out <= in")
+  }
+
+  it should "support bulk connections between FlatIOs and regular IOs" in {
+    class MyModule extends RawModule {
+      val in = FlatIO(Input(Valid(UInt(8.W))))
+      val out = IO(Output(Valid(UInt(8.W))))
+      out := in
+    }
+    val chirrtl = emitChirrtl(new MyModule)
+    chirrtl should include("out.bits <= bits")
+    chirrtl should include("out.valid <= valid")
+  }
+
+  it should "dynamically indexing Vecs inside of FlatIOs" in {
+    class MyModule extends RawModule {
+      val io = FlatIO(new Bundle {
+        val addr = Input(UInt(2.W))
+        val in = Input(Vec(4, UInt(8.W)))
+        val out = Output(Vec(4, UInt(8.W)))
+      })
+      io.out(io.addr) := io.in(io.addr)
+    }
+    val chirrtl = emitChirrtl(new MyModule)
+    chirrtl should include("out[addr] <= in[addr]")
+  }
+}


### PR DESCRIPTION
h/t @davidbiancolin for the implementation idea

@oharboe I promised you this a while ago, here it finally is!

The best way to understand this PR is to look at the tests (including the `DataViewTargetSpec` which is a subtle change but an enhancement). Basically, I changed the AggregateViewBinding to include mappings between Aggregates when there is a 1-1 correspondence. This enables dynamically indexing Vecs that are themselves elements of larger Aggregates in views when the corresponding element of the view is a Vec of the same type. It also increases the number of cases where a single Target can represent part of a view.

It also enabled implementing `FlatIO` (which really needed dynamic indexing to work), so I went ahead and did that too!

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

  - new feature/API        

#### API Impact

This enables dynamic indexing of more views. It also adds `chisel3.experimental.FlatIO` for creating ports without a prefix.

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

   - Rebase

#### Release Notes

Enable dynamic indexing for more views. Add `chisel3.experimental.FlatIO` for creating ports from Bundles without a prefix for the name of the `val`.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
