### PR TITLE
Deprecate chiselName and NoChiselNamePrefix trait

### DIFF
--- a/core/src/main/scala/chisel3/experimental/package.scala
+++ b/core/src/main/scala/chisel3/experimental/package.scala
@@ -160,6 +160,7 @@ package object experimental {
     * }
     * }}}
     */
+  @deprecated("@chiselName and NoChiselNamePrefix have been replaced by the compiler plugin and AffectsChiselPrefix. Use these instead", "Chisel 3.5")
   trait NoChiselNamePrefix
 
   /** Generate prefixes from values of this type in the Chisel compiler plugin

--- a/core/src/main/scala/chisel3/experimental/package.scala
+++ b/core/src/main/scala/chisel3/experimental/package.scala
@@ -160,7 +160,10 @@ package object experimental {
     * }
     * }}}
     */
-  @deprecated("@chiselName and NoChiselNamePrefix have been replaced by the compiler plugin and AffectsChiselPrefix. Use these instead", "Chisel 3.5")
+  @deprecated(
+    "@chiselName and NoChiselNamePrefix have been replaced by the compiler plugin and AffectsChiselPrefix. Use these instead",
+    "Chisel 3.5"
+  )
   trait NoChiselNamePrefix
 
   /** Generate prefixes from values of this type in the Chisel compiler plugin

--- a/macros/src/main/scala/chisel3/internal/naming/NamingAnnotations.scala
+++ b/macros/src/main/scala/chisel3/internal/naming/NamingAnnotations.scala
@@ -207,6 +207,7 @@ class treedump extends StaticAnnotation {
   def macroTransform(annottees: Any*): Any = macro chisel3.internal.naming.DebugTransforms.treedump
 }
 @compileTimeOnly("enable macro paradise to expand macro annotations")
+@deprecated("Use chisel3.experimental.AffectsChiselPrefix instead. @chiselName will be removed in Chisel 3.6", "Chisel 3.5")
 class chiselName extends StaticAnnotation {
   def macroTransform(annottees: Any*): Any = macro chisel3.internal.naming.NamingTransforms.chiselName
 }

--- a/macros/src/main/scala/chisel3/internal/naming/NamingAnnotations.scala
+++ b/macros/src/main/scala/chisel3/internal/naming/NamingAnnotations.scala
@@ -207,7 +207,10 @@ class treedump extends StaticAnnotation {
   def macroTransform(annottees: Any*): Any = macro chisel3.internal.naming.DebugTransforms.treedump
 }
 @compileTimeOnly("enable macro paradise to expand macro annotations")
-@deprecated("Use chisel3.experimental.AffectsChiselPrefix instead. @chiselName will be removed in Chisel 3.6", "Chisel 3.5")
+@deprecated(
+  "Use chisel3.experimental.AffectsChiselPrefix instead. @chiselName will be removed in Chisel 3.6",
+  "Chisel 3.5"
+)
 class chiselName extends StaticAnnotation {
   def macroTransform(annottees: Any*): Any = macro chisel3.internal.naming.NamingTransforms.chiselName
 }

--- a/src/main/scala/chisel3/util/Arbiter.scala
+++ b/src/main/scala/chisel3/util/Arbiter.scala
@@ -6,7 +6,6 @@
 package chisel3.util
 
 import chisel3._
-import chisel3.internal.naming.chiselName // can't use chisel3_ version because of compile order
 
 /** IO bundle definition for an Arbiter, which takes some number of ready-valid inputs and outputs
   * (selects) at most one.
@@ -116,7 +115,6 @@ class LockingArbiter[T <: Data](gen: T, n: Int, count: Int, needsLock: Option[T 
   * consumer.io.in <> arb.io.out
   * }}}
   */
-@chiselName
 class RRArbiter[T <: Data](val gen: T, val n: Int) extends LockingRRArbiter[T](gen, n, 1)
 
 /** Hardware module that is used to sequence n producers into 1 consumer.
@@ -132,7 +130,6 @@ class RRArbiter[T <: Data](val gen: T, val n: Int) extends LockingRRArbiter[T](g
   * consumer.io.in <> arb.io.out
   * }}}
   */
