### PR TITLE
Pass optional name in ImportDefinitionAnno used during Separate elaboration of definition and instance 

### DIFF
--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/Definition.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/Definition.scala
@@ -120,6 +120,6 @@ object Definition extends SourceInfoDoc {
   * compiled separately.
   */
 case class ImportDefinitionAnnotation[T <: BaseModule with IsInstantiable](
-  definition: Definition[T],
-  name:       Option[String] = None)
+  definition:      Definition[T],
+  overrideDefName: Option[String] = None)
     extends NoTargetAnnotation

--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/Definition.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/Definition.scala
@@ -119,5 +119,5 @@ object Definition extends SourceInfoDoc {
 /** Stores a [[Definition]] that is imported so that its Instances can be
   * compiled separately.
   */
-case class ImportDefinitionAnnotation[T <: BaseModule with IsInstantiable](definition: Definition[T])
+case class ImportDefinitionAnnotation[T <: BaseModule with IsInstantiable](definition: Definition[T], name : Option[String] = None)
     extends NoTargetAnnotation

--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/Definition.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/Definition.scala
@@ -119,5 +119,7 @@ object Definition extends SourceInfoDoc {
 /** Stores a [[Definition]] that is imported so that its Instances can be
   * compiled separately.
   */
-case class ImportDefinitionAnnotation[T <: BaseModule with IsInstantiable](definition: Definition[T], name : Option[String] = None)
+case class ImportDefinitionAnnotation[T <: BaseModule with IsInstantiable](
+  definition: Definition[T],
+  name:       Option[String] = None)
     extends NoTargetAnnotation

--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/Instance.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/Instance.scala
@@ -119,7 +119,12 @@ object Instance extends SourceInfoDoc {
     if (existingMod.isEmpty) {
       // Add a Definition that will get emitted as an ExtModule so that FIRRTL
       // does not complain about a missing element
-      val extModName = Builder.importDefinitionMap.getOrElse(definition.proto.name,throwException("Imported Definition information not found - possibly forgot to add ImportDefinition annotation?"))
+      val extModName = Builder.importDefinitionMap.getOrElse(
+        definition.proto.name,
+        throwException(
+          "Imported Definition information not found - possibly forgot to add ImportDefinition annotation?"
+        )
+      )
       class EmptyExtModule extends ExtModule {
         override def desiredName: String = extModName
         override def generateComponent(): Option[Component] = {

--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/Instance.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/Instance.scala
@@ -10,6 +10,7 @@ import chisel3.internal.sourceinfo.{InstanceTransform, SourceInfo}
 import chisel3.experimental.{BaseModule, ExtModule}
 import chisel3.internal.firrtl.{Component, DefBlackBox, DefModule, Port}
 import firrtl.annotations.IsModule
+import chisel3.internal.throwException
 
 /** User-facing Instance type.
   * Represents a unique instance of type [[A]] which are marked as @instantiable
@@ -118,8 +119,9 @@ object Instance extends SourceInfoDoc {
     if (existingMod.isEmpty) {
       // Add a Definition that will get emitted as an ExtModule so that FIRRTL
       // does not complain about a missing element
+      val extModName = Builder.importDefinitionMap.getOrElse(definition.proto.name,throwException("Imported Definition information not found - possibly forgot to add ImportDefinition annotation?"))
       class EmptyExtModule extends ExtModule {
-        override def desiredName: String = definition.proto.name
+        override def desiredName: String = extModName
         override def generateComponent(): Option[Component] = {
           require(!_closed, s"Can't generate $desiredName module more than once")
           _closed = true

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -344,7 +344,7 @@ private[chisel3] class DynamicContext(
   // Ensure there are no repeated names for imported Definitions - both Proto Names as well as ExtMod Names
   val importAllDefinitionProtoNames = importDefinitionAnnos.map { a => a.definition.proto.name }
   val importDistinctDefinitionProtoNames = importDefinitionMap.keys.toSeq
-  val importAllDefinitionExtModNames = importDefinitionMap.values.toSeq
+  val importAllDefinitionExtModNames = importDefinitionMap.toSeq.map(_._2)
   val importDistinctDefinitionExtModNames = importAllDefinitionExtModNames.distinct
 
   if (importDistinctDefinitionProtoNames.length < importAllDefinitionProtoNames.length) {
@@ -353,7 +353,7 @@ private[chisel3] class DynamicContext(
   }
   if (importDistinctDefinitionExtModNames.length < importAllDefinitionExtModNames.length) {
     val duplicates = importAllDefinitionExtModNames.diff(importDistinctDefinitionExtModNames).mkString(", ")
-    throwException(s"Expected distinct imported Definition names but found duplicates for: $duplicates")
+    throwException(s"Expected distinct overrideDef names but found duplicates for: $duplicates")
   }
 
   val globalNamespace = Namespace.empty

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -338,7 +338,7 @@ private[chisel3] class DynamicContext(
   // Map holding the actual names of extModules
   // Pick the definition name by default in case not passed through annotation.
   val importDefinitionMap = importDefinitionAnnos
-    .map(a => ((a.definition.proto.name, a.overrideDefName.getOrElse(a.definition.proto.name))))
+    .map(a => a.definition.proto.name -> a.overrideDefName.getOrElse(a.definition.proto.name))
     .toMap
 
   // Helper function which does 2 things

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -362,6 +362,9 @@ private[chisel3] class DynamicContext(
   // Ensure imported Definitions emit as ExtModules with the correct name so
   // that instantiations will also use the correct name and prevent any name
   // conflicts with Modules/Definitions in this elaboration
+  importAllDefinitionProtoNames.foreach { importDefName =>
+    globalNamespace.name(importDefName)
+  }
   importAllDefinitionExtModNames.foreach { importDefName =>
     globalNamespace.name(importDefName)
   }

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -336,18 +336,20 @@ private[chisel3] class DynamicContext(
   val throwOnFirstError: Boolean) {
   val importDefinitionAnnos = annotationSeq.collect { case a: ImportDefinitionAnnotation[_] => a }
 
-  // Map holding the actual names of extModules 
-  val importDefinitionMap : mutable.Map[String,String] = mutable.Map.empty
+  // Map holding the actual names of extModules
+  val importDefinitionMap: mutable.Map[String, String] = mutable.Map.empty
 
-  // Pick the definition name by default in case not passed through annotation. 
-  importDefinitionAnnos.foreach {a => importDefinitionMap += ((a.definition.proto.name,a.name.getOrElse(a.definition.proto.name)))}
-  
+  // Pick the definition name by default in case not passed through annotation.
+  importDefinitionAnnos.foreach { a =>
+    importDefinitionMap += ((a.definition.proto.name, a.name.getOrElse(a.definition.proto.name)))
+  }
+
   // Ensure there are no repeated names for imported Definitions - both Proto Names as well as ExtMod Names
-  val importAllDefinitionProtoNames = importDefinitionAnnos.map {a => a.definition.proto.name}
+  val importAllDefinitionProtoNames = importDefinitionAnnos.map { a => a.definition.proto.name }
   val importDistinctDefinitionProtoNames = importDefinitionMap.keys.toSeq
   val importAllDefinitionExtModNames = importDefinitionMap.values.toSeq
   val importDistinctDefinitionExtModNames = importAllDefinitionExtModNames.distinct
-  
+
   if (importDistinctDefinitionProtoNames.length < importAllDefinitionProtoNames.length) {
     val duplicates = importAllDefinitionProtoNames.diff(importDistinctDefinitionProtoNames).mkString(", ")
     throwException(s"Expected distinct imported Definition names but found duplicates for: $duplicates")
@@ -362,14 +364,15 @@ private[chisel3] class DynamicContext(
   // Ensure imported Definitions emit as ExtModules with the correct name so
   // that instantiations will also use the correct name and prevent any name
   // conflicts with Modules/Definitions in this elaboration
-  
-  importAllDefinitionProtoNames.zip(importAllDefinitionExtModNames).foreach { case ((protoName,extModName)) =>
-    globalNamespace.name(protoName)
 
-    // Only add the extModName to Namespace if it is different from definition proto name
-    if(protoName != extModName) {
-      globalNamespace.name(extModName)
-    }
+  importAllDefinitionProtoNames.zip(importAllDefinitionExtModNames).foreach {
+    case ((protoName, extModName)) =>
+      globalNamespace.name(protoName)
+
+      // Only add the extModName to Namespace if it is different from definition proto name
+      if (protoName != extModName) {
+        globalNamespace.name(extModName)
+      }
   }
 
   val components = ArrayBuffer[Component]()
@@ -436,12 +439,12 @@ private[chisel3] object Builder extends LazyLogging {
 
   def idGen: IdGen = chiselContext.get.idGen
 
-  def globalNamespace: Namespace = dynamicContext.globalNamespace
-  def components:      ArrayBuffer[Component] = dynamicContext.components
-  def annotations:     ArrayBuffer[ChiselAnnotation] = dynamicContext.annotations
-  def annotationSeq:   AnnotationSeq = dynamicContext.annotationSeq
-  def namingStack:     NamingStack = dynamicContext.namingStack
-  def importDefinitionMap: mutable.Map[String,String] = dynamicContext.importDefinitionMap
+  def globalNamespace:     Namespace = dynamicContext.globalNamespace
+  def components:          ArrayBuffer[Component] = dynamicContext.components
+  def annotations:         ArrayBuffer[ChiselAnnotation] = dynamicContext.annotations
+  def annotationSeq:       AnnotationSeq = dynamicContext.annotationSeq
+  def namingStack:         NamingStack = dynamicContext.namingStack
+  def importDefinitionMap: mutable.Map[String, String] = dynamicContext.importDefinitionMap
 
   def unnamedViews:  ArrayBuffer[Data] = dynamicContext.unnamedViews
   def viewNamespace: Namespace = chiselContext.get.viewNamespace

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -362,11 +362,14 @@ private[chisel3] class DynamicContext(
   // Ensure imported Definitions emit as ExtModules with the correct name so
   // that instantiations will also use the correct name and prevent any name
   // conflicts with Modules/Definitions in this elaboration
-  importAllDefinitionProtoNames.foreach { importDefName =>
-    globalNamespace.name(importDefName)
-  }
-  importAllDefinitionExtModNames.foreach { importDefName =>
-    globalNamespace.name(importDefName)
+  
+  importAllDefinitionProtoNames.zip(importAllDefinitionExtModNames).foreach { case ((protoName,extModName)) =>
+    globalNamespace.name(protoName)
+
+    // Only add the extModName to Namespace if it is different from definition proto name
+    if(protoName != extModName) {
+      globalNamespace.name(extModName)
+    }
   }
 
   val components = ArrayBuffer[Component]()

--- a/src/test/scala/chiselTests/experimental/hierarchy/SeparateElaborationSpec.scala
+++ b/src/test/scala/chiselTests/experimental/hierarchy/SeparateElaborationSpec.scala
@@ -354,7 +354,7 @@ class SeparateElaborationSpec extends ChiselFunSpec with Utils {
       "Expected distinct imported Definition names but found duplicates for: AddOne"
     )
   }
-  
+
   describe("(4): With ExtMod Names") {
     it("should pick correct ExtMod names when passed") {
       val testDir = createTestDirectory(this.getClass.getSimpleName).toString
@@ -375,12 +375,12 @@ class SeparateElaborationSpec extends ChiselFunSpec with Utils {
         Seq(
           ChiselGeneratorAnnotation(() => new Testbench(dutDef)),
           TargetDirAnnotation(testDir),
-          ImportDefinitionAnnotation(dutDef,Some("CustomPrefix_AddOne_CustomSuffix"))
+          ImportDefinitionAnnotation(dutDef, Some("CustomPrefix_AddOne_CustomSuffix"))
         )
       )
 
       val tb_rtl = Source.fromFile(s"$testDir/Testbench.v").getLines.mkString
-      
+
       tb_rtl should include("module AddOne_1(")
       tb_rtl should include("AddOne_1 mod (")
       (tb_rtl should not).include("module AddOne(")

--- a/src/test/scala/chiselTests/experimental/hierarchy/SeparateElaborationSpec.scala
+++ b/src/test/scala/chiselTests/experimental/hierarchy/SeparateElaborationSpec.scala
@@ -356,7 +356,7 @@ class SeparateElaborationSpec extends ChiselFunSpec with Utils {
   }
 
   describe("(4): With ExtMod Names") {
-    it("should pick correct ExtMod names when passed") {
+    it("(4.a): should pick correct ExtMod names when passed") {
       val testDir = createTestDirectory(this.getClass.getSimpleName).toString
 
       val dutDef = getAddOneDefinition(testDir)
@@ -387,4 +387,57 @@ class SeparateElaborationSpec extends ChiselFunSpec with Utils {
       tb_rtl should include("CustomPrefix_AddOne_CustomSuffix inst (")
     }
   }
+
+  it(
+      "(4.b): should work if a list of imported Definitions is passed between Stages with ExtModName."
+    ) {
+      val testDir = createTestDirectory(this.getClass.getSimpleName).toString
+
+      val dutAnnos0 = (new ChiselStage).run(
+        Seq(
+          ChiselGeneratorAnnotation(() => new AddOneParameterized(4)),
+          TargetDirAnnotation(s"$testDir/dutDef0")
+        )
+      )
+      val dutDef0 = getDesignAnnotation(dutAnnos0).design.asInstanceOf[AddOneParameterized].toDefinition
+
+      val dutAnnos1 = (new ChiselStage).run(
+        Seq(
+          ChiselGeneratorAnnotation(() => new AddOneParameterized(8)),
+          TargetDirAnnotation(s"$testDir/dutDef1"),
+          // pass in previously elaborated Definitions
+          ImportDefinitionAnnotation(dutDef0)
+        )
+      )
+      val dutDef1 = getDesignAnnotation(dutAnnos1).design.asInstanceOf[AddOneParameterized].toDefinition
+
+      class Testbench(defn0: Definition[AddOneParameterized], defn1: Definition[AddOneParameterized]) extends Module {
+        val inst0 = Instance(defn0)
+        val inst1 = Instance(defn1)
+
+        // Tie inputs to a value so ChiselStage does not complain
+        inst0.in := 0.U
+        inst1.in := 0.U
+      }
+
+      (new ChiselStage).run(
+        Seq(
+          ChiselGeneratorAnnotation(() => new Testbench(dutDef0, dutDef1)),
+          TargetDirAnnotation(testDir),
+          ImportDefinitionAnnotation(dutDef0,Some("Inst1_Prefix_AddOnePramaterized_Inst1_Suffix")),
+          ImportDefinitionAnnotation(dutDef1,Some("Inst2_Prefix_AddOnePrameterized_1_Inst2_Suffix"))
+        )
+      )
+
+      val dutDef0_rtl = Source.fromFile(s"$testDir/dutDef0/AddOneParameterized.v").getLines.mkString
+      dutDef0_rtl should include("module AddOneParameterized(")
+      val dutDef1_rtl = Source.fromFile(s"$testDir/dutDef1/AddOneParameterized_1.v").getLines.mkString
+      dutDef1_rtl should include("module AddOneParameterized_1(")
+
+      val tb_rtl = Source.fromFile(s"$testDir/Testbench.v").getLines.mkString
+      tb_rtl should include("Inst1_Prefix_AddOnePramaterized_Inst1_Suffix inst0 (")
+      tb_rtl should include("Inst2_Prefix_AddOnePrameterized_1_Inst2_Suffix inst1 (")
+      (tb_rtl should not).include("module AddOneParameterized(")
+      (tb_rtl should not).include("module AddOneParameterized_1(")
+    }
 }


### PR DESCRIPTION
### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [ ] Did you specify the code generation impact?
- [ ] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement
- code refactoring
- new API 
<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->
- No impact - since the default value of this option is None - and the previous behavior should hold 

#### Backend Code Generation Impact
- Change is relative to the override name given for the external definition. Previously it used to pick only `definition.proto.name` - now it can hold a different value provided by the user. 
<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

#### Technical Debt
- Ideally the original issue of getting actual names of the external components in the final circuit can / should be solved more cleanly by making Prefixing a first class support within Chisel and/or having the concept of Namespaces within Firrtl. 

#### Desired Merge Strategy
Squash 
<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
