### PR TITLE
Support VerificationStatement in the naming plugin

### DIFF
--- a/src/test/scala/chiselTests/VerificationSpec.scala
+++ b/src/test/scala/chiselTests/VerificationSpec.scala
@@ -105,9 +105,9 @@ class VerificationSpec extends ChiselPropSpec with Matchers {
     val firLines = scala.io.Source.fromFile(firFile).getLines.toList
 
     // check that verification components have expected names
-    exactly(1, firLines) should include("cover(clock, _T, UInt<1>(\"h1\"), \"\") : cov")
-    exactly(1, firLines) should include("assume(clock, _T_3, UInt<1>(\"h1\"), \"\") : assm")
-    exactly(1, firLines) should include("assert(clock, _T_7, UInt<1>(\"h1\"), \"\") : asst")
+    (exactly(1, firLines) should include).regex("^\\s*cover\\(.*\\) : cov")
+    (exactly(1, firLines) should include).regex("^\\s*assume\\(.*\\) : assm")
+    (exactly(1, firLines) should include).regex("^\\s*assert\\(.*\\) : asst")
   }
 
   property("annotation of verification constructs with suggested name should work") {
@@ -150,7 +150,7 @@ class VerificationSpec extends ChiselPropSpec with Matchers {
     val firLines = scala.io.Source.fromFile(firFile).getLines.toList
 
     // check that verification components have expected names
-    exactly(1, firLines) should include("assert(clock, _T, UInt<1>(\"h1\"), \"\") : hello")
-    exactly(1, firLines) should include("assume(clock, _T_4, UInt<1>(\"h1\"), \"\") : howdy")
+    (exactly(1, firLines) should include).regex("^\\s*assert\\(.*\\) : hello")
+    (exactly(1, firLines) should include).regex("^\\s*assume\\(.*\\) : howdy")
   }
 }


### PR DESCRIPTION
Previously, verification statements (assert, assume, cover, and printf)
were only named via reflection.

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

- bug fix   

#### API Impact

Verification statements are now named in the same way as normal hardware components. 

#### Backend Code Generation Impact

In rare cases, some signals may get a new prefix based on the name of a verification statement, but this should only occur in cases where the statement is returned from a function/block and assigned to a val, eg.
```scala
val foo = {
  val wire = Wire(UInt(8.W))
  wire := ...
  assert(wire =/= 123.U)
}
```
In this case, `wire` will now be named `foo_wire`.

#### Desired Merge Strategy

   - Squash
  
#### Release Notes

Handle naming and prefixing of verification statements in the same way as `Data` and `Mems`. This primarily affects the names used by annotations but also will now cause prefixing when a verification statement is returned from a function or block and assigned to a `val`.

### Reviewer Checklist (only modified by reviewer)
- [x] Did you add the appropriate labels?
- [x] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [x] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [x] Did you do one of the following when ready to merge:
  - [x] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