-@chiselName
 class Arbiter[T <: Data](val gen: T, val n: Int) extends Module {
   val io = IO(new ArbiterIO(gen, n))
 

--- a/src/main/scala/chisel3/util/CircuitMath.scala
+++ b/src/main/scala/chisel3/util/CircuitMath.scala
@@ -6,7 +6,6 @@
 package chisel3.util
 
 import chisel3._
-import chisel3.internal.naming.chiselName // can't use chisel3_ version because of compile order
 
 /** Returns the base-2 integer logarithm of an UInt.
   *
@@ -22,7 +21,6 @@ object Log2 {
 
   /** Returns the base-2 integer logarithm of the least-significant `width` bits of an UInt.
     */
-  @chiselName
   def apply(x: Bits, width: Int): UInt = {
     if (width < 2) {
       0.U

--- a/src/main/scala/chisel3/util/Counter.scala
+++ b/src/main/scala/chisel3/util/Counter.scala
@@ -4,7 +4,6 @@ package chisel3.util
 
 import chisel3._
 import chisel3.experimental.AffectsChiselPrefix
-import chisel3.internal.naming.chiselName // can't use chisel3_ version because of compile order
 
 /** Used to generate an inline (logic directly in the containing Module, no internal Module is created)
   * hardware counter.
@@ -113,7 +112,6 @@ object Counter {
     * @return tuple of the counter value and whether the counter will wrap (the value is at
     * maximum and the condition is true).
     */
-  @chiselName
   def apply(cond: Bool, n: Int): (UInt, Bool) = {
     val c = new Counter(n)
     val wrap = WireInit(false.B)
@@ -129,7 +127,6 @@ object Counter {
     * @return tuple of the counter value and whether the counter will wrap (the value is at
     * maximum and the condition is true).
     */
-  @chiselName
   def apply(r: Range, enable: Bool = true.B, reset: Bool = false.B): (UInt, Bool) = {
     val c = new Counter(r)
     val wrap = WireInit(false.B)

--- a/src/main/scala/chisel3/util/Decoupled.scala
+++ b/src/main/scala/chisel3/util/Decoupled.scala
@@ -233,7 +233,6 @@ class QueueIO[T <: Data](
   * consumer.io.in <> q.io.deq
   * }}}
   */
-@chiselName
 class Queue[T <: Data](
   val gen:            T,
   val entries:        Int,
@@ -345,7 +344,6 @@ object Queue {
     * }}}
     */
   @nowarn("cat=deprecation&msg=TransitName")
-  @chiselName
   def apply[T <: Data](
     enq:            ReadyValidIO[T],
     entries:        Int = 2,

--- a/src/test/scala/chiselTests/StrongEnum.scala
+++ b/src/test/scala/chiselTests/StrongEnum.scala
@@ -4,8 +4,8 @@ package chiselTests
 
 import chisel3._
 import chisel3.experimental.ChiselEnum
+import chisel3.experimental.AffectsChiselPrefix
 import chisel3.internal.firrtl.UnknownWidth
-import chisel3.internal.naming.chiselName
 import chisel3.stage.{ChiselGeneratorAnnotation, ChiselStage}
 import chisel3.util._
 import chisel3.testers.BasicTester
@@ -575,11 +575,10 @@ class StrongEnumAnnotator extends Module {
   val indexed2 = vec_of_bundles(cycle)
 }
 
-@chiselName
 class StrongEnumAnnotatorWithChiselName extends Module {
   import EnumExample._
 
-  object LocalEnum extends ChiselEnum {
+  object LocalEnum extends ChiselEnum with AffectsChiselPrefix {
     val le0, le1 = Value
     val le2 = Value
     val le100 = Value(100.U)


### PR DESCRIPTION
This PR deprecates `@chiselName` and `NoChiselNamePrefix` in favor of the newly added `AffectsChiselPrefix` trait, and deletes all non-testing uses of them.

Needs to be backported so that a followup PR that removes both of these can be made

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
- code cleanup/refactoring

#### API Impact
- deprecates chisellName and NoChiselNamePrefix

#### Backend Code Generation Impact
- no impact

#### Desired Merge Strategy
- squash and merge

#### Release Notes
- Deprecate chiselName and associated NoChiselNamePrefix trait

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
