### PR TITLE
Add ProcessLogger to TesterDriver for less test noise

### DIFF
--- a/src/test/scala/chisel3/testers/TreadleBackend.scala
+++ b/src/test/scala/chisel3/testers/TreadleBackend.scala
@@ -14,6 +14,8 @@ import treadle.{CallResetAtStartupAnnotation, TreadleTesterAnnotation, WriteVcdA
 
 import java.io.File
 
+import scala.sys.process.ProcessLogger
+
 case object TreadleBackend extends TesterDriver.Backend {
   val MaxTreadleCycles = 10000L
 
@@ -21,7 +23,8 @@ case object TreadleBackend extends TesterDriver.Backend {
     t:                    () => BasicTester,
     additionalVResources: Seq[String] = Seq(),
     annotations:          AnnotationSeq = Seq(),
-    nameHint:             Option[String] = None
+    nameHint:             Option[String] = None,
+    processLogger:        ProcessLogger = TesterDriver.loggingProcessLogger
   ): Boolean = {
     val generatorAnnotation = chisel3.stage.ChiselGeneratorAnnotation(t)
 


### PR DESCRIPTION
Captures default output in TesterDriver with a ProcessLogger using the
Logger from FIRRTL to suppress output from Verilator when running tests.
This will change behavior for any users of the TesterDriver because the
standard out of Verilator compilation and execution is suppressed by default.

Users can create their own ProcessLogger to restore the previous
behavior, eg.
```scala
import scala.sys.process.ProcessLogger
val echoLogger = ProcessLogger(Console.out.println, Console.err.println)
```
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

 - code cleanup 

#### API Impact

This is binary incompatible. It could be made compatible but I don't care enough to do so, this is just for CI.

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

 - Squash
 
#### Release Notes

Add `ProcessLogger` argument to `TesterDriver.execute`. By default, stdout and stderr are now sent to a `logger.Logger` object instead of echoing to the user's Console.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
