### PR TITLE
[docs] Document partial register reset

### DIFF
--- a/docs/src/appendix/experimental-features.md
+++ b/docs/src/appendix/experimental-features.md
@@ -10,6 +10,7 @@ Chisel has a number of new features that are worth checking out.  This page is a
 - [FixedPoint](#fixed-point)
 - [Module Variants](#module-variants)
 - [Bundle Literals](#bundle-literals)
+- [Vec Literals](#vec-literals)
 - [Interval Type](#interval-type)
 - [Loading Memories for simulation or FPGA initialization](#loading-memories)
 
@@ -52,7 +53,10 @@ class Example extends RawModule {
 chisel3.stage.ChiselStage.emitVerilog(new Example)
 ```
 
-Partial specification is allowed, defaulting any unconnected fields to 0 (regardless of type).
+Partial specification is allowed, which results in "invalidated fields" as
+described in [Unconnected Wires](../explanations/unconnected-wires).
+Note that this can be used with `RegInit` to construct partially reset registers as
+described in the [Cookbook](../cookbooks/cookbook#how-do-i-partially-reset-an-aggregate-reg).
 
 ```scala mdoc
 class Example2 extends RawModule {
@@ -122,9 +126,10 @@ chisel3.stage.ChiselStage.emitVerilog(new VecExample1a)
 ```
 
 The following examples all use the explicit form.
-With the explicit form partial specification is allowed.
-When used with as a `Reg` `reset` value, only specified indices of the `Reg`'s `Vec`
-will be reset
+With the explicit form partial specification is allowed, which results in
+"invalidated fields" as described in [Unconnected Wires](../explanations/unconnected-wires).
+Note that this can be used with `RegInit` to construct partially reset registers as
+described in the [Cookbook](../cookbooks/cookbook#how-do-i-partially-reset-an-aggregate-reg).
 
 ```scala mdoc
 class VecExample2 extends RawModule {


### PR DESCRIPTION
### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

- documentation    

#### API Impact

No impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

- Squash

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
