### PR TITLE
Support Vecs of empty Bundles

### DIFF
--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -226,8 +226,8 @@ sealed class Vec[T <: Data] private[chisel3] (gen: => T, val length: Int) extend
     }
 
     // Since all children are the same, we can just use the sample_element rather than all children
-    // .get is safe because None means mixed directions, we only pass 1 so that's not possible
-    direction = ActualDirection.fromChildren(Set(sample_element.direction), resolvedDirection).get
+    direction =
+      ActualDirection.fromChildren(Set(sample_element.direction), resolvedDirection).getOrElse(ActualDirection.Empty)
   }
 
   // Note: the constructor takes a gen() function instead of a Seq to enforce
@@ -321,6 +321,7 @@ sealed class Vec[T <: Data] private[chisel3] (gen: => T, val length: Int) extend
       case ActualDirection.Bidirectional(ActualDirection.Default) | ActualDirection.Unspecified =>
         SpecifiedDirection.Unspecified
       case ActualDirection.Bidirectional(ActualDirection.Flipped) => SpecifiedDirection.Flip
+      case ActualDirection.Empty                                  => SpecifiedDirection.Unspecified
     }
     // TODO port technically isn't directly child of this data structure, but the result of some
     // muxes / demuxes. However, this does make access consistent with the top-level bindings.


### PR DESCRIPTION
Fixes https://github.com/chipsalliance/chisel3/issues/1953

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

  - bug fix 

#### API Impact

It is now possible to create Vecs of empty Bundles

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

- Squash

#### Release Notes

Support creating Vecs of empty Bundles. Hardware components of this type are removed by the time of Verilog emission (similar to components of empty Bundles or zero-width UInts).

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
