### PR TITLE
Fix warning injected into user code by @chiselName

### DIFF
--- a/macros/src/main/scala/chisel3/internal/naming/NamingAnnotations.scala
+++ b/macros/src/main/scala/chisel3/internal/naming/NamingAnnotations.scala
@@ -125,7 +125,7 @@ class NamingTransforms(val c: Context) {
     q"""
     val $contextVar = $globalNamingStack.pushContext()
     ..$transformedBody
-    if($globalNamingStack.length == 1){
+    if($globalNamingStack.length() == 1){
       $contextVar.namePrefix("")
     }
     $globalNamingStack.popReturnContext(this, $contextVar)


### PR DESCRIPTION
In Scala 2.13, Auto-application to `()` is deprecated. Any nullary
method (ie. a method with no arguments) that is defined with () must now
be called with (). @chiselName used to inject a case of this warning
into user code which would then cause a warning on the @chiselName macro
that the user has no way to fix.

To see this warning, compile Chisel with Scala 2.13, you'll see something like:
```
[warn] .../chisel3/src/main/scala/chisel3/util/Arbiter.scala:119:2: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method length,
[warn] or remove the empty argument list from its definition (Java-defined methods are exempt).
[warn] In Scala 3, an unapplied method like this will be eta-expanded into a function.
[warn] @chiselName
[warn]  ^
[warn] .../chisel3/src/main/scala/chisel3/util/Arbiter.scala:135:2: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method length,
[warn] or remove the empty argument list from its definition (Java-defined methods are exempt).
[warn] In Scala 3, an unapplied method like this will be eta-expanded into a function.
[warn] @chiselName
[warn]  ^
[warn] two warnings found
```

This changes fixes this bug.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

  - bug fix 

#### API Impact

No impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

  - Squash

#### Release Notes

Fix Scala 2.13 warning "Auto-application to `()` is deprecated." when using `@chiselName` in user code.

### Reviewer Checklist (only modified by reviewer)
- [x] Did you add the appropriate labels?
- [x] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [x] Did you review?
- [x] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
