### PR TITLE
CompileOptions: add and use emitStrictConnects

### DIFF
--- a/core/src/main/scala/chisel3/CompileOptions.scala
+++ b/core/src/main/scala/chisel3/CompileOptions.scala
@@ -35,8 +35,8 @@ trait CompileOptions {
   /** If marked true, then any Module which consumes `inferModuleReset=false` must also mix in [[RequireSyncReset]] */
   def migrateInferModuleReset: Boolean = false
 
-  /** Should biconnects use firrtl biconnection semantics (both LHS and RHS must be true to do so) */
-  def firrtlBiConnectSemantics: Boolean = true
+  /** Should biconnects emit firrtl <= if possible */
+  def emitStrictConnectsIfPossible: Boolean = true
 }
 
 object CompileOptions {
@@ -82,7 +82,7 @@ object ExplicitCompileOptions {
     explicitInvalidate = false,
     inferModuleReset = false
   ) {
-    override def firrtlBiConnectSemantics = false
+    override def emitStrictConnectsIfPossible = false
   }
 
   // Collection of "strict" connection compile options, preferred for new code.

--- a/core/src/main/scala/chisel3/CompileOptions.scala
+++ b/core/src/main/scala/chisel3/CompileOptions.scala
@@ -35,8 +35,8 @@ trait CompileOptions {
   /** If marked true, then any Module which consumes `inferModuleReset=false` must also mix in [[RequireSyncReset]] */
   def migrateInferModuleReset: Boolean = false
 
-  /** Should biconnects emit firrtl <= if possible */
-  def emitStrictConnectsIfPossible: Boolean = true
+  /** Should connects emit as firrtl <= instead of <- */
+  def emitStrictConnects: Boolean = true
 }
 
 object CompileOptions {
@@ -82,7 +82,7 @@ object ExplicitCompileOptions {
     explicitInvalidate = false,
     inferModuleReset = false
   ) {
-    override def emitStrictConnectsIfPossible = false
+    override def emitStrictConnects = false
   }
 
   // Collection of "strict" connection compile options, preferred for new code.

--- a/core/src/main/scala/chisel3/CompileOptions.scala
+++ b/core/src/main/scala/chisel3/CompileOptions.scala
@@ -6,25 +6,37 @@ import scala.language.experimental.macros
 import scala.reflect.macros.blackbox.Context
 
 trait CompileOptions {
-  // Should Record connections require a strict match of fields.
-  // If true and the same fields aren't present in both source and sink, a MissingFieldException,
-  // MissingLeftFieldException, or MissingRightFieldException will be thrown.
+
+  /** Should Record connections require a strict match of fields.
+    *
+    * If true and the same fields aren't present in both source and sink, a MissingFieldException,
+    * MissingLeftFieldException, or MissingRightFieldException will be thrown.
+    */
   val connectFieldsMustMatch: Boolean
-  // When creating an object that takes a type argument, the argument must be unbound (a pure type).
+
+  /** When creating an object that takes a type argument, the argument must be unbound (a pure type). */
   val declaredTypeMustBeUnbound: Boolean
-  // If a connection operator fails, don't try the connection with the operands (source and sink) reversed.
+
+  /** If a connection operator fails, don't try the connection with the operands (source and sink) reversed. */
   val dontTryConnectionsSwapped: Boolean
-  // If connection directionality is not explicit, do not use heuristics to attempt to determine it.
+
+  /** If connection directionality is not explicit, do not use heuristics to attempt to determine it. */
   val dontAssumeDirectionality: Boolean
-  // Check that referenced Data have actually been declared.
+
+  /** Check that referenced Data have actually been declared. */
   val checkSynthesizable: Boolean
-  // Require explicit assignment of DontCare to generate "x is invalid"
+
+  /** Require explicit assignment of DontCare to generate "x is invalid" */
   val explicitInvalidate: Boolean
-  // Should the reset type of Module be a Bool or a Reset
+
+  /** Should the reset type of Module be a Bool or a Reset */
   val inferModuleReset: Boolean
 
   /** If marked true, then any Module which consumes `inferModuleReset=false` must also mix in [[RequireSyncReset]] */
   def migrateInferModuleReset: Boolean = false
+
+  /** Should biconnects use firrtl biconnection semantics (both LHS and RHS must be true to do so) */
+  def firrtlBiConnectSemantics: Boolean = true
 }
 
 object CompileOptions {
@@ -39,6 +51,7 @@ object CompileOptions {
 }
 
 object ExplicitCompileOptions {
+
   case class CompileOptionsClass(
     // Should Record connections require a strict match of fields.
     // If true and the same fields aren't present in both source and sink, a MissingFieldException,
@@ -68,7 +81,9 @@ object ExplicitCompileOptions {
     checkSynthesizable = false,
     explicitInvalidate = false,
     inferModuleReset = false
-  )
+  ) {
+    override def firrtlBiConnectSemantics = false
+  }
 
   // Collection of "strict" connection compile options, preferred for new code.
   implicit val Strict = new CompileOptionsClass(

--- a/core/src/main/scala/chisel3/Data.scala
+++ b/core/src/main/scala/chisel3/Data.scala
@@ -621,7 +621,7 @@ abstract class Data extends HasId with NamedComponent with SourceInfoDoc {
         case _ => // fine
       }
     }
-    if (connectCompileOptions.emitStrictConnectsIfPossible) {
+    if (connectCompileOptions.emitStrictConnects) {
 
       try {
         MonoConnect.connect(sourceInfo, connectCompileOptions, this, that, Builder.referenceUserModule)
@@ -651,7 +651,7 @@ abstract class Data extends HasId with NamedComponent with SourceInfoDoc {
         case _ => // fine
       }
     }
-    if (connectCompileOptions.emitStrictConnectsIfPossible) {
+    if (connectCompileOptions.emitStrictConnects) {
       try {
         BiConnect.connect(sourceInfo, connectCompileOptions, this, that, Builder.referenceUserModule)
       } catch {

--- a/core/src/main/scala/chisel3/Data.scala
+++ b/core/src/main/scala/chisel3/Data.scala
@@ -657,7 +657,7 @@ abstract class Data extends HasId with NamedComponent with SourceInfoDoc {
       } catch {
         case BiConnectException(message) =>
           throwException(
-            s"Connection between left ($this) and source ($that) failed @$message"
+            s"Connection between left  and source  failed @$message"
           )
       }
     } else {

--- a/core/src/main/scala/chisel3/Data.scala
+++ b/core/src/main/scala/chisel3/Data.scala
@@ -606,6 +606,7 @@ abstract class Data extends HasId with NamedComponent with SourceInfoDoc {
 
   private[chisel3] def badConnect(that: Data)(implicit sourceInfo: SourceInfo): Unit =
     throwException(s"cannot connect ${this} and ${that}")
+
   private[chisel3] def connect(
     that: Data
   )(
@@ -619,6 +620,9 @@ abstract class Data extends HasId with NamedComponent with SourceInfoDoc {
         case _: ReadOnlyBinding => throwException(s"Cannot reassign to read-only $this")
         case _ => // fine
       }
+    }
+    if (connectCompileOptions.emitStrictConnectsIfPossible) {
+
       try {
         MonoConnect.connect(sourceInfo, connectCompileOptions, this, that, Builder.referenceUserModule)
       } catch {
@@ -646,6 +650,8 @@ abstract class Data extends HasId with NamedComponent with SourceInfoDoc {
         case (_: DontCareBinding, _) => throw BiConnect.DontCareCantBeSink
         case _ => // fine
       }
+    }
+    if (connectCompileOptions.emitStrictConnectsIfPossible) {
       try {
         BiConnect.connect(sourceInfo, connectCompileOptions, this, that, Builder.referenceUserModule)
       } catch {

--- a/core/src/main/scala/chisel3/Data.scala
+++ b/core/src/main/scala/chisel3/Data.scala
@@ -657,7 +657,7 @@ abstract class Data extends HasId with NamedComponent with SourceInfoDoc {
       } catch {
         case BiConnectException(message) =>
           throwException(
-            s"Connection between left  and source  failed @$message"
+            s"Connection between left ($this) and source ($that) failed @$message"
           )
       }
     } else {

--- a/core/src/main/scala/chisel3/internal/BiConnect.scala
+++ b/core/src/main/scala/chisel3/internal/BiConnect.scala
@@ -55,6 +55,24 @@ private[chisel3] object BiConnect {
     * There is some cleverness in the use of internal try-catch to catch exceptions
     * during the recursive decent and then rethrow them with extra information added.
     * This gives the user a 'path' to where in the connections things went wrong.
+    *
+    * == Chisel Semantics and how they emit to firrtl ==
+    *
+    * 1. Strict Bi-Connect (all fields as seen by firrtl must match exactly)
+    *   `a <= b`
+    *
+    * 2. Strict Bi-Connect (implemented as being field-blasted because we know all firrtl fields would not match exactly)
+    *   `a.foo <= b.foo, b.bar <= a.bar`
+    *
+    * 3. Not-Strict Bi-Connect (firrtl will allow fields to not match exactly)
+    *   `a <- b`
+    *
+    * 4. Mixed Semantic Bi-Connect (some fields need to be handled differently)
+    *   `a.foo <= b.foo` (case 2),  `b.bar <- a.bar` (case 3)
+    *
+    * - The decision on 1 vs 2 is based on structural type -- if same type once emitted to firrtl, emit 1, otherwise emit 2
+    * - 1/2 vs 3 is based on CompileOptions at connection point e.g. at `<>` , emit 3 if `emitStrictConnectsIfPossible = false` for either side
+    * - 4 is a special case of 2 turning into 3 for some subfields, when either side's subfield at `extends Bundle/Record` has `emitStrictConnectsIfPossible = false`
     */
   def connect(
     sourceInfo:            SourceInfo,
@@ -140,8 +158,8 @@ private[chisel3] object BiConnect {
       // Handle Records defined in Chisel._ code by emitting a FIRRTL bulk
       // connect when possible and a partial connect otherwise
       case pair @ (left_r: Record, right_r: Record) =>
-        val firrtlBiConnectSemantics: Boolean =
-          left_r.compileOptions.firrtlBiConnectSemantics && right_r.compileOptions.firrtlBiConnectSemantics
+        val emitStrictConnectsIfPossible: Boolean =
+          left_r.compileOptions.emitStrictConnectsIfPossible && right_r.compileOptions.emitStrictConnectsIfPossible
 
         // chisel3 <> is commutative but FIRRTL <- is not
         val flipConnection =
@@ -161,7 +179,7 @@ private[chisel3] object BiConnect {
           )
         ) {
           pushCommand(Connect(sourceInfo, leftReified.get.lref, rightReified.get.lref))
-        } else if (!firrtlBiConnectSemantics) {
+        } else if (!emitStrictConnectsIfPossible) {
           newLeft.legacyConnect(newRight)(sourceInfo)
         } else {
           recordConnect(sourceInfo, connectCompileOptions, left_r, right_r, context_mod)
@@ -169,7 +187,7 @@ private[chisel3] object BiConnect {
 
       // Handle Records connected to DontCare
       case (left_r: Record, DontCare) =>
-        if (!left_r.compileOptions.firrtlBiConnectSemantics) {
+        if (!left_r.compileOptions.emitStrictConnectsIfPossible) {
           left.legacyConnect(right)(sourceInfo)
         } else {
           // For each field in left, descend with right
@@ -182,7 +200,7 @@ private[chisel3] object BiConnect {
           }
         }
       case (DontCare, right_r: Record) =>
-        if (!right_r.compileOptions.firrtlBiConnectSemantics) {
+        if (!right_r.compileOptions.emitStrictConnectsIfPossible) {
           left.legacyConnect(right)(sourceInfo)
         } else {
           // For each field in left, descend with right

--- a/src/test/scala/chiselTests/ChiselSpec.scala
+++ b/src/test/scala/chiselTests/ChiselSpec.scala
@@ -93,7 +93,7 @@ trait ChiselRunners extends Assertions with BackendCompilationUtilities {
   def compile(t: => RawModule): String = {
     (new ChiselStage)
       .execute(
-        Array("--target-dir", createTestDirectory(this.getClass.getSimpleName).toString),
+        Array("--target-dir", createTestDirectory(this.getClass.getSimpleName).toString, "--full-stacktrace"),
         Seq(ChiselGeneratorAnnotation(() => t))
       )
       .collectFirst {

--- a/src/test/scala/chiselTests/ChiselSpec.scala
+++ b/src/test/scala/chiselTests/ChiselSpec.scala
@@ -93,7 +93,7 @@ trait ChiselRunners extends Assertions with BackendCompilationUtilities {
   def compile(t: => RawModule): String = {
     (new ChiselStage)
       .execute(
-        Array("--target-dir", createTestDirectory(this.getClass.getSimpleName).toString, "--full-stacktrace"),
+        Array("--target-dir", createTestDirectory(this.getClass.getSimpleName).toString),
         Seq(ChiselGeneratorAnnotation(() => t))
       )
       .collectFirst {

--- a/src/test/scala/chiselTests/CompatibilityInteroperabilitySpec.scala
+++ b/src/test/scala/chiselTests/CompatibilityInteroperabilitySpec.scala
@@ -356,7 +356,7 @@ class CompatibilityInteroperabilitySpec extends ChiselFlatSpec {
     object Compat {
       import Chisel.{defaultCompileOptions => _, _}
       // arbitrary thing to make this *not* exactly NotStrict
-      implicit val myCompileOptions = new chisel3.ExplicitCompileOptions.CompileOptionsClass(
+      implicit val defaultCompileOptions = new chisel3.ExplicitCompileOptions.CompileOptionsClass(
         connectFieldsMustMatch = false,
         declaredTypeMustBeUnbound = false,
         dontTryConnectionsSwapped = false,
@@ -376,7 +376,7 @@ class CompatibilityInteroperabilitySpec extends ChiselFlatSpec {
       }
     }
     import chisel3._
-    import Compat.{myCompileOptions => _, _}
+    import Compat.{defaultCompileOptions => _, _}
     class Top(extraFlip: Boolean) extends RawModule {
       val port = IO(new MyBundle(extraFlip))
       val wire = Wire(new MyBundle(extraFlip))

--- a/src/test/scala/chiselTests/CompatibilityInteroperabilitySpec.scala
+++ b/src/test/scala/chiselTests/CompatibilityInteroperabilitySpec.scala
@@ -352,20 +352,17 @@ class CompatibilityInteroperabilitySpec extends ChiselFlatSpec {
     compile(new Top(false))
   }
 
-  /* This test currently fails:
-    [info] A unidirectional but flipped Bundle with something close to NotStrict compileOptions, but not exactly
-[info] chiselTests.CompatibilityInteroperabilitySpec *** ABORTED ***
-[info]   java.lang.InternalError: Malformed class name
-[info]   at java.lang.Class.getSimpleName(Class.java:1330)
-[info]   at chisel3.Bundle.className(Aggregate.scala:1200)
-[info]   at chisel3.Record.toString(Aggregate.scala:1092)
-[info]   at java.lang.String.valueOf(String.java:2994)
-[info]   at java.lang.StringBuilder.append(StringBuilder.java:136)
-[info]   at chisel3.Data.bulkConnect(Data.scala:654)
-[info]   at chisel3.Data.$anonfun$$less$greater$1(Data.scala:797)
+  /* This test currently fails, with a little bit of commenting out of stuff we get:
+    A unidirectional but flipped Bundle with something close to NotStrict compileOptions, but not exactly
+[info] - should bulk connect in import chisel3._ code correctly *** FAILED ***
+[info]   chisel3.internal.ChiselException: Connection between left  and source  failed @.foo.bar: Locally unclear whether Left or Right (both internal)
+[info]   at chisel3.internal.throwException$.apply(Error.scala:169)
+[info]   at chisel3.Data.bulkConnect(Data.scala:659)
+[info]   at chisel3.Data.$anonfun$$less$greater$1(Data.scala:803)
 [info]   at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
 [info]   at chisel3.internal.prefix$.apply(prefix.scala:31)
-[info]   at chisel3.Data.$less$greater(Data.scala:797)
+[info]   at chisel3.Data.$less$greater(Data.scala:803)
+[info]   at chiselTests.CompatibilityInteroperabilitySpec$Top$2.<init>(CompatibilityInteroperabilitySpec.scala:389)
    */
   "A unidirectional but flipped Bundle with something close to NotStrict compileOptions, but not exactly" should "bulk connect in import chisel3._ code correctly" in {
     object Compat {


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
  - bug fix                       
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
   - code cleanup                       
<!--   - backend code generation            -->
   - new feature/API            

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

This breaks out a specific field in `CompileOptions`, `emitStrictConnects`. Previously, this behavior was conditioned matching on `NotStrict` itself, which isn't right for users who may make their own `CompileOptions` variants.

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->
This doesn't change anything except for users who may have been writing their own CompileOptions variants, who would now need to appropriately set this flag to `false` if they were manually making some sort of `NonStrict` variant. 


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
  - Squash: The PR will be squashed and merged (choose this if you have no preference.
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

CompileOptions: add and use a emitStrictConnects flag.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
