### PR TITLE
Added migration for inferModuleReset

### DIFF
--- a/core/src/main/scala/chisel3/CompileOptions.scala
+++ b/core/src/main/scala/chisel3/CompileOptions.scala
@@ -24,7 +24,7 @@ trait CompileOptions {
   val inferModuleReset: Boolean
 
   // If marked true, then any Module which consumes inferModuleReset=false must also mix in chisel3.RequireSyncReset
-  val migrateInferModuleReset: Boolean = false
+  def migrateInferModuleReset: Boolean = false
 }
 
 object CompileOptions {

--- a/core/src/main/scala/chisel3/CompileOptions.scala
+++ b/core/src/main/scala/chisel3/CompileOptions.scala
@@ -22,6 +22,9 @@ trait CompileOptions {
   val explicitInvalidate: Boolean
   // Should the reset type of Module be a Bool or a Reset
   val inferModuleReset: Boolean
+
+  // If marked true, then any Module which consumes inferModuleReset=false must also mix in chisel3.RequireSyncReset
+  val migrateInferModuleReset: Boolean = false
 }
 
 object CompileOptions {

--- a/core/src/main/scala/chisel3/CompileOptions.scala
+++ b/core/src/main/scala/chisel3/CompileOptions.scala
@@ -23,7 +23,7 @@ trait CompileOptions {
   // Should the reset type of Module be a Bool or a Reset
   val inferModuleReset: Boolean
 
-  // If marked true, then any Module which consumes inferModuleReset=false must also mix in chisel3.RequireSyncReset
+  /** If marked true, then any Module which consumes `inferModuleReset=false` must also mix in [[RequireSyncReset]] */
   def migrateInferModuleReset: Boolean = false
 }
 

--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -141,6 +141,15 @@ abstract class Module(implicit moduleCompileOptions: CompileOptions) extends Raw
     // Top module and compatibility mode use Bool for reset
     // Note that a Definition elaboration will lack a parent, but still not be a Top module
     val inferReset = (_parent.isDefined || Builder.inDefinition) && moduleCompileOptions.inferModuleReset
+    if (moduleCompileOptions.migrateInferModuleReset && !moduleCompileOptions.inferModuleReset) {
+      this match {
+        case _: RequireSyncReset => // Good! It's been migrated.
+        case _ => // Bad! It hasn't been migrated.
+          Builder.error(
+            s"$desiredName is not inferring its module reset, but has not been marked `RequireSyncReset`. Please extend this trait."
+          )
+      }
+    }
     if (inferReset) Reset() else Bool()
   }
 

--- a/src/test/scala/chiselTests/MigrateCompileOptionsSpec.scala
+++ b/src/test/scala/chiselTests/MigrateCompileOptionsSpec.scala
@@ -38,6 +38,6 @@ class MigrateCompileOptionsSpec extends ChiselFlatSpec with ScalaCheckDrivenProp
     class Foo extends Module with RequireSyncReset {
       val io = new Bundle {}
     }
-    ChiselStage.elaborate(new Foo {})
+    ChiselStage.elaborate(new Foo)
   }
 }

--- a/src/test/scala/chiselTests/MigrateCompileOptionsSpec.scala
+++ b/src/test/scala/chiselTests/MigrateCompileOptionsSpec.scala
@@ -30,7 +30,7 @@ class MigrateCompileOptionsSpec extends ChiselFlatSpec with ScalaCheckDrivenProp
       val io = new Bundle {}
     }
     intercept[Exception] {
-      ChiselStage.elaborate(new Foo {})
+      ChiselStage.elaborate(new Foo)
     }
   }
   it should "not error if migrating, and you mix with RequireSyncReset" in {

--- a/src/test/scala/chiselTests/MigrateCompileOptionsSpec.scala
+++ b/src/test/scala/chiselTests/MigrateCompileOptionsSpec.scala
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiselTests
+
+import chisel3.stage.ChiselStage
+
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+
+class MigrateCompileOptionsSpec extends ChiselFlatSpec with ScalaCheckDrivenPropertyChecks with Utils {
+  import Chisel.{defaultCompileOptions => _, _}
+  import chisel3.RequireSyncReset
+
+  behavior.of("Migrating infer resets")
+
+  val migrateIR = new chisel3.CompileOptions {
+    val connectFieldsMustMatch = false
+    val declaredTypeMustBeUnbound = false
+    val dontTryConnectionsSwapped = false
+    val dontAssumeDirectionality = false
+    val checkSynthesizable = false
+    val explicitInvalidate = false
+    val inferModuleReset = false
+
+    override val migrateInferModuleReset = true
+  }
+
+  it should "error if migrating, but not extended RequireSyncReset" in {
+    implicit val options = migrateIR
+    class Foo extends Module {
+      val io = new Bundle {}
+    }
+    intercept[Exception] {
+      ChiselStage.elaborate(new Foo {})
+    }
+  }
+  it should "not error if migrating, and you mix with RequireSyncReset" in {
+    implicit val options = migrateIR
+    class Foo extends Module with RequireSyncReset {
+      val io = new Bundle {}
+    }
+    ChiselStage.elaborate(new Foo {})
+  }
+}


### PR DESCRIPTION
### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

I didn't add more comprehensive ScalaDoc. I will add that once we add migration options for all the compilation options.

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->
Adds another optional field to CompileOptions to migrate inferModuleReset.

#### Desired Merge Strategy

Squash

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

Added an optional field to CompileOptions to help users migrate the inferModuleReset compile option.

### Reviewer Checklist (only modified by reviewer)
- [x] Did you add the appropriate labels?
- [x] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [x] Did you review?
- [x] Did you check whether all relevant Contributor checkboxes have been checked?
- [x] Did you do one of the following when ready to merge:
  - [x] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
