### PR TITLE
Handle varargs constructor arguments in Bundle plugin

### DIFF
--- a/plugin/src/main/scala/chisel3/internal/plugin/BundleComponent.scala
+++ b/plugin/src/main/scala/chisel3/internal/plugin/BundleComponent.scala
@@ -84,6 +84,8 @@ private[plugin] class BundleComponent(val global: Global, arguments: ChiselPlugi
     def isNullaryMethodNamed(name: String, defdef: DefDef): Boolean =
       defdef.name.decodedName.toString == name && defdef.tparams.isEmpty && defdef.vparamss.isEmpty
 
+    def isVarArgs(sym: Symbol): Boolean = definitions.isRepeatedParamType(sym.tpe)
+
     def getConstructorAndParams(body: List[Tree]): (Option[DefDef], Seq[Symbol]) = {
       val paramAccessors = mutable.ListBuffer[Symbol]()
       var primaryConstructor: Option[DefDef] = None
@@ -134,7 +136,9 @@ private[plugin] class BundleComponent(val global: Global, arguments: ChiselPlugi
               // Make this.<ref>
               val select = gen.mkAttributedSelect(thiz.asInstanceOf[Tree], p)
               // Clone any Data parameters to avoid field aliasing, need full clone to include direction
-              if (isData(vp.symbol)) cloneTypeFull(select.asInstanceOf[Tree]) else select
+              val cloned = if (isData(vp.symbol)) cloneTypeFull(select.asInstanceOf[Tree]) else select
+              // Need to splat varargs
+              if (isVarArgs(vp.symbol)) q"$cloned: _*" else cloned
             })
 
           val tparamList = bundle.tparams.map { t => Ident(t.symbol) }

--- a/src/test/scala/chiselTests/AutoClonetypeSpec.scala
+++ b/src/test/scala/chiselTests/AutoClonetypeSpec.scala
@@ -381,4 +381,23 @@ class AutoClonetypeSpec extends ChiselFlatSpec with Utils {
     }
     elaborate(new MyModule)
   }
+
+  it should "support Bundles with vararg arguments" in {
+    // Without the fix, this doesn't even compile
+    // Extra parameter lists to make this a complex test case
+    class VarArgsBundle(x: Int)(y: Int, widths: Int*) extends Bundle {
+      def mkField(idx: Int): Option[UInt] =
+        (x +: y +: widths).lift(idx).map(w => UInt(w.W))
+      val foo = mkField(0)
+      val bar = mkField(1)
+      val fizz = mkField(2)
+      val buzz = mkField(3)
+    }
+    class MyModule extends Module {
+      val in = IO(Input(new VarArgsBundle(1)(2, 3, 4)))
+      val out = IO(Output(new VarArgsBundle(1)(2, 3, 4)))
+      out := in
+    }
+    elaborate(new MyModule)
+  }
 }


### PR DESCRIPTION
Previously, the plugin would crash with a useless internal error.

Fixes #2584

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

   - bug fix 

#### API Impact

Just a bug fix, no real impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

 - Squash

#### Release Notes

Fix compiler plugin crash on varargs arguments to Bundle constructors.

### Reviewer Checklist (only modified by reviewer)
- [x] Did you add the appropriate labels?
- [x] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
