### PR TITLE
Micro-optimize and memoize BitPat.rawString

### DIFF
--- a/src/main/scala/chisel3/util/BitPat.scala
+++ b/src/main/scala/chisel3/util/BitPat.scala
@@ -421,15 +421,29 @@ sealed class BitPat(val value: BigInt, val mask: BigInt, val width: Int)
   override def isEmpty: Boolean = false
 
   /** Generate raw string of a [[BitPat]]. */
-  def rawString: String = Seq
-    .tabulate(width) { i =>
-      (value.testBit(width - i - 1), mask.testBit(width - i - 1)) match {
-        case (true, true)  => "1"
-        case (false, true) => "0"
-        case (_, false)    => "?"
-      }
+  def rawString: String = _rawString
+
+  // This is micro-optimized and memoized because it is used for lots of BitPat operations
+  private lazy val _rawString: String = {
+    val sb = new StringBuilder(width)
+    var i = 0
+    while (i < width) {
+      val bitIdx = width - i - 1
+      val char =
+        if (mask.testBit(bitIdx)) {
+          if (value.testBit(bitIdx)) {
+            '1'
+          } else {
+            '0'
+          }
+        } else {
+          '?'
+        }
+      sb += char
+      i += 1
     }
-    .mkString
+    sb.result()
+  }
 
   override def toString = s"BitPat($rawString)"
 }


### PR DESCRIPTION
BitPat.rawString is called a lot when decoding and is used for certain
BitPat operations. We should use it less but this is at least a bandaid.

@sequencer, have you noticed issues with this?

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement


 - performance improvement


#### API Impact

No impact, this should be source and binary compatible

#### Backend Code Generation Impact

None

#### Desired Merge Strategy

Squash

#### Release Notes

Micro-optimize and memoize BitPat.rawString to speed up decoding APIs

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
