### PR TITLE
Add single argument Bits.extract

### DIFF
--- a/core/src/main/scala/chisel3/Bits.scala
+++ b/core/src/main/scala/chisel3/Bits.scala
@@ -100,10 +100,7 @@ sealed abstract class Bits(private[chisel3] val width: Width) extends Element wi
     * @param x an index
     * @return the specified bit
     */
-  final def apply(x: BigInt): Bool = macro IntLiteralApplyTransform.safeApply
-
-  /** @group SourceInfoTransformMacro */
-  final def do_apply(x: BigInt)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool = {
+  final def extract(x: BigInt)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool = {
     if (x < 0) {
       Builder.error(s"Negative bit indices are illegal (got $x)")
     }
@@ -128,11 +125,32 @@ sealed abstract class Bits(private[chisel3] val width: Width) extends Element wi
     * @param x an index
     * @return the specified bit
     */
+  final def apply(x: BigInt): Bool = macro IntLiteralApplyTransform.safeApply
+
+  /** @group SourceInfoTransformMacro */
+  final def do_apply(x: BigInt)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool =
+    extract(x)
+
+  /** Returns the specified bit on this $coll as a [[Bool]], statically addressed.
+    *
+    * @param x an index
+    * @return the specified bit
+    */
   final def apply(x: Int): Bool = macro IntLiteralApplyTransform.safeApply
 
   /** @group SourceInfoTransformMacro */
   final def do_apply(x: Int)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool =
-    do_apply(BigInt(x))
+    extract(BigInt(x))
+
+  /** Returns the specified bit on this wire as a [[Bool]], dynamically addressed.
+    *
+    * @param x a hardware component whose value will be used for dynamic addressing
+    * @return the specified bit
+    */
+  final def extract(x: UInt)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool = {
+    val theBits = this >> x
+    theBits(0)
+  }
 
   /** Returns the specified bit on this wire as a [[Bool]], dynamically addressed.
     *
@@ -142,10 +160,8 @@ sealed abstract class Bits(private[chisel3] val width: Width) extends Element wi
   final def apply(x: UInt): Bool = macro SourceInfoTransform.xArg
 
   /** @group SourceInfoTransformMacro */
-  final def do_apply(x: UInt)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool = {
-    val theBits = this >> x
-    theBits(0)
-  }
+  final def do_apply(x: UInt)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool =
+    extract(x)
 
   /** Returns a subset of bits on this $coll from `hi` to `lo` (inclusive), statically addressed.
     *

--- a/core/src/main/scala/chisel3/Bits.scala
+++ b/core/src/main/scala/chisel3/Bits.scala
@@ -100,7 +100,10 @@ sealed abstract class Bits(private[chisel3] val width: Width) extends Element wi
     * @param x an index
     * @return the specified bit
     */
-  final def extract(x: BigInt)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool = {
+  final def extract(x: BigInt): Bool = macro SourceInfoTransform.xArg
+
+  /** @group SourceInfoTransformMacro */
+  final def do_extract(x: BigInt)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool = {
     if (x < 0) {
       Builder.error(s"Negative bit indices are illegal (got $x)")
     }
@@ -129,7 +132,7 @@ sealed abstract class Bits(private[chisel3] val width: Width) extends Element wi
 
   /** @group SourceInfoTransformMacro */
   final def do_apply(x: BigInt)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool =
-    extract(x)
+    do_extract(x)
 
   /** Returns the specified bit on this $coll as a [[Bool]], statically addressed.
     *
@@ -140,14 +143,17 @@ sealed abstract class Bits(private[chisel3] val width: Width) extends Element wi
 
   /** @group SourceInfoTransformMacro */
   final def do_apply(x: Int)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool =
-    extract(BigInt(x))
+    do_extract(BigInt(x))
 
   /** Returns the specified bit on this wire as a [[Bool]], dynamically addressed.
     *
     * @param x a hardware component whose value will be used for dynamic addressing
     * @return the specified bit
     */
-  final def extract(x: UInt)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool = {
+  final def extract(x: UInt): Bool = macro SourceInfoTransform.xArg
+
+  /** @group SourceInfoTransformMacro */
+  final def do_extract(x: UInt)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool = {
     val theBits = this >> x
     theBits(0)
   }
@@ -161,7 +167,7 @@ sealed abstract class Bits(private[chisel3] val width: Width) extends Element wi
 
   /** @group SourceInfoTransformMacro */
   final def do_apply(x: UInt)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool =
-    extract(x)
+    do_extract(x)
 
   /** Returns a subset of bits on this $coll from `hi` to `lo` (inclusive), statically addressed.
     *

--- a/macros/src/main/scala/chisel3/internal/sourceinfo/SourceInfoTransform.scala
+++ b/macros/src/main/scala/chisel3/internal/sourceinfo/SourceInfoTransform.scala
@@ -312,7 +312,7 @@ class IntLiteralApplyTransform(val c: Context) extends AutoSourceTransform {
           val msg =
             s"""Passing an Int to .$func is usually a mistake: It does *not* set the width but does a bit extract.
                |Did you mean .$func($arg.W)?
-               |If you want to hide this message, assign .$func to a val first, then invoke .apply($arg)
+               |If you do want bit extraction, use .extract($arg) instead
                |""".stripMargin
           c.warning(c.enclosingPosition, msg)
         }

--- a/src/test/scala/chiselTests/SIntOps.scala
+++ b/src/test/scala/chiselTests/SIntOps.scala
@@ -85,18 +85,9 @@ class SIntOpsTester(c: SIntOps) extends Tester(c) {
  */
 
 class SIntLitExtractTester extends BasicTester {
-  assert({
-    val lit = -5.S
-    lit(1) === true.B
-  })
-  assert({
-    val lit = -5.S
-    lit(2) === false.B
-  })
-  assert({
-    val lit = -5.S
-    lit(100) === true.B
-  })
+  assert(-5.S.extract(1) === true.B)
+  assert(-5.S.extract(2) === false.B)
+  assert(-5.S.extract(100) === true.B)
   assert(-5.S(3, 0) === "b1011".U)
   assert(-5.S(9, 0) === "b1111111011".U)
   assert(-5.S(4.W)(1) === true.B)

--- a/src/test/scala/chiselTests/UIntOps.scala
+++ b/src/test/scala/chiselTests/UIntOps.scala
@@ -172,18 +172,9 @@ class MatchedRotateLeftAndRight(w: Int = 13) extends BasicTester {
 }
 
 class UIntLitExtractTester extends BasicTester {
-  assert({
-    val lit = "b101010".U
-    lit(2) === false.B
-  })
-  assert({
-    val lit = "b101010".U
-    lit(3) === true.B
-  })
-  assert({
-    val lit = "b101010".U
-    lit(100) === false.B
-  })
+  assert("b101010".U.extract(2) === false.B)
+  assert("b101010".U.extract(3) === true.B)
+  assert("b101010".U.extract(100) === false.B)
   assert("b101010".U(3, 0) === "b1010".U)
   assert("b101010".U(9, 0) === "b0000101010".U)
 


### PR DESCRIPTION
This PR adds the `.extract` function discussed in #2534, but instead being for the purpose of reducing boilerplate code (e.g. assigning a literal to a val, then calling .apply).

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
- new feature/API

#### API Impact

Adds single argument `Bits.extract` functions which the existing `apply()` functions alias to

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

Squash and merge

#### Release Notes
Add `Bits.extract` and alias single-argument `.apply()` functions to it
This is to make deprecation of the literal bit extract pattern easier by removing the need for lots of boilerplate.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
