### PR TITLE
Make BitSet.terms private

### DIFF
--- a/src/main/scala/chisel3/util/BitPat.scala
+++ b/src/main/scala/chisel3/util/BitPat.scala
@@ -150,7 +150,7 @@ package experimental {
     /** all [[BitPat]] elements in [[terms]] make up this [[BitSet]].
       * all [[terms]] should be have the same width.
       */
-    def terms: Set[BitPat]
+    private[chisel3] def terms: Set[BitPat]
 
     /** Get specified width of said BitSet */
     def getWidth: Int = {


### PR DESCRIPTION
Discussed in previous dev-meetings:
1. `BitSet.terms` should be an internal API
2. `BitSet` might need have a new binding, supporting bitset operators, we need to use MFC to handle it.(After 3.6)

This PR will avoid user using(abusing) `terms` and `BitSet` to avoid further migration burdens.
 
### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [ ] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [ ] Did you state the API impact?
- [ ] Did you specify the code generation impact?
- [ ] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

- code refactoring

#### API Impact

private `BitSet.terms`.

#### Backend Code Generation Impact
None

#### Desired Merge Strategy
- Rebase: You will rebase the PR onto master and it will be merged with a merge commit.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
