### PR TITLE
fix for scalacPluginClasspath in build.sc

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -105,9 +105,9 @@ class chisel3CrossModule(val crossScalaVersion: String) extends CommonModule wit
   }
 
   object test extends Tests with TestModule.ScalaTest {
-    override def scalacPluginClasspath = m.scalacPluginClasspath
+    override def scalacPluginClasspath = T { m.scalacPluginClasspath() }
 
-    override  def scalacOptions = T {
+    override def scalacOptions = T {
       super.scalacOptions() ++ Agg("-P:chiselplugin:genBundleElements")
     }
 


### PR DESCRIPTION
refer to
https://github.com/com-lihaoyi/mill/blob/61698d6dab93d18b050fab31fcc7d9c57716c430/scalalib/src/ScalaModule.scala#L25-L32
these parameters are included. adding those will lead to strange
behavior.
