### PR TITLE
Enhance suggestion in literal extract warning

### DIFF
--- a/macros/src/main/scala/chisel3/internal/sourceinfo/SourceInfoTransform.scala
+++ b/macros/src/main/scala/chisel3/internal/sourceinfo/SourceInfoTransform.scala
@@ -312,7 +312,7 @@ class IntLiteralApplyTransform(val c: Context) extends AutoSourceTransform {
           val msg =
             s"""Passing an Int to .$func is usually a mistake: It does *not* set the width but does a bit extract.
                |Did you mean .$func($arg.W)?
-               |If you do want bit extraction, use .extract($arg) instead
+               |If you do want bit extraction, use .$func.extract($arg) instead.
                |""".stripMargin
           c.warning(c.enclosingPosition, msg)
         }


### PR DESCRIPTION
Include the function being called in the suggestion.

A very minor enhancement to the warning. Given:
```scala
  val out = IO(Output(UInt(8.W)))
  out := 12.U(8)
```
Old suggestion:
```
[warn] If you do want bit extraction, use .extract(8) instead
[warn]   out := 12.U(8)
[warn]              ^
```
New suggestion:
```
[warn] If you do want bit extraction, use .U.extract(8) instead.
[warn]   out := 12.U(8)
[warn]              ^
```

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [NA] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

 - documentation (warning suggestion)


#### API Impact

No impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

- Squash

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
