### PR TITLE
Plugin generation of Bundle elements is now mandatory

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -195,7 +195,6 @@ lazy val chisel = (project in file("."))
   .settings(
     mimaPreviousArtifacts := Set(),
     libraryDependencies += defaultVersions("treadle") % "test",
-    Test / scalacOptions += "-P:chiselplugin:genBundleElements",
     Test / scalacOptions ++= Seq("-language:reflectiveCalls"),
     Compile / doc / scalacOptions ++= Seq(
       "-diagrams",

--- a/build.sc
+++ b/build.sc
@@ -105,7 +105,7 @@ class chisel3CrossModule(val crossScalaVersion: String) extends CommonModule wit
   }
 
   override def scalacOptions = T {
-    super.scalacOptions() ++ Agg(s"-Xplugin:${plugin.jar().path}", "-P:chiselplugin:genBundleElements")
+    super.scalacOptions() ++ Agg(s"-Xplugin:${plugin.jar().path}")
   }
 
   object stdlib extends CommonModule {

--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -1198,11 +1198,11 @@ package experimental {
   * }}}
   */
 abstract class Bundle(implicit compileOptions: CompileOptions) extends Record {
-  assert(
-    _usingPlugin,
+
+  private def mustUsePluginMsg: String =
     "The Chisel compiler plugin is now required for compiling Chisel code. " +
       "Please see https://github.com/chipsalliance/chisel3#build-your-own-chisel-projects."
-  )
+  assert(_usingPlugin, mustUsePluginMsg)
 
   override def className: String = this.getClass.getSimpleName match {
     case name if name.startsWith("$anon$") => "AnonymousBundle" // fallback for anonymous Bundle case
@@ -1228,14 +1228,7 @@ abstract class Bundle(implicit compileOptions: CompileOptions) extends Record {
     *   assert(uint === "h12345678".U) // This will pass
     * }}}
     */
-  final lazy val elements: SeqMap[String, Data] =
-    // _elementsImpl is a method, only call it once
-    _elementsImpl match {
-      // Those not using plugin-generated _elementsImpl use the old reflective implementation
-      case oldElements: VectorMap[_, _] => oldElements.asInstanceOf[VectorMap[String, Data]]
-      // Plugin-generated _elementsImpl are incomplete and need some processing
-      case rawElements => _processRawElements(rawElements)
-    }
+  final lazy val elements: SeqMap[String, Data] = _processRawElements(_elementsImpl)
 
   // The compiler plugin is imperfect at picking out elements statically so we process at runtime
   // checking for errors and filtering out mistakes
@@ -1284,58 +1277,18 @@ abstract class Bundle(implicit compileOptions: CompileOptions) extends Record {
     }: _*)
   }
 
-  /* The old, reflective implementation of Bundle.elements
-   * This method is optionally overwritten by the compiler plugin for much better performance
-   */
-  protected def _elementsImpl: Iterable[(String, Any)] = {
-    val nameMap = LinkedHashMap[String, Data]()
-    for (m <- getPublicFields(classOf[Bundle])) {
-      getBundleField(m) match {
-        case Some(d: Data) =>
-          requireIsChiselType(d)
-
-          if (nameMap contains m.getName) {
-            require(nameMap(m.getName) eq d)
-          } else {
-            nameMap(m.getName) = d
-          }
-        case None =>
-          if (!ignoreSeq) {
-            m.invoke(this) match {
-              case s: scala.collection.Seq[Any] if s.nonEmpty =>
-                s.head match {
-                  // Ignore empty Seq()
-                  case d: Data =>
-                    throwException(
-                      "Public Seq members cannot be used to define Bundle elements " +
-                        s"(found public Seq member '${m.getName}'). " +
-                        "Either use a Vec if all elements are of the same type, or MixedVec if the elements " +
-                        "are of different types. If this Seq member is not intended to construct RTL, mix in the trait " +
-                        "IgnoreSeqInBundle."
-                    )
-                  case _ => // don't care about non-Data Seq
-                }
-              case _ => // not a Seq
-            }
-          }
-      }
-    }
-    VectorMap(nameMap.toSeq.sortWith { case ((an, a), (bn, b)) => (a._id > b._id) || ((a eq b) && (an > bn)) }: _*)
-  }
+  /** This method is implemented by the compiler plugin
+    *
+    * @note For some reason, the Scala compiler errors on child classes if this method is made
+    * virtual. It appears that the way the plugin implements this method is insufficient for
+    * implementing virtual methods. It is probably better kept concrete for future refactoring.
+    */
+  protected def _elementsImpl: Iterable[(String, Any)] = throwException(mustUsePluginMsg)
 
   /**
     * Overridden by [[IgnoreSeqInBundle]] to allow arbitrary Seqs of Chisel elements.
     */
   def ignoreSeq: Boolean = false
