### PR TITLE
Deprecate accessing the name of non-hardware Data

### DIFF
--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -240,7 +240,18 @@ private[chisel3] trait HasId extends InstanceId {
 
   private def refName(c: Component): String = _ref match {
     case Some(arg) => arg.fullName(c)
-    case None      => _computeName(None, None).get
+    case None      =>
+      // This is super hacky but this is just for a short term deprecation
+      // These accesses occur after Chisel elaboration so we cannot use the normal
+      // Builder.deprecated mechanism, we have to create our own one off ErrorLog and print the
+      // warning right away.
+      val errors = new ErrorLog
+      val logger = new _root_.logger.Logger(this.getClass.getName)
+      val msg = "Accessing the .instanceName or .toTarget of non-hardware Data is deprecated. " +
+        "This will become an error in Chisel 3.6."
+      errors.deprecated(msg, None)
+      errors.checkpoint(logger)
+      _computeName(None, None).get
   }
 
   // Helper for reifying views if they map to a single Target

--- a/src/test/scala/chiselTests/InstanceNameSpec.scala
+++ b/src/test/scala/chiselTests/InstanceNameSpec.scala
@@ -22,28 +22,36 @@ class InstanceNameModule extends Module {
   io.bar := io.foo + x
 }
 
-class InstanceNameSpec extends ChiselFlatSpec {
+class InstanceNameSpec extends ChiselFlatSpec with Utils {
   behavior.of("instanceName")
   val moduleName = "InstanceNameModule"
   var m: InstanceNameModule = _
   ChiselStage.elaborate { m = new InstanceNameModule; m }
+
+  val deprecationMsg = "Accessing the .instanceName or .toTarget of non-hardware Data is deprecated"
 
   it should "work with module IO" in {
     val io = m.io.pathName
     assert(io == moduleName + ".io")
   }
 
-  it should "work with internal vals" in {
+  it should "work for literals" in {
     val x = m.x.pathName
-    val y = m.y.pathName
-    val z = m.z.pathName
     assert(x == moduleName + ".UInt<2>(\"h03\")")
+  }
+
+  it should "work with non-hardware values (but be deprecated)" in {
+    val (ylog, y) = grabLog(m.y.pathName)
+    val (zlog, z) = grabLog(m.z.pathName)
+    ylog should include(deprecationMsg)
     assert(y == moduleName + ".y")
+    zlog should include(deprecationMsg)
     assert(z == moduleName + ".z")
   }
 
-  it should "work with bundle elements" in {
-    val foo = m.z.foo.pathName
+  it should "work with non-hardware bundle elements (but be deprecated)" in {
+    val (log, foo) = grabLog(m.z.foo.pathName)
+    log should include(deprecationMsg)
     assert(foo == moduleName + ".z.foo")
   }
 

--- a/src/test/scala/chiselTests/ToTargetSpec.scala
+++ b/src/test/scala/chiselTests/ToTargetSpec.scala
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiselTests
+
+import chisel3._
+import chisel3.stage.ChiselStage
+import chisel3.util.Queue
+import chisel3.internal.ChiselException
+
+class ToTargetSpec extends ChiselFlatSpec with Utils {
+
+  var m: InstanceNameModule = _
+  ChiselStage.elaborate { m = new InstanceNameModule; m }
+
+  val mn = "InstanceNameModule"
+  val top = s"~$mn|$mn"
+
+  behavior.of(".toTarget")
+
+  val deprecationMsg = "Accessing the .instanceName or .toTarget of non-hardware Data is deprecated"
+
+  it should "work with module IO" in {
+    val io = m.io.toTarget.toString
+    assert(io == s"$top>io")
+  }
+
+  it should "not work for literals" in {
+    a[ChiselException] shouldBe thrownBy {
+      m.x.toTarget.toString
+    }
+  }
+
+  it should "work with non-hardware values (but be deprecated)" in {
+    val (ylog, y) = grabLog(m.y.toTarget.toString)
+    val (zlog, z) = grabLog(m.z.toTarget.toString)
+    assert(y == s"$top>y")
+    ylog should include(deprecationMsg)
+    assert(z == s"$top>z")
+    zlog should include(deprecationMsg)
+  }
+
+  it should "work with non-hardware bundle elements (but be deprecated)" in {
+    val (log, foo) = grabLog(m.z.foo.toTarget.toString)
+    log should include(deprecationMsg)
+    assert(foo == s"$top>z.foo")
+  }
+
+  it should "work with modules" in {
+    val q = m.q.toTarget.toString
+    assert(q == s"~$mn|Queue")
+  }
+}


### PR DESCRIPTION
This includes (and is tested) for both the old .*Name APIs and
.toTarget

Note that this PR primarily exists to be backported to `3.5.x` and I will immediately follow it with a PR turning these accesses into errors on `master`.

Note that this deprecation and ultimate removal was contemplated in https://github.com/chipsalliance/chisel3/pull/1616. I am finally doing it now in preparation for removing all reflective naming in Chisel 3.6.

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

   - code cleanup
   - API deprecation

#### API Impact

This deprecates accessing the name (via `.instanceName` and related APIs as well as via `.toTarget`) of non-hardware `Data` (ie. unbound `Data` objects). These names do not correspond to anything in the FIRRTL and are thus very misleading.

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

   - Squash
  
#### Release Notes

Accessing the "hardware name" of non-hardware `Data` is now deprecated. This includes `.pathName` and `.toTarget`.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
