### PR TITLE
Avoid making unnecessary clones during binding

### DIFF
--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -1304,7 +1304,7 @@ abstract class Bundle(implicit compileOptions: CompileOptions) extends Record {
     }
   }
 
-  lazy val hasExternalRef: Boolean = this.elements.exists(_._2._id < _id)
+  private[chisel3] lazy val hasExternalRef: Boolean = this.elements.exists(_._2._id < _id)
 
   override def cloneType: this.type = {
     val clone = _cloneTypeImpl.asInstanceOf[this.type]

--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -1304,16 +1304,7 @@ abstract class Bundle(implicit compileOptions: CompileOptions) extends Record {
     }
   }
 
-  private case class memoVal[T](var value: Option[T], val fn: () => T) {
-    def get(): T = {
-      if (value.isEmpty) {
-        value = Some(fn())
-      }
-      value.get
-    }
-  }
-  private var externalRef = memoVal[Boolean](None, () => elements.exists(_._2._id < _id))
-  private[chisel3] def hasExternalRef(): Boolean = externalRef.get()
+  lazy val hasExternalRef: Boolean = this.elements.exists(_._2._id < _id)
 
   override def cloneType: this.type = {
     val clone = _cloneTypeImpl.asInstanceOf[this.type]

--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -1302,8 +1302,18 @@ abstract class Bundle(implicit compileOptions: CompileOptions) extends Record {
         )
       }
     }
-
   }
