### PR TITLE
Define leading '_' as API for creating temporaries

### DIFF
--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -362,7 +362,7 @@ package experimental {
 
     private[chisel3] def namePorts(): Unit = {
       for (port <- getModulePorts) {
-        port._computeName(None, None) match {
+        port._computeName(None) match {
           case Some(name) =>
             if (_namespace.contains(name)) {
               Builder.error(

--- a/core/src/main/scala/chisel3/RawModule.scala
+++ b/core/src/main/scala/chisel3/RawModule.scala
@@ -55,26 +55,26 @@ abstract class RawModule(implicit moduleCompileOptions: CompileOptions) extends 
       id match {
         case id: ModuleClone[_]   => id.setRefAndPortsRef(_namespace) // special handling
         case id: InstanceClone[_] => id.setAsInstanceRef()
-        case id: BaseModule       => id.forceName(None, default = id.desiredName, _namespace)
-        case id: MemBase[_]       => id.forceName(None, default = "MEM", _namespace)
-        case id: stop.Stop        => id.forceName(None, default = "stop", _namespace)
-        case id: assert.Assert    => id.forceName(None, default = "assert", _namespace)
-        case id: assume.Assume    => id.forceName(None, default = "assume", _namespace)
-        case id: cover.Cover      => id.forceName(None, default = "cover", _namespace)
-        case id: printf.Printf => id.forceName(None, default = "printf", _namespace)
+        case id: BaseModule       => id.forceName(default = id.desiredName, _namespace)
+        case id: MemBase[_]       => id.forceName(default = "MEM", _namespace)
+        case id: stop.Stop        => id.forceName(default = "stop", _namespace)
+        case id: assert.Assert    => id.forceName(default = "assert", _namespace)
+        case id: assume.Assume    => id.forceName(default = "assume", _namespace)
+        case id: cover.Cover      => id.forceName(default = "cover", _namespace)
+        case id: printf.Printf => id.forceName(default = "printf", _namespace)
         case id: Data =>
           if (id.isSynthesizable) {
             id.topBinding match {
               case OpBinding(_, _) =>
-                id.forceName(None, default = "_T", _namespace)
+                id.forceName(default = "_T", _namespace)
               case MemoryPortBinding(_, _) =>
-                id.forceName(None, default = "MPORT", _namespace)
+                id.forceName(default = "MPORT", _namespace)
               case PortBinding(_) =>
-                id.forceName(None, default = "PORT", _namespace)
+                id.forceName(default = "PORT", _namespace)
               case RegBinding(_, _) =>
-                id.forceName(None, default = "REG", _namespace)
+                id.forceName(default = "REG", _namespace)
               case WireBinding(_, _) =>
-                id.forceName(None, default = "_WIRE", _namespace)
+                id.forceName(default = "_WIRE", _namespace)
               case _ => // don't name literals
             }
           } // else, don't name unbound types

--- a/core/src/main/scala/chisel3/experimental/dataview/package.scala
+++ b/core/src/main/scala/chisel3/experimental/dataview/package.scala
@@ -33,7 +33,7 @@ package object dataview {
       // The names of views do not matter except for when a view is annotated. For Views that correspond
       // To a single Data, we just forward the name of the Target. For Views that correspond to more
       // than one Data, we return this assigned name but rename it in the Convert stage
-      result.forceName(None, "view", Builder.viewNamespace)
+      result.forceName("view", Builder.viewNamespace)
       result
     }
   }

--- a/core/src/main/scala/chisel3/experimental/hierarchy/ModuleClone.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/ModuleClone.scala
@@ -48,7 +48,7 @@ private[chisel3] class ModuleClone[T <: BaseModule](val getProto: T) extends Pse
   private[chisel3] def setRefAndPortsRef(namespace: Namespace): Unit = {
     val record = _portsRecord
     // Use .forceName to re-use default name resolving behavior
-    record.forceName(None, default = this.desiredName, namespace)
+    record.forceName(default = this.desiredName, namespace)
     // Now take the Ref that forceName set and convert it to the correct Arg
     val instName = record.getRef match {
       case Ref(name) => name

--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/Lookupable.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/Lookupable.scala
@@ -218,7 +218,7 @@ object Lookupable {
 
     result.bind(newBinding)
     result.setAllParents(Some(ViewParent))
-    result.forceName(None, "view", Builder.viewNamespace)
+    result.forceName("view", Builder.viewNamespace)
     result
   }
 

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -186,7 +186,7 @@ private[chisel3] trait HasId extends InstanceId {
     } else {
       defaultSeed.map { default =>
         defaultPrefix match {
-          case Some(p) => buildName(default, p :: naming_prefix.reverse)
+          case Some(p) => buildName(default, naming_prefix.reverse)
           case None    => buildName(default, naming_prefix.reverse)
         }
       }
@@ -474,7 +474,11 @@ private[chisel3] object Builder extends LazyLogging {
       }
     }
     buildAggName(d).map { name =>
-      pushPrefix(name)
+      if (isTemp(name)) {
+        pushPrefix(name.tail)
+      } else {
+        pushPrefix(name)
+      }
     }.isDefined
   }
 

--- a/core/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -94,7 +94,7 @@ object Arg {
     case Some(arg)                           => arg.name
     case None =>
       id match {
-        case data: Data => data._computeName(None, Some("?")).get
+        case data: Data => data._computeName(Some("?")).get
         case _ => "?"
       }
   }

--- a/plugin/src/main/scala/chisel3/internal/plugin/ChiselComponent.scala
+++ b/plugin/src/main/scala/chisel3/internal/plugin/ChiselComponent.scala
@@ -181,8 +181,11 @@ class ChiselComponent(val global: Global, arguments: ChiselPluginArguments)
         // If a Data or a Memory, get the name and a prefix
         else if (shouldMatchNamedComp(tpe)) {
           val str = stringFromTermName(name)
+          // Starting with '_' signifies a temporary, we ignore it for prefixing because we don't
+          // want double "__" in names when the user is just specifying a temporary
+          val prefix = if (str.head == '_') str.tail else str
           val newRHS = transform(rhs)
-          val prefixed = q"chisel3.experimental.prefix.apply[$tpt](name=$str)(f=$newRHS)"
+          val prefixed = q"chisel3.experimental.prefix.apply[$tpt](name=$prefix)(f=$newRHS)"
           val named = q"chisel3.internal.plugin.autoNameRecursively($str)($prefixed)"
           treeCopy.ValDef(dd, mods, name, tpt, localTyper.typed(named))
           // If an instance, just get a name but no prefix

--- a/src/test/scala/chiselTests/naming/NamePluginSpec.scala
+++ b/src/test/scala/chiselTests/naming/NamePluginSpec.scala
@@ -340,4 +340,23 @@ class NamePluginSpec extends ChiselFlatSpec with Utils {
       Select.wires(top).map(_.instanceName) should be(List("a_b_c", "a_b", "a"))
     }
   }
+
+  behavior.of("Unnamed values (aka \"Temporaries\")")
+
+  they should "be declared by starting the name with '_'" in {
+    class Test extends Module {
+      {
+        val a = {
+          val b = {
+            val _c = Wire(UInt(3.W))
+            4.U // literal so there is no name
+          }
+          b
+        }
+      }
+    }
+    aspectTest(() => new Test) { top: Test =>
+      Select.wires(top).map(_.instanceName) should be(List("_a_b_c"))
+    }
+  }
 }


### PR DESCRIPTION
Note, I've rendered the updated docs [here](https://gist.github.com/jackkoenig/5777f77ba7c1a66c574d6f566bc31724).

Chisel and FIRRTL have long used signals with names beginning with an
underscore as an API to specify that the name does not really matter.
Tools like Verilator follow a similar convention and exclude signals
with underscore names from waveform dumps by default. With the
introduction of compiler-plugin prefixing in Chisel 3.4, the convention
remained but was hard for users to use unless the unnnamed signal
existed outside of any prefix domain. Notably, unnamed signals are most
useful when creating wires inside of utility methods which almost always
results in the signal ending up with a prefix.

With this commit, Chisel explicitly recognizes signals whos val names
start with an underscore and preserve that underscore regardless of any
prefixing. Chisel will also ignore such underscores when generating
prefixes based on the temporary signal, preventing accidental double
underscores in the names of signals that are prefixed by the temporary.

Here's a specific example of the change this makes, Given:
```scala
class Example extends Module {
  val foo, bar = IO(Input(UInt(8.W)))
  val out = {
    val port = IO(Output(UInt(8.W)))
    val _sum = foo + bar
    val _sum2 = Wire(UInt(8.W))
    _sum2 := foo + 1.U
    port := _sum + _sum2
    port
  }
}
```
Chisel master (and 3.4.3) currently compile this to:
```
module Example :
  input clock : Clock
  input reset : UInt<1>
  input foo : UInt<8>
  input bar : UInt<8>
  output out : UInt<8>

  node _out__sum_T = add(foo, bar)
  node out__sum = tail(_out__sum_T, 1)
  wire out__sum2 : UInt<8>
  node _out__sum2_T = add(foo, UInt<1>("h1"))
  node _out__sum2_T_1 = tail(_out__sum2_T, 1)
  out__sum2 <= _out__sum2_T_1
  node _out_port_T = add(out__sum, out__sum2)
  node _out_port_T_1 = tail(_out_port_T, 1)
  out <= _out_port_T_1
```

Now this is compiled to:
```
  module Example :
    input clock : Clock
    input reset : UInt<1>
    input foo : UInt<8>
    input bar : UInt<8>
    output out : UInt<8>

    node _out_sum_T = add(foo, bar)
    node _out_sum = tail(_out_sum_T, 1)
    wire _out_sum2 : UInt<8>
    node _out_sum2_T = add(foo, UInt<1>("h1"))
    node _out_sum2_T_1 = tail(_out_sum2_T, 1)
    _out_sum2 <= _out_sum2_T_1
    node _out_port_T = add(_out_sum, _out_sum2)
    node _out_port_T_1 = tail(_out_port_T, 1)
    out <= _out_port_T_1 
```

Note that `out__sum` and `out__sum2` become `_out_sum` and `_out_sum2`. This change comes from Chisel effectively recognizing the leading `_` is not actually part of the name, but is the signifier of a temporary so it is stripped from the "seed" and moved to the front of the final name.

Also note that `_out__sum2_T` becomes `_out_sum2_T`. This functionality looks similar to the previous paragraph, but is actually a totally different change where Chisel, again recognizing that `_` is the signifier of a temporary and not really part of the name, actually ignores the leading `_` for generating prefixes from signals.

Between these two changes, I think the naming behavior is a pretty nice improvement over the current behavior.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

 - new feature/API    

#### API Impact

This adds a new API to let users creating "temporary" signals. I will note that this might have a s

#### Backend Code Generation Impact

This could potentially rejigger a lot of names. On the one hand, I see this as a bug fix (and thus backportable) because I think the prior behavior of ignoring users defining signals with leading `_` as sort of a bug. On the other hand, this has the potential to cause a big change in naming when bumping and users may not appreciate that on a minor release.

#### Desired Merge Strategy

  - Squash

#### Release Notes

Define leading '_' as API for creating temporaries. Chisel will now preserve the leading `_` for any val-named signal which signifies to FIRRTL and other backend tools that the name does not matter. Chisel also now ignores the leading `_` in prefixes generated from such "unnamed signals" which reduces the number of cases of double `__` in the middle of signal names.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
