### PR TITLE
Enable Clock Invalidation

### DIFF
--- a/core/src/main/scala/chisel3/Clock.scala
+++ b/core/src/main/scala/chisel3/Clock.scala
@@ -23,7 +23,7 @@ sealed class Clock(private[chisel3] val width: Width = Width(1)) extends Element
 
   override def connect(that: Data)(implicit sourceInfo: SourceInfo, connectCompileOptions: CompileOptions): Unit =
     that match {
-      case _: Clock => super.connect(that)(sourceInfo, connectCompileOptions)
+      case _: Clock | DontCare => super.connect(that)(sourceInfo, connectCompileOptions)
       case _ => super.badConnect(that)(sourceInfo)
     }
 

--- a/src/test/scala/chiselTests/InvalidateAPISpec.scala
+++ b/src/test/scala/chiselTests/InvalidateAPISpec.scala
@@ -228,4 +228,12 @@ class InvalidateAPISpec extends ChiselPropSpec with Matchers with BackendCompila
     val firrtlOutput = myGenerateFirrtl(new ModuleWithoutDontCare)
     firrtlOutput should include("is invalid")
   }
+
+  property("a clock should be able to be connected to a DontCare") {
+    class ClockConnectedToDontCare extends Module {
+      val foo = IO(Output(Clock()))
+      foo := DontCare
+    }
+    myGenerateFirrtl(new ClockConnectedToDontCare) should include("foo is invalid")
+  }
 }


### PR DESCRIPTION
Loosen restrictions on clocks to enable them to be connected to
DontCare, i.e., be invalidated.

Co-authored-by: Jack Koenig <koenig@sifive.com>
Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>