### PR TITLE
Add ImplicitInvalidate, to help migrate the explicitInvalidate compiler option

### DIFF
--- a/core/src/main/scala/chisel3/Data.scala
+++ b/core/src/main/scala/chisel3/Data.scala
@@ -866,7 +866,7 @@ trait WireFactory {
     x.bind(WireBinding(Builder.forcedUserModule, Builder.currentWhen))
 
     pushCommand(DefWire(sourceInfo, x))
-    if (!compileOptions.explicitInvalidate) {
+    if (!compileOptions.explicitInvalidate || Builder.currentModule.get.isInstanceOf[ImplicitInvalidate]) {
       pushCommand(DefInvalid(sourceInfo, x.ref))
     }
 

--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -251,7 +251,7 @@ package internal {
       clonePorts.setAllParents(Some(cloneParent))
       cloneParent._portsRecord = clonePorts
       // Normally handled during Module construction but ClonePorts really lives in its parent's parent
-      if (!compileOptions.explicitInvalidate) {
+      if (!compileOptions.explicitInvalidate || Builder.currentModule.get.isInstanceOf[ImplicitInvalidate]) {
         // FIXME This almost certainly doesn't work since clonePorts is not a real thing...
         pushCommand(DefInvalid(sourceInfo, clonePorts.ref))
       }

--- a/core/src/main/scala/chisel3/RawModule.scala
+++ b/core/src/main/scala/chisel3/RawModule.scala
@@ -136,7 +136,7 @@ trait RequireSyncReset extends Module {
 }
 
 /** Mix with a [[RawModule]] to automatically connect DontCare to the module's ports, wires, and children instance IOs. */
-trait ImplicitInvalidate
+trait ImplicitInvalidate { self: RawModule => }
 
 package object internal {
 

--- a/core/src/main/scala/chisel3/RawModule.scala
+++ b/core/src/main/scala/chisel3/RawModule.scala
@@ -135,6 +135,7 @@ trait RequireSyncReset extends Module {
   override private[chisel3] def mkReset: Bool = Bool()
 }
 
+/** Mix with a [[RawModule]] to automatically connect DontCare to the module's ports, wires, and children instance IOs. */
 trait ImplicitInvalidate
 
 package object internal {

--- a/core/src/main/scala/chisel3/RawModule.scala
+++ b/core/src/main/scala/chisel3/RawModule.scala
@@ -105,7 +105,7 @@ abstract class RawModule(implicit moduleCompileOptions: CompileOptions) extends 
     // Generate IO invalidation commands to initialize outputs as unused,
     //  unless the client wants explicit control over their generation.
     val invalidateCommands = {
-      if (!compileOptions.explicitInvalidate) {
+      if (!compileOptions.explicitInvalidate || this.isInstanceOf[ImplicitInvalidate]) {
         getModulePorts.map { port => DefInvalid(UnlocatableSourceInfo, port.ref) }
       } else {
         Seq()
@@ -119,7 +119,7 @@ abstract class RawModule(implicit moduleCompileOptions: CompileOptions) extends 
   private[chisel3] def initializeInParent(parentCompileOptions: CompileOptions): Unit = {
     implicit val sourceInfo = UnlocatableSourceInfo
 
-    if (!parentCompileOptions.explicitInvalidate) {
+    if (!parentCompileOptions.explicitInvalidate || Builder.currentModule.get.isInstanceOf[ImplicitInvalidate]) {
       for (port <- getModulePorts) {
         pushCommand(DefInvalid(sourceInfo, port.ref))
       }
@@ -134,6 +134,8 @@ trait RequireAsyncReset extends Module {
 trait RequireSyncReset extends Module {
   override private[chisel3] def mkReset: Bool = Bool()
 }
+
+trait ImplicitInvalidate
 
 package object internal {
 

--- a/src/test/scala/chiselTests/MigrateCompileOptionsSpec.scala
+++ b/src/test/scala/chiselTests/MigrateCompileOptionsSpec.scala
@@ -3,41 +3,132 @@
 package chiselTests
 
 import chisel3.stage.ChiselStage
+import chisel3.ImplicitInvalidate
+import chisel3.ExplicitCompileOptions
 
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
-class MigrateCompileOptionsSpec extends ChiselFlatSpec with ScalaCheckDrivenPropertyChecks with Utils {
+class MigrateCompileOptionsSpec extends ChiselFunSpec with Utils {
   import Chisel.{defaultCompileOptions => _, _}
   import chisel3.RequireSyncReset
 
-  behavior.of("Migrating infer resets")
-
-  val migrateIR = new chisel3.CompileOptions {
-    val connectFieldsMustMatch = false
-    val declaredTypeMustBeUnbound = false
-    val dontTryConnectionsSwapped = false
-    val dontAssumeDirectionality = false
-    val checkSynthesizable = false
-    val explicitInvalidate = false
-    val inferModuleReset = false
-
-    override val migrateInferModuleReset = true
+  describe("(0): Migrating infer resets") {
+    import MigrationExamples.InferResets._
+    it("(0.a): Error if migrating, but not extended RequireSyncReset") {
+      intercept[Exception] { ChiselStage.elaborate(new Foo) }
+    }
+    it("(0.b): Not error if migrating, and you mix with RequireSyncReset") {
+      ChiselStage.elaborate(new FooWithRequireSyncReset)
+    }
   }
 
-  it should "error if migrating, but not extended RequireSyncReset" in {
-    implicit val options = migrateIR
+
+  describe("(1): Migrating explicit invalidate") {
+    import MigrationExamples.ExplicitInvalidate._
+
+    it("(1.a): error if migrating module input, but not extending ImplicitInvalidate") {
+      intercept[_root_.firrtl.passes.CheckInitialization.RefNotInitializedException] {
+        ChiselStage.emitVerilog(new ChiselChildren.Foo)
+      }
+    }
+    it("(1.b): succeed if migrating module input with extending ImplicitInvalidate") {
+      ChiselStage.emitVerilog(new ChiselChildren.FooWithImplicitInvalidate)
+    }
+
+    it("(1.c): error if migrating instance output, but not extending ImplicitInvalidate") {
+      intercept[_root_.firrtl.passes.CheckInitialization.RefNotInitializedException] {
+        ChiselStage.emitVerilog(new ChiselParents.FooParent)
+      }
+    }
+    it("(1.d): succeed if migrating instance output with extending ImplicitInvalidate") {
+      ChiselStage.emitVerilog(new ChiselParents.FooParentWithImplicitInvalidate)
+    }
+
+    it("(1.e): error if migrating wire declaration, but not extending ImplicitInvalidate") {
+      intercept[_root_.firrtl.passes.CheckInitialization.RefNotInitializedException] {
+        ChiselStage.emitVerilog(new ChiselChildren.FooWire)
+      }
+    }
+    it("(1.f): succeed if migrating wire declaration with extending ImplicitInvalidate") {
+      ChiselStage.emitVerilog(new ChiselChildren.FooWireWithImplicitInvalidate)
+    }
+  }
+}
+
+object MigrationExamples {
+  object InferResets {
+    import Chisel.{defaultCompileOptions => _, _}
+    import chisel3.RequireSyncReset
+    implicit val migrateIR = new chisel3.CompileOptions {
+      val connectFieldsMustMatch = false
+      val declaredTypeMustBeUnbound = false
+      val dontTryConnectionsSwapped = false
+      val dontAssumeDirectionality = false
+      val checkSynthesizable = false
+      val explicitInvalidate = false
+      val inferModuleReset = false
+
+      override val migrateInferModuleReset = true
+    }
+
     class Foo extends Module {
       val io = new Bundle {}
     }
-    intercept[Exception] {
-      ChiselStage.elaborate(new Foo)
-    }
-  }
-  it should "not error if migrating, and you mix with RequireSyncReset" in {
-    implicit val options = migrateIR
-    class Foo extends Module with RequireSyncReset {
+    class FooWithRequireSyncReset extends Module with RequireSyncReset {
       val io = new Bundle {}
     }
-    ChiselStage.elaborate(new Foo)
+  }
+  object ExplicitInvalidate {
+    import chisel3.ImplicitInvalidate
+    val migrateEI = new chisel3.CompileOptions {
+      val connectFieldsMustMatch = false
+      val declaredTypeMustBeUnbound = false
+      val dontTryConnectionsSwapped = false
+      val dontAssumeDirectionality = false
+      val checkSynthesizable = false
+      val explicitInvalidate = true
+      val inferModuleReset = false
+    }
+    object ChiselChildren {
+      import Chisel.{defaultCompileOptions => _, _}
+      implicit val options = migrateEI
+      class Foo extends Module {
+        val io = new Bundle {
+          val out = Output(UInt(width = 3))
+        }
+      }
+      class FooWithImplicitInvalidate extends Module with ImplicitInvalidate {
+        val io = new Bundle {
+          val out = Output(UInt(width = 3))
+        }
+      }
+      class FooWire extends Module {
+        val io = new Bundle {}
+        val wire = Wire(Bool())
+      }
+      class FooWireWithImplicitInvalidate extends Module with ImplicitInvalidate {
+        val io = new Bundle {}
+        val wire = Wire(Bool())
+      }
+    }
+    object chisel3Children {
+      import chisel3._
+      class Foo extends Module {
+        val in = IO(chisel3.Input(UInt(3.W)))
+      }
+    }
+    object ChiselParents {
+      import Chisel.{defaultCompileOptions => _, _}
+      implicit val options = migrateEI
+
+      class FooParent extends Module {
+        val io = new Bundle {}
+        val i = Module(new chisel3Children.Foo)
+      }
+      class FooParentWithImplicitInvalidate extends Module with ImplicitInvalidate {
+        val io = new Bundle {}
+        val i = Module(new chisel3Children.Foo)
+      }
+    }
   }
 }

--- a/src/test/scala/chiselTests/MigrateCompileOptionsSpec.scala
+++ b/src/test/scala/chiselTests/MigrateCompileOptionsSpec.scala
@@ -22,7 +22,6 @@ class MigrateCompileOptionsSpec extends ChiselFunSpec with Utils {
     }
   }
 
-
   describe("(1): Migrating explicit invalidate") {
     import MigrationExamples.ExplicitInvalidate._
 

--- a/src/test/scala/chiselTests/MigrateCompileOptionsSpec.scala
+++ b/src/test/scala/chiselTests/MigrateCompileOptionsSpec.scala
@@ -8,52 +8,6 @@ import chisel3.ExplicitCompileOptions
 
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
-class MigrateCompileOptionsSpec extends ChiselFunSpec with Utils {
-  import Chisel.{defaultCompileOptions => _, _}
-  import chisel3.RequireSyncReset
-
-  describe("(0): Migrating infer resets") {
-    import MigrationExamples.InferResets._
-    it("(0.a): Error if migrating, but not extended RequireSyncReset") {
-      intercept[Exception] { ChiselStage.elaborate(new Foo) }
-    }
-    it("(0.b): Not error if migrating, and you mix with RequireSyncReset") {
-      ChiselStage.elaborate(new FooWithRequireSyncReset)
-    }
-  }
-
-  describe("(1): Migrating explicit invalidate") {
-    import MigrationExamples.ExplicitInvalidate._
-
-    it("(1.a): error if migrating module input, but not extending ImplicitInvalidate") {
-      intercept[_root_.firrtl.passes.CheckInitialization.RefNotInitializedException] {
-        ChiselStage.emitVerilog(new ChiselChildren.Foo)
-      }
-    }
-    it("(1.b): succeed if migrating module input with extending ImplicitInvalidate") {
-      ChiselStage.emitVerilog(new ChiselChildren.FooWithImplicitInvalidate)
-    }
-
-    it("(1.c): error if migrating instance output, but not extending ImplicitInvalidate") {
-      intercept[_root_.firrtl.passes.CheckInitialization.RefNotInitializedException] {
-        ChiselStage.emitVerilog(new ChiselParents.FooParent)
-      }
-    }
-    it("(1.d): succeed if migrating instance output with extending ImplicitInvalidate") {
-      ChiselStage.emitVerilog(new ChiselParents.FooParentWithImplicitInvalidate)
-    }
-
-    it("(1.e): error if migrating wire declaration, but not extending ImplicitInvalidate") {
-      intercept[_root_.firrtl.passes.CheckInitialization.RefNotInitializedException] {
-        ChiselStage.emitVerilog(new ChiselChildren.FooWire)
-      }
-    }
-    it("(1.f): succeed if migrating wire declaration with extending ImplicitInvalidate") {
-      ChiselStage.emitVerilog(new ChiselChildren.FooWireWithImplicitInvalidate)
-    }
-  }
-}
-
 object MigrationExamples {
   object InferResets {
     import Chisel.{defaultCompileOptions => _, _}
@@ -128,6 +82,52 @@ object MigrationExamples {
         val io = new Bundle {}
         val i = Module(new chisel3Children.Foo)
       }
+    }
+  }
+}
+
+class MigrateCompileOptionsSpec extends ChiselFunSpec with Utils {
+  import Chisel.{defaultCompileOptions => _, _}
+  import chisel3.RequireSyncReset
+
+  describe("(0): Migrating infer resets") {
+    import MigrationExamples.InferResets._
+    it("(0.a): Error if migrating, but not extended RequireSyncReset") {
+      intercept[Exception] { ChiselStage.elaborate(new Foo) }
+    }
+    it("(0.b): Not error if migrating, and you mix with RequireSyncReset") {
+      ChiselStage.elaborate(new FooWithRequireSyncReset)
+    }
+  }
+
+  describe("(1): Migrating explicit invalidate") {
+    import MigrationExamples.ExplicitInvalidate._
+
+    it("(1.a): error if migrating module input, but not extending ImplicitInvalidate") {
+      intercept[_root_.firrtl.passes.CheckInitialization.RefNotInitializedException] {
+        ChiselStage.emitVerilog(new ChiselChildren.Foo)
+      }
+    }
+    it("(1.b): succeed if migrating module input with extending ImplicitInvalidate") {
+      ChiselStage.emitVerilog(new ChiselChildren.FooWithImplicitInvalidate)
+    }
+
+    it("(1.c): error if migrating instance output, but not extending ImplicitInvalidate") {
+      intercept[_root_.firrtl.passes.CheckInitialization.RefNotInitializedException] {
+        ChiselStage.emitVerilog(new ChiselParents.FooParent)
+      }
+    }
+    it("(1.d): succeed if migrating instance output with extending ImplicitInvalidate") {
+      ChiselStage.emitVerilog(new ChiselParents.FooParentWithImplicitInvalidate)
+    }
+
+    it("(1.e): error if migrating wire declaration, but not extending ImplicitInvalidate") {
+      intercept[_root_.firrtl.passes.CheckInitialization.RefNotInitializedException] {
+        ChiselStage.emitVerilog(new ChiselChildren.FooWire)
+      }
+    }
+    it("(1.f): succeed if migrating wire declaration with extending ImplicitInvalidate") {
+      ChiselStage.emitVerilog(new ChiselChildren.FooWireWithImplicitInvalidate)
     }
   }
 }


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [N/A] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
 - code cleanup  
<!--   - backend code generation            -->
- new feature/API

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->
Adds a new trait `ImplicitInvalidate`, which when mixed with a Module mimics the behavior when the compiler option has `explicitInvalidate=false`.

The best way to migrate would be to set the compiler option `explicitInvalidate=true`, then for all modules where the FIRRTL compilation errors, add back in the `ImplicitInvalidate` trait.

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
- Squash: The PR will be squashed and merged (choose this if you have no preference
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

Adds a new trait `ImplicitInvalidate`, which when mixed with a Module mimics the behavior when the compiler option has `explicitInvalidate=false`.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