-
-  /** Returns a field's contained user-defined Bundle element if it appears to
-    * be one, otherwise returns None.
-    */
-  private def getBundleField(m: java.lang.reflect.Method): Option[Data] = m.invoke(this) match {
-    case d: Data => Some(d)
-    case Some(d: Data) => Some(d)
-    case _ => None
-  }
 
   /** Indicates if a concrete Bundle class was compiled using the compiler plugin
     *

--- a/core/src/main/scala/chisel3/experimental/package.scala
+++ b/core/src/main/scala/chisel3/experimental/package.scala
@@ -218,6 +218,10 @@ package object experimental {
     // Because this implementation exists in chisel3.core, it cannot compile with the plugin, so we implement the behavior manually
     override protected def _usingPlugin:   Boolean = true
     override protected def _cloneTypeImpl: Bundle = new HWTuple2(chiselTypeClone(_1), chiselTypeClone(_2))
+    override protected def _elementsImpl: Iterable[(String, Any)] = Vector(
+      "_1" -> _1,
+      "_2" -> _2
+    )
   }
 
   /** [[Data]] equivalent of Scala's [[Tuple3]]
@@ -236,6 +240,11 @@ package object experimental {
       chiselTypeClone(_1),
       chiselTypeClone(_2),
       chiselTypeClone(_3)
+    )
+    override protected def _elementsImpl: Iterable[(String, Any)] = Vector(
+      "_1" -> _1,
+      "_2" -> _2,
+      "_3" -> _3
     )
   }
 
@@ -257,6 +266,12 @@ package object experimental {
       chiselTypeClone(_2),
       chiselTypeClone(_3),
       chiselTypeClone(_4)
+    )
+    override protected def _elementsImpl: Iterable[(String, Any)] = Vector(
+      "_1" -> _1,
+      "_2" -> _2,
+      "_3" -> _3,
+      "_4" -> _4
     )
   }
 
@@ -280,6 +295,13 @@ package object experimental {
       chiselTypeClone(_3),
       chiselTypeClone(_4),
       chiselTypeClone(_5)
+    )
+    override protected def _elementsImpl: Iterable[(String, Any)] = Vector(
+      "_1" -> _1,
+      "_2" -> _2,
+      "_3" -> _3,
+      "_4" -> _4,
+      "_5" -> _5
     )
   }
 
@@ -305,6 +327,14 @@ package object experimental {
       chiselTypeClone(_4),
       chiselTypeClone(_5),
       chiselTypeClone(_6)
+    )
+    override protected def _elementsImpl: Iterable[(String, Any)] = Vector(
+      "_1" -> _1,
+      "_2" -> _2,
+      "_3" -> _3,
+      "_4" -> _4,
+      "_5" -> _5,
+      "_6" -> _6
     )
   }
 
@@ -340,6 +370,15 @@ package object experimental {
       chiselTypeClone(_5),
       chiselTypeClone(_6),
       chiselTypeClone(_7)
+    )
+    override protected def _elementsImpl: Iterable[(String, Any)] = Vector(
+      "_1" -> _1,
+      "_2" -> _2,
+      "_3" -> _3,
+      "_4" -> _4,
+      "_5" -> _5,
+      "_6" -> _6,
+      "_7" -> _7
     )
   }
 
@@ -378,6 +417,16 @@ package object experimental {
       chiselTypeClone(_6),
       chiselTypeClone(_7),
       chiselTypeClone(_8)
+    )
+    override protected def _elementsImpl: Iterable[(String, Any)] = Vector(
+      "_1" -> _1,
+      "_2" -> _2,
+      "_3" -> _3,
+      "_4" -> _4,
+      "_5" -> _5,
+      "_6" -> _6,
+      "_7" -> _7,
+      "_8" -> _8
     )
   }
 
@@ -419,6 +468,17 @@ package object experimental {
       chiselTypeClone(_7),
       chiselTypeClone(_8),
       chiselTypeClone(_9)
+    )
+    override protected def _elementsImpl: Iterable[(String, Any)] = Vector(
+      "_1" -> _1,
+      "_2" -> _2,
+      "_3" -> _3,
+      "_4" -> _4,
+      "_5" -> _5,
+      "_6" -> _6,
+      "_7" -> _7,
+      "_8" -> _8,
+      "_9" -> _9
     )
   }
 
@@ -463,6 +523,18 @@ package object experimental {
       chiselTypeClone(_8),
       chiselTypeClone(_9),
       chiselTypeClone(_10)
+    )
+    override protected def _elementsImpl: Iterable[(String, Any)] = Vector(
+      "_1" -> _1,
+      "_2" -> _2,
+      "_3" -> _3,
+      "_4" -> _4,
+      "_5" -> _5,
+      "_6" -> _6,
+      "_7" -> _7,
+      "_8" -> _8,
+      "_9" -> _9,
+      "_10" -> _10
     )
   }
 }

--- a/plugin/src/main/scala/chisel3/internal/plugin/BundleComponent.scala
+++ b/plugin/src/main/scala/chisel3/internal/plugin/BundleComponent.scala
@@ -162,9 +162,7 @@ private[plugin] class BundleComponent(val global: Global, arguments: ChiselPlugi
         /* Test to see if the bundle found is amenable to having it's elements
          * converted to an immediate form that will not require reflection
          */
