### PR TITLE
[3.5.x] Deprecate named arguments for methods moving to macros in 3.6

### DIFF
--- a/src/main/scala/chisel3/util/Bitwise.scala
+++ b/src/main/scala/chisel3/util/Bitwise.scala
@@ -24,13 +24,16 @@ object FillInterleaved {
     *
     * Output data-equivalent to in(size(in)-1) (n times) ## ... ## in(1) (n times) ## in(0) (n times)
     */
-  def apply(n: Int, in: UInt): UInt = apply(n, in.asBools)
+  def apply(@deprecatedName('n, "Chisel 3.5") n: Int, @deprecatedName('in, "Chisel 3.5") in: UInt): UInt =
+    apply(n, in.asBools)
 
   /** Creates n repetitions of each bit of x in order.
     *
     * Output data-equivalent to in(size(in)-1) (n times) ## ... ## in(1) (n times) ## in(0) (n times)
     */
-  def apply(n: Int, in: Seq[Bool]): UInt = Cat(in.map(Fill(n, _)).reverse)
+  def apply(@deprecatedName('n, "Chisel 3.5") n: Int, @deprecatedName('in, "Chisel 3.5") in: Seq[Bool]): UInt = Cat(
+    in.map(Fill(n, _)).reverse
+  )
 }
 
 /** Returns the number of bits set (value is 1 or true) in the input signal.
@@ -45,9 +48,9 @@ object FillInterleaved {
   * }}}
   */
 object PopCount {
-  def apply(in: Iterable[Bool]): UInt = SeqUtils.count(in.toSeq)
+  def apply(@deprecatedName('in, "Chisel 3.5") in: Iterable[Bool]): UInt = SeqUtils.count(in.toSeq)
 
-  def apply(in: Bits): UInt = apply((0 until in.getWidth).map(in(_)))
+  def apply(@deprecatedName('in, "Chisel 3.5") in: Bits): UInt = apply((0 until in.getWidth).map(in(_)))
 }
 
 /** Create repetitions of the input using a tree fanout topology.
@@ -65,7 +68,7 @@ object Fill {
     * Output data-equivalent to x ## x ## ... ## x (n repetitions).
     * @throws java.lang.IllegalArgumentException if `n` is less than zero
     */
-  def apply(n: Int, x: UInt): UInt = {
+  def apply(@deprecatedName('n, "Chisel 3.5") n: Int, @deprecatedName('x, "Chisel 3.5") x: UInt): UInt = {
     n match {
       case _ if n < 0 => throw new IllegalArgumentException(s"n (=$n) must be nonnegative integer.")
       case 0          => UInt(0.W)
@@ -111,5 +114,5 @@ object Reverse {
       Cat(doit(in(half - 1, 0), half), doit(in(length - 1, half), length - half))
   }
 
-  def apply(in: UInt): UInt = doit(in, in.getWidth)
+  def apply(@deprecatedName('in, "Chisel 3.5") in: UInt): UInt = doit(in, in.getWidth)
 }

--- a/src/main/scala/chisel3/util/Cat.scala
+++ b/src/main/scala/chisel3/util/Cat.scala
@@ -19,7 +19,9 @@ object Cat {
   /** Concatenates the argument data elements, in argument order, together. The first argument
     * forms the most significant bits, while the last argument forms the least significant bits.
     */
-  def apply[T <: Bits](a: T, r: T*): UInt = apply(a :: r.toList)
+  def apply[T <: Bits](@deprecatedName('a, "Chisel 3.5") a: T, @deprecatedName('r, "Chisel 3.5") r: T*): UInt = apply(
+    a :: r.toList
+  )
 
   /** Concatenates the data elements of the input sequence, in reverse sequence order, together.
     * The first element of the sequence forms the most significant bits, while the last element
@@ -28,5 +30,5 @@ object Cat {
     * Equivalent to r(0) ## r(1) ## ... ## r(n-1).
     * @note This returns a `0.U` if applied to a zero-element `Vec`.
     */
-  def apply[T <: Bits](r: Seq[T]): UInt = SeqUtils.asUInt(r.reverse)
+  def apply[T <: Bits](@deprecatedName('r, "Chisel 3.5") r: Seq[T]): UInt = SeqUtils.asUInt(r.reverse)
 }

--- a/src/main/scala/chisel3/util/Reg.scala
+++ b/src/main/scala/chisel3/util/Reg.scala
@@ -12,7 +12,10 @@ object RegEnable {
     * val regWithEnable = RegEnable(nextVal, ena)
     * }}}
     */
-  def apply[T <: Data](next: T, enable: Bool): T = {
+  def apply[T <: Data](
+    @deprecatedName('next, "Chisel 3.5") next:     T,
+    @deprecatedName('enable, "Chisel 3.5") enable: Bool
+  ): T = {
     val r = Reg(chiselTypeOf(next))
     when(enable) { r := next }
     r
@@ -24,7 +27,11 @@ object RegEnable {
     * val regWithEnableAndReset = RegEnable(nextVal, 0.U, ena)
     * }}}
     */
-  def apply[T <: Data](next: T, init: T, enable: Bool): T = {
+  def apply[T <: Data](
+    @deprecatedName('next, "Chisel 3.5") next:     T,
+    @deprecatedName('init, "Chisel 3.5") init:     T,
+    @deprecatedName('enable, "Chisel 3.5") enable: Bool
+  ): T = {
     val r = RegInit(init)
     when(enable) { r := next }
     r
@@ -43,7 +50,11 @@ object ShiftRegister {
     * val regDelayTwo = ShiftRegister(nextVal, 2, ena)
     * }}}
     */
-  def apply[T <: Data](in: T, n: Int, en: Bool = true.B): T = ShiftRegisters(in, n, en).lastOption.getOrElse(in)
+  def apply[T <: Data](
+    @deprecatedName('in, "Chisel 3.5") in: T,
+    @deprecatedName('n, "Chisel 3.5") n:   Int,
+    @deprecatedName('en, "Chisel 3.5") en: Bool = true.B
+  ): T = ShiftRegisters(in, n, en).lastOption.getOrElse(in)
 
   /** Returns the n-cycle delayed version of the input signal with reset initialization.
     *
@@ -56,7 +67,12 @@ object ShiftRegister {
     * val regDelayTwoReset = ShiftRegister(nextVal, 2, 0.U, ena)
     * }}}
     */
-  def apply[T <: Data](in: T, n: Int, resetData: T, en: Bool): T =
+  def apply[T <: Data](
+    @deprecatedName('in, "Chisel 3.5") in:               T,
+    @deprecatedName('n, "Chisel 3.5") n:                 Int,
+    @deprecatedName('resetData, "Chisel 3.5") resetData: T,
+    @deprecatedName('en, "Chisel 3.5") en:               Bool
+  ): T =
     ShiftRegisters(in, n, resetData, en).lastOption.getOrElse(in)
 }
 
@@ -68,7 +84,11 @@ object ShiftRegisters {
     * @param n  number of cycles to delay
     * @param en enable the shift
     */
-  def apply[T <: Data](in: T, n: Int, en: Bool = true.B): Seq[T] =
+  def apply[T <: Data](
+    @deprecatedName('in, "Chisel 3.5") in: T,
+    @deprecatedName('n, "Chisel 3.5") n:   Int,
+    @deprecatedName('en, "Chisel 3.5") en: Bool = true.B
+  ): Seq[T] =
     Seq.iterate(in, n + 1)(util.RegEnable(_, en)).drop(1)
 
   /** Returns delayed input signal registers with reset initialization from 1 to n.
@@ -78,6 +98,11 @@ object ShiftRegisters {
     * @param resetData reset value for each register in the shift
     * @param en        enable the shift
     */
-  def apply[T <: Data](in: T, n: Int, resetData: T, en: Bool): Seq[T] =
+  def apply[T <: Data](
+    @deprecatedName('in, "Chisel 3.5") in:               T,
+    @deprecatedName('n, "Chisel 3.5") n:                 Int,
+    @deprecatedName('resetData, "Chisel 3.5") resetData: T,
+    @deprecatedName('en, "Chisel 3.5") en:               Bool
+  ): Seq[T] =
     Seq.iterate(in, n + 1)(util.RegEnable(_, resetData, en)).drop(1)
 }


### PR DESCRIPTION
These methods will start using def macros and since def macros do not
supported named arguments this will be a source-incompatible change.
This deprecation will warn users that they need to remove any uses of
named arguments on these methods.

This resolves the issue discussed in https://github.com/chipsalliance/chisel3/pull/2515.

This doesn't give perfect error messages, but it's not bad. For the following
```scala
RegEnable(next = 0.U, enable = true.B)
```
You'll get the warnings:
```
[warn] .../Example.scala:5:18: naming parameter next is deprecated (since Chisel 3.5).
[warn]   RegEnable(next = 0.U, enable = true.B)
[warn]                  ^
[warn] .../Example.scala:5:32: naming parameter enable is deprecated (since Chisel 3.5).
[warn]   RegEnable(next = 0.U, enable = true.B)
[warn]                                ^
```
Note as precise as one would like but it does suggest that you should stop using the names 🤷‍♂️ 

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

 - code cleanup    


#### API Impact

Warn about impending API change in 3.6.

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

- Squash

#### Release Notes

In Chisel 3.6, several chisel3 utils will start using def macros which do not allow named arguments. These utils are: `Cat`, `Fill`, `FillInterleaved`, `PopCount`, `Reverse`, `RegEnable`, `ShiftRegister`, and `ShiftRegisters`.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
