### PR TITLE
Make ExtModule port naming consistent with Module

### DIFF
--- a/core/src/main/scala/chisel3/BlackBox.scala
+++ b/core/src/main/scala/chisel3/BlackBox.scala
@@ -71,11 +71,8 @@ package experimental {
 
       val names = nameIds(classOf[ExtModule])
 
-      // Name ports based on reflection
-      for (port <- getModulePorts) {
-        require(names.contains(port), s"Unable to name port $port in $this")
-        port.setRef(ModuleIO(this, _namespace.name(names(port))))
-      }
+      // Ports are named in the same way as regular Modules
+      namePorts(names)
 
       // All suggestions are in, force names to every node.
       // While BlackBoxes are not supposed to have an implementation, we still need to call

--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -351,6 +351,27 @@ package experimental {
       */
     private[chisel3] def initializeInParent(parentCompileOptions: CompileOptions): Unit
 
+    private[chisel3] def namePorts(names: HashMap[HasId, String]): Unit = {
+      for (port <- getModulePorts) {
+        port._computeName(None, None).orElse(names.get(port)) match {
+          case Some(name) =>
+            if (_namespace.contains(name)) {
+              Builder.error(
+                s"""Unable to name port $port to "$name" in $this,""" +
+                  " name is already taken by another port!"
+              )
+            }
+            port.setRef(ModuleIO(this, _namespace.name(name)))
+          case None =>
+            Builder.error(
+              s"Unable to name port $port in $this, " +
+                "try making it a public field of the Module"
+            )
+            port.setRef(ModuleIO(this, "<UNNAMED>"))
+        }
+      }
+    }
+
     //
     // Chisel Internals
     //

--- a/core/src/main/scala/chisel3/RawModule.scala
+++ b/core/src/main/scala/chisel3/RawModule.scala
@@ -43,27 +43,6 @@ abstract class RawModule(implicit moduleCompileOptions: CompileOptions) extends 
 
   val compileOptions = moduleCompileOptions
 
-  private[chisel3] def namePorts(names: HashMap[HasId, String]): Unit = {
-    for (port <- getModulePorts) {
-      port._computeName(None, None).orElse(names.get(port)) match {
-        case Some(name) =>
-          if (_namespace.contains(name)) {
-            Builder.error(
-              s"""Unable to name port $port to "$name" in $this,""" +
-                " name is already taken by another port!"
-            )
-          }
-          port.setRef(ModuleIO(this, _namespace.name(name)))
-        case None =>
-          Builder.error(
-            s"Unable to name port $port in $this, " +
-              "try making it a public field of the Module"
-          )
-          port.setRef(ModuleIO(this, "<UNNAMED>"))
-      }
-    }
-  }
-
   private[chisel3] override def generateComponent(): Option[Component] = {
     require(!_closed, "Can't generate module more than once")
     _closed = true


### PR DESCRIPTION
ExtModule now uses the same namePorts implementation as regular Modules.
Previously, ExtModules only allowed port naming via runtime reflection.
This meant that .suggestName and other naming APIs do not work. It also
breaks FlatIO for ExtModule which is a potential replacement API for
BlackBox's special `val io` handling.

This is an API expansion (see `API Impact` below) but it is arguably a bugfix that the APIs that work for normal modules just don't work for `ExtModule`. I can be convinced that this should be done in 3.6.0 as this fix/change is a necessary piece of my effort to remove runtime reflection naming in 3.6.0, but I think there's value in getting this piece out as a bugfix in 3.5.4.

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
 - bug fix 
 - code cleanup 
 - new feature/API   

#### API Impact

Previously, ExtModule ports could **only** be named by runtime reflection. This meant that compiler plugin naming and APIs like `.suggestName` would not work. This also meant that `FlatIO` didn't work. Now the naming behavior for `ExtModule` ports is consistent with that of regular `Modules`.

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

   - Squash

#### Release Notes

`ExtModule` port naming is now consistent with `Module` port naming. This means things like `.suggestName` work and cases where reflective naming fails will now work via the compiler plugin. Also it makes `FlatIO` work on `ExtModule`.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