-        def isSupportedBundleType: Boolean = {
-          arguments.genBundleElements && !bundle.mods.hasFlag(Flag.ABSTRACT)
-        }
+        def isSupportedBundleType: Boolean = !bundle.mods.hasFlag(Flag.ABSTRACT)
 
         val elementsImplOpt = if (isSupportedBundleType) {
           /* extract the true fields from the super classes a given bundle

--- a/plugin/src/main/scala/chisel3/internal/plugin/ChiselPlugin.scala
+++ b/plugin/src/main/scala/chisel3/internal/plugin/ChiselPlugin.scala
@@ -9,8 +9,7 @@ import scala.reflect.internal.util.NoPosition
 import scala.collection.mutable
 
 private[plugin] case class ChiselPluginArguments(
-  val skipFiles:         mutable.HashSet[String] = mutable.HashSet.empty,
-  var genBundleElements: Boolean = false) {
+  val skipFiles: mutable.HashSet[String] = mutable.HashSet.empty) {
   def useBundlePluginOpt = "useBundlePlugin"
   def useBundlePluginFullOpt = s"-P:${ChiselPlugin.name}:$useBundlePluginOpt"
   def genBundleElementsOpt = "genBundleElements"
@@ -62,7 +61,7 @@ class ChiselPlugin(val global: Global) extends Plugin {
   override def init(options: List[String], error: String => Unit): Boolean = {
     for (option <- options) {
       if (option == arguments.useBundlePluginOpt) {
-        val msg = s"'${arguments.useBundlePluginFullOpt}' is now default behavior, you can stop using the scalacOption."
+        val msg = s"'${arguments.useBundlePluginFullOpt}' is now default behavior, you can remove the scalacOption."
         global.reporter.warning(NoPosition, msg)
       } else if (option.startsWith(arguments.skipFilePluginOpt)) {
         val filename = option.stripPrefix(arguments.skipFilePluginOpt)
@@ -71,7 +70,8 @@ class ChiselPlugin(val global: Global) extends Plugin {
         val msg = s"Option -P:${ChiselPlugin.name}:$option should only be used for internal chisel3 compiler purposes!"
         global.reporter.warning(NoPosition, msg)
       } else if (option == arguments.genBundleElementsOpt) {
-        arguments.genBundleElements = true
+        val msg = s"'${arguments.genBundleElementsOpt}' is now default behavior, you can remove the scalacOption."
+        global.reporter.warning(NoPosition, msg)
       } else {
         error(s"Option not understood: '$option'")
       }


### PR DESCRIPTION
Feature originally added in [v3.5.1](https://github.com/chipsalliance/chisel3/releases/tag/v3.5.1), it was technically a binary incompatible change so in v3.6.0 it will become mandatory.

This enables removing reflection.

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

  - performance improvement  
  - code cleanup  

#### API Impact

No impact since the plugin is required and the same names are given.

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

- Squash

#### Release Notes

Make Chisel-plugin generation of `Bundle.elements` mandatory. Scalac option `-P:chiselplugin:genBundleElements` no longer does anything.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [x] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [x] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