+
+  private case class memoVal[T](var value: Option[T], val fn: () => T) {
+    def get(): T = {
+      if (value.isEmpty) {
+        value = Some(fn())
+      }
+      value.get
+    }
+  }
+  private var externalRef = memoVal[Boolean](None, () => elements.exists(_._2._id < _id))
+  private[chisel3] def hasExternalRef(): Boolean = externalRef.get()
 
   override def cloneType: this.type = {
     val clone = _cloneTypeImpl.asInstanceOf[this.type]

--- a/core/src/main/scala/chisel3/Data.scala
+++ b/core/src/main/scala/chisel3/Data.scala
@@ -55,16 +55,18 @@ object SpecifiedDirection {
     }
 
   private[chisel3] def specifiedDirection[T <: Data](
-    source: T
-  )(dir:    SpecifiedDirection
+    source: => T
+  )(dir:    T => SpecifiedDirection
   )(
     implicit compileOptions: CompileOptions
   ): T = {
+    val prevId = Builder.idGen.value
+    val data = source // evaluate source once (passed by name)
     if (compileOptions.checkSynthesizable) {
-      requireIsChiselType(source)
+      requireIsChiselType(data)
     }
-    val out = source.cloneType.asInstanceOf[T]
-    out.specifiedDirection = dir
+    val out = if (!data.mustClone(prevId)) data else data.cloneType.asInstanceOf[T]
+    out.specifiedDirection = dir(out)
     out
   }
 
@@ -427,19 +429,19 @@ object chiselTypeOf {
   * Thus, an error will be thrown if these are used on bound Data
   */
 object Input {
-  def apply[T <: Data](source: T)(implicit compileOptions: CompileOptions): T = {
-    SpecifiedDirection.specifiedDirection(source)(SpecifiedDirection.Input)
+  def apply[T <: Data](source: => T)(implicit compileOptions: CompileOptions): T = {
+    SpecifiedDirection.specifiedDirection(source)(_ => SpecifiedDirection.Input)
   }
 }
 object Output {
-  def apply[T <: Data](source: T)(implicit compileOptions: CompileOptions): T = {
-    SpecifiedDirection.specifiedDirection(source)(SpecifiedDirection.Output)
+  def apply[T <: Data](source: => T)(implicit compileOptions: CompileOptions): T = {
+    SpecifiedDirection.specifiedDirection(source)(_ => SpecifiedDirection.Output)
   }
 }
 
 object Flipped {
-  def apply[T <: Data](source: T)(implicit compileOptions: CompileOptions): T = {
-    SpecifiedDirection.specifiedDirection(source)(SpecifiedDirection.flip(source.specifiedDirection))
+  def apply[T <: Data](source: => T)(implicit compileOptions: CompileOptions): T = {
+    SpecifiedDirection.specifiedDirection(source)(x => SpecifiedDirection.flip(x.specifiedDirection))
   }
 }
 
@@ -462,6 +464,19 @@ abstract class Data extends HasId with NamedComponent with SourceInfoDoc {
     }
   }
 
+  // must clone a data if
+  // * it has a binding
+  // * its id is older than prevId (not "freshly created")
+  // * it is a bundle with a non-fresh member (external reference)
+  private[chisel3] def mustClone(prevId: Long): Boolean = {
+    if (this.hasBinding || this._id <= prevId) true
+    else
+      this match {
+        case b: Bundle => b.hasExternalRef()
+        case _ => false
+      }
+  }
+
   override def autoSeed(name: String): this.type = {
     topBindingOpt match {
       // Ports are special in that the autoSeed will keep the first name, not the last name
@@ -475,13 +490,6 @@ abstract class Data extends HasId with NamedComponent with SourceInfoDoc {
   private var _specifiedDirection:         SpecifiedDirection = SpecifiedDirection.Unspecified
   private[chisel3] def specifiedDirection: SpecifiedDirection = _specifiedDirection
   private[chisel3] def specifiedDirection_=(direction: SpecifiedDirection) = {
-    if (_specifiedDirection != SpecifiedDirection.Unspecified) {
-      this match {
-        // Anything flies in compatibility mode
-        case t: Record if !t.compileOptions.dontAssumeDirectionality =>
-        case _ => throw RebindingException(s"Attempted reassignment of user-specified direction to $this")
-      }
-    }
     _specifiedDirection = direction
   }
 
@@ -510,6 +518,8 @@ abstract class Data extends HasId with NamedComponent with SourceInfoDoc {
     }
     _binding = Some(target)
   }
+
+  private[chisel3] def hasBinding: Boolean = _binding.isDefined
 
   // Similar to topBindingOpt except it explicitly excludes SampleElements which are bound but not
   // hardware
@@ -882,11 +892,13 @@ trait WireFactory {
   /** Construct a [[Wire]] from a type template
     * @param t The template from which to construct this wire
     */
-  def apply[T <: Data](t: T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T = {
+  def apply[T <: Data](source: => T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T = {
+    val prevId = Builder.idGen.value
+    val t = source // evaluate once (passed by name)
     if (compileOptions.declaredTypeMustBeUnbound) {
       requireIsChiselType(t, "wire type")
     }
-    val x = t.cloneTypeFull
+    val x = if (!t.mustClone(prevId)) t else t.cloneTypeFull
 
     // Bind each element of x to being a Wire
     x.bind(WireBinding(Builder.forcedUserModule, Builder.currentWhen))

--- a/core/src/main/scala/chisel3/Data.scala
+++ b/core/src/main/scala/chisel3/Data.scala
@@ -472,7 +472,7 @@ abstract class Data extends HasId with NamedComponent with SourceInfoDoc {
     if (this.hasBinding || this._id <= prevId) true
     else
       this match {
-        case b: Bundle => b.hasExternalRef()
+        case b: Bundle => b.hasExternalRef
         case _ => false
       }
   }

--- a/src/test/scala/chiselTests/CompatibilitySpec.scala
+++ b/src/test/scala/chiselTests/CompatibilitySpec.scala
@@ -20,7 +20,7 @@ object CompatibilityCustomCompileOptions {
   }
 }
 
-class CompatibiltySpec extends ChiselFlatSpec with ScalaCheckDrivenPropertyChecks with Utils {
+class CompatibilitySpec extends ChiselFlatSpec with ScalaCheckDrivenPropertyChecks with Utils {
   import Chisel._
 
   behavior.of("Chisel compatibility layer")

--- a/src/test/scala/chiselTests/LazyCloneSpec.scala
+++ b/src/test/scala/chiselTests/LazyCloneSpec.scala
@@ -5,28 +5,59 @@ package chiselTests
 import chisel3._
 import chisel3.stage.ChiselStage
 import chiselTests.ChiselFlatSpec
+import chisel3.stage.ChiselStage.elaborate
+
+object Counter {
+  var count = 0L
+}
+
+class Foo extends Bundle {
+  val a = UInt(8.W)
+  Counter.count += 1
+}
+
+class Bar(x: UInt) extends Bundle {
+  val a = x
+  Counter.count += 1
+}
 
 class LazyCloneSpec extends ChiselFlatSpec {
   behavior.of("LazyClone")
 
-  it should "lazily clone" in {
-    object Foo {
-      var count = 0L
-    }
-
-    class Foo extends Bundle {
-      val a = UInt(8.W)
-      Foo.count += 1
-    }
-
+  it should "not clone" in {
+    Counter.count = 0L
     class MyModule extends RawModule {
       val io = IO(Flipped(new Bundle {
-        val foo = Output(new Foo)
-        val bar = Input(new Foo)
+        val x = Output(new Foo)
+        val y = Input(new Foo)
       }))
     }
     ChiselStage.elaborate(new MyModule)
-    println(s"copies: ${Foo.count}")
-    Foo.count should be < 12L
+    Counter.count should be(2L)
+  }
+
+  it should "share with cloning" in {
+    Counter.count = 0L
+    class MyModule extends RawModule {
+      val foo = new Foo
+      val io = IO(Flipped(new Bundle {
+        val x = Output(foo)
+        val y = Input(foo)
+      }))
+    }
+    ChiselStage.elaborate(new MyModule)
+    Counter.count should be(3L)
+  }
+
+  it should "clone because of external ref" in {
+    Counter.count = 0L
+    class MyModule extends RawModule {
+      val io = IO(Flipped(new Bundle {
+        val foo = Output(new Bar(UInt(8.W)))
+        val bar = Input(new Bar(UInt(8.W)))
+      }))
+    }
+    ChiselStage.elaborate(new MyModule)
+    Counter.count should be(4L)
   }
 }

--- a/src/test/scala/chiselTests/LazyCloneSpec.scala
+++ b/src/test/scala/chiselTests/LazyCloneSpec.scala
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiselTests
+
+import chisel3._
+import chisel3.stage.ChiselStage
+import chiselTests.ChiselFlatSpec
+
+class LazyCloneSpec extends ChiselFlatSpec {
+  behavior.of("LazyClone")
+
+  it should "lazily clone" in {
+    object Foo {
+      var count = 0L
+    }
+
+    class Foo extends Bundle {
+      val a = UInt(8.W)
+      Foo.count += 1
+    }
+
+    class MyModule extends RawModule {
+      val io = IO(Flipped(new Bundle {
+        val foo = Output(new Foo)
+        val bar = Input(new Foo)
+      }))
+    }
+    ChiselStage.elaborate(new MyModule)
+    println(s"copies: ${Foo.count}")
+    Foo.count should be < 12L
+  }
+}

--- a/src/test/scala/chiselTests/LazyCloneSpec.scala
+++ b/src/test/scala/chiselTests/LazyCloneSpec.scala
@@ -5,23 +5,22 @@ package chiselTests
 import chisel3._
 import chisel3.stage.ChiselStage
 import chiselTests.ChiselFlatSpec
-import chisel3.stage.ChiselStage.elaborate
-
-object Counter {
-  var count = 0L
-}
-
-class Foo extends Bundle {
-  val a = UInt(8.W)
-  Counter.count += 1
-}
-
-class Bar(x: UInt) extends Bundle {
-  val a = x
-  Counter.count += 1
-}
 
 class LazyCloneSpec extends ChiselFlatSpec {
+  object Counter {
+    var count = 0L
+  }
+
+  class Foo extends Bundle {
+    val a = UInt(8.W)
+    Counter.count += 1
+  }
+
+  class Bar(x: UInt) extends Bundle {
+    val a = x
+    Counter.count += 1
+  }
+
   behavior.of("LazyClone")
 
   it should "not clone" in {


### PR DESCRIPTION
This change prevents unnecessary clones from happening where possible. Currently when creating a binding, the underlying Data object is always cloned. For example, elaborating this module creates 12 Foo objects.

```scala
class Foo extends Bundle {
  val a = UInt(8.W)
}
class MyModule extends RawModule {
  val io = IO(Flipped(new Bundle {
    val foo = Output(new Foo)
    val bar = Input(new Foo)
  }))
}
```

Since the objects being passed to the binding functions are never used again they do not need to be copied. After this PR, only 2 Foo objects are created when elaborating MyModule.

This change improves elaboration time and memory usage. On two large designs, I saw the following improvements:

**Design 1**

| Metric               |   Default    |   Optimized cloning   |  Improvement  |
| ---------            |   ---------  |   ------------------  |  ------------ |
| Elaboration time (s) |   60.53      |   55.96               |  7.5%         |
| Memory usage (MiB)   |   4389       |   4000                |  7%           |

**Design 2**

| Metric               |   Default    |   Optimized cloning   |  Improvement  |
| ---------            |   ---------  |   ------------------  |  ------------ |
| Elaboration time (s) |   93.57      |   86.40               |  7.5%         |
| Memory usage (MiB)   |   6180       |   5974                |  3%           |


The change works by evaluating the latest builder ID before and after evaluation of the bound expression. If it is newly created (created during the binding call itself), then it is assumed to never be used again (uncaptured), and can be safely reused without cloning.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
- performance improvement
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

This change is mostly source compatible, except in cases that should already be avoided. If the user creates a fresh type during binding, but also captures it into a variable at a higher scope, then it could be reused and doing so would cause errors after this change. This is a bad practice in general, so users should not be doing this in the first place.

For example, this program now causes an error because the result of `mk()` is not cloned and the binding is added directly to the object, but it is actually captured into `x` and used again (causing an error).

```scala
var x: UInt = null;

def mk(): UInt = {
  x = UInt(8.W)
  x
}

val foo = Wire(mk())
val bar = Wire(x)
```

Note: Scala 3 includes support for capture checking which would allow Chisel to ensure that the type has not been captured externally.

This change is not binary compatible because some public functions have changed signatures (bindings are now call-by-name instead of call-by-value).

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

No impact to code generation.

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

Squash.

#### Release Notes

Bindings now use call-by-name to avoid unnecessary clones of data objects. This change does alter the behavior of programs that perform a capture to an outer scope during a binding (bad practice). Elaboration time and memory usage may improve by about 7%.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.

