### PR TITLE
New enhanced API for  specifying Chisel to Firrtl Annotations

### DIFF
--- a/core/src/main/scala/chisel3/Annotation.scala
+++ b/core/src/main/scala/chisel3/Annotation.scala
@@ -39,7 +39,6 @@ object annotate {
     Builder.annotations += anno
   }
   def apply(annos: ChiselToFirrtlAnnotations): Unit = {
-    println("Adding to new annotations in the builder")
     Builder.newAnnotations += annos
   }
 }

--- a/core/src/main/scala/chisel3/Annotation.scala
+++ b/core/src/main/scala/chisel3/Annotation.scala
@@ -20,6 +20,10 @@ trait ChiselAnnotation {
   def toFirrtl: Annotation
 }
 
+trait ChiselToFirrtlAnnotations {
+  def toFirrtlAnnotations: Seq[Annotation]
+}
+
 /** Mixin for [[ChiselAnnotation]] that instantiates an associated FIRRTL Transform when this Annotation is present
   * during a run of
   * [[Driver$.execute(args:Array[String],dut:()=>chisel3\.RawModule)* Driver.execute]].
@@ -33,6 +37,10 @@ trait RunFirrtlTransform extends ChiselAnnotation {
 object annotate {
   def apply(anno: ChiselAnnotation): Unit = {
     Builder.annotations += anno
+  }
+  def apply(annos: ChiselToFirrtlAnnotations): Unit = {
+    println("Adding to new annotations in the builder")
+    Builder.newAnnotations += annos
   }
 }
 

--- a/core/src/main/scala/chisel3/Annotation.scala
+++ b/core/src/main/scala/chisel3/Annotation.scala
@@ -20,6 +20,10 @@ trait ChiselAnnotation {
   def toFirrtl: Annotation
 }
 
+/** Enhanced interface for Annotations in Chisel
+  *
+  *  Defines a conversion to corresponding FIRRTL Annotation(s)
+  */
 trait ChiselToFirrtlAnnotations {
   def toFirrtlAnnotations: Seq[Annotation]
 }

--- a/core/src/main/scala/chisel3/Annotation.scala
+++ b/core/src/main/scala/chisel3/Annotation.scala
@@ -24,8 +24,8 @@ trait ChiselAnnotation {
   *
   *  Defines a conversion to corresponding FIRRTL Annotation(s)
   */
-trait ChiselToFirrtlAnnotations {
-  def toFirrtlAnnotations: Seq[Annotation]
+trait ChiselMultiAnnotation {
+  def toFirrtl: Seq[Annotation]
 }
 
 /** Mixin for [[ChiselAnnotation]] that instantiates an associated FIRRTL Transform when this Annotation is present
@@ -42,7 +42,7 @@ object annotate {
   def apply(anno: ChiselAnnotation): Unit = {
     Builder.annotations += anno
   }
-  def apply(annos: ChiselToFirrtlAnnotations): Unit = {
+  def apply(annos: ChiselMultiAnnotation): Unit = {
     Builder.newAnnotations += annos
   }
 }

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -424,10 +424,13 @@ private[chisel3] object Builder extends LazyLogging {
 
   def idGen: IdGen = chiselContext.get.idGen
 
-  def globalNamespace:     Namespace = dynamicContext.globalNamespace
-  def components:          ArrayBuffer[Component] = dynamicContext.components
-  def annotations:         ArrayBuffer[ChiselAnnotation] = dynamicContext.annotations
-  def newAnnotations:      ArrayBuffer[ChiselToFirrtlAnnotations] = dynamicContext.newAnnotations
+  def globalNamespace: Namespace = dynamicContext.globalNamespace
+  def components:      ArrayBuffer[Component] = dynamicContext.components
+  def annotations:     ArrayBuffer[ChiselAnnotation] = dynamicContext.annotations
+
+  // TODO : Unify this with annotations in the future - done this way for backward compatability
+  def newAnnotations: ArrayBuffer[ChiselToFirrtlAnnotations] = dynamicContext.newAnnotations
+
   def annotationSeq:       AnnotationSeq = dynamicContext.annotationSeq
   def namingStack:         NamingStack = dynamicContext.namingStack
   def importDefinitionMap: Map[String, String] = dynamicContext.importDefinitionMap

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -727,7 +727,7 @@ private[chisel3] object Builder extends LazyLogging {
       errors.checkpoint(logger)
       logger.info("Done elaborating.")
 
-      (Circuit(components.last.name, components.toSeq, annotations.toSeq, newAnnotations.toSeq, makeViewRenameMap), mod)
+      (Circuit(components.last.name, components.toSeq, annotations.toSeq, makeViewRenameMap, newAnnotations.toSeq), mod)
     }
   }
   initializeSingletons()

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -361,6 +361,7 @@ private[chisel3] class DynamicContext(
 
   val components = ArrayBuffer[Component]()
   val annotations = ArrayBuffer[ChiselAnnotation]()
+  val newAnnotations = ArrayBuffer[ChiselToFirrtlAnnotations]()
   var currentModule: Option[BaseModule] = None
 
   /** Contains a mapping from a elaborated module to their aspect
@@ -426,6 +427,7 @@ private[chisel3] object Builder extends LazyLogging {
   def globalNamespace:     Namespace = dynamicContext.globalNamespace
   def components:          ArrayBuffer[Component] = dynamicContext.components
   def annotations:         ArrayBuffer[ChiselAnnotation] = dynamicContext.annotations
+  def newAnnotations:      ArrayBuffer[ChiselToFirrtlAnnotations] = dynamicContext.newAnnotations
   def annotationSeq:       AnnotationSeq = dynamicContext.annotationSeq
   def namingStack:         NamingStack = dynamicContext.namingStack
   def importDefinitionMap: Map[String, String] = dynamicContext.importDefinitionMap
@@ -725,7 +727,7 @@ private[chisel3] object Builder extends LazyLogging {
       errors.checkpoint(logger)
       logger.info("Done elaborating.")
 
-      (Circuit(components.last.name, components.toSeq, annotations.toSeq, makeViewRenameMap), mod)
+      (Circuit(components.last.name, components.toSeq, annotations.toSeq, newAnnotations.toSeq, makeViewRenameMap), mod)
     }
   }
   initializeSingletons()

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -361,7 +361,7 @@ private[chisel3] class DynamicContext(
 
   val components = ArrayBuffer[Component]()
   val annotations = ArrayBuffer[ChiselAnnotation]()
-  val newAnnotations = ArrayBuffer[ChiselToFirrtlAnnotations]()
+  val newAnnotations = ArrayBuffer[ChiselMultiAnnotation]()
   var currentModule: Option[BaseModule] = None
 
   /** Contains a mapping from a elaborated module to their aspect
@@ -429,7 +429,7 @@ private[chisel3] object Builder extends LazyLogging {
   def annotations:     ArrayBuffer[ChiselAnnotation] = dynamicContext.annotations
 
   // TODO : Unify this with annotations in the future - done this way for backward compatability
-  def newAnnotations: ArrayBuffer[ChiselToFirrtlAnnotations] = dynamicContext.newAnnotations
+  def newAnnotations: ArrayBuffer[ChiselMultiAnnotation] = dynamicContext.newAnnotations
 
   def annotationSeq:       AnnotationSeq = dynamicContext.annotationSeq
   def namingStack:         NamingStack = dynamicContext.namingStack

--- a/core/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -872,11 +872,11 @@ case class DefBlackBox(
   @deprecated("Do not use newAnnotations val of Circuit directly - use firrtlAnnotations instead. Will be removed in a future release",
     "Chisel 3.5")
   @since("Chisel 3.5.4")
-  newAnnotations: Seq[ChiselToFirrtlAnnotations] = Seq.empty) {
+  newAnnotations: Seq[ChiselMultiAnnotation] = Seq.empty) {
 
   def firrtlAnnotations: Iterable[Annotation] =
     annotations.flatMap(_.toFirrtl.update(renames)) ++ newAnnotations.flatMap(
-      _.toFirrtlAnnotations.flatMap(_.update(renames))
+      _.toFirrtl.flatMap(_.update(renames))
     )
 
   def copy(

--- a/core/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -865,9 +865,8 @@ case class Circuit(
   name:           String,
   components:     Seq[Component],
   annotations:    Seq[ChiselAnnotation],
-  newAnnotations: Seq[ChiselToFirrtlAnnotations],
-  renames:        RenameMap) {
-  println(s"NewAnnoSize = ${newAnnotations.size}")
+  renames:        RenameMap,
+  newAnnotations: Seq[ChiselToFirrtlAnnotations] = Seq.empty) {
   def firrtlAnnotations: Iterable[Annotation] =
     annotations.flatMap(_.toFirrtl.update(renames)) ++ newAnnotations.flatMap(
       _.toFirrtlAnnotations.flatMap(_.update(renames))

--- a/core/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -14,7 +14,6 @@ import _root_.firrtl.annotations.Annotation
 import scala.collection.immutable.NumericRange
 import scala.math.BigDecimal.RoundingMode
 import scala.annotation.nowarn
-import dataclass.{data, since}
 
 case class PrimOp(name: String) {
   override def toString: String = name
@@ -862,7 +861,7 @@ case class DefBlackBox(
   params: Map[String, Param])
     extends Component
 
-@data class Circuit(
+case class Circuit(
   name:       String,
   components: Seq[Component],
   @deprecated("Do not use annotations val of Circuit directly - use firrtlAnnotations instead. Will be removed in a future release",
@@ -871,8 +870,11 @@ case class DefBlackBox(
   renames:     RenameMap,
   @deprecated("Do not use newAnnotations val of Circuit directly - use firrtlAnnotations instead. Will be removed in a future release",
     "Chisel 3.5")
-  @since("Chisel 3.5.4")
-  newAnnotations: Seq[ChiselMultiAnnotation] = Seq.empty) {
+
+  newAnnotations: Seq[ChiselMultiAnnotation]) {
+
+  def this(name: String, components: Seq[Component], annotations: Seq[ChiselAnnotation], renames: RenameMap) =
+    this(name, components, annotations, renames, Seq.empty)
 
   def firrtlAnnotations: Iterable[Annotation] =
     annotations.flatMap(_.toFirrtl.update(renames)) ++ newAnnotations.flatMap(
@@ -887,8 +889,12 @@ case class DefBlackBox(
   ) = Circuit(name, components, annotations, renames, newAnnotations)
 
 }
-object Circuit {
+object Circuit
+    extends scala.runtime.AbstractFunction4[String, Seq[Component], Seq[ChiselAnnotation], RenameMap, Circuit] {
   def unapply(c: Circuit): Option[(String, Seq[Component], Seq[ChiselAnnotation], RenameMap)] = {
     Some((c.name, c.components, c.annotations, c.renames))
   }
+
+  def apply(name: String, components: Seq[Component], annotations: Seq[ChiselAnnotation], renames: RenameMap): Circuit =
+    new Circuit(name, components, annotations, renames)
 }

--- a/core/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -871,7 +871,8 @@ case class DefBlackBox(
   renames:     RenameMap,
   @deprecated("Do not use newAnnotations val of Circuit directly - use firrtlAnnotations instead. Will be removed in a future release",
     "Chisel 3.5")
-  @since newAnnotations: Seq[ChiselToFirrtlAnnotations] = Seq.empty) {
+  @since("Chisel 3.5.4")
+  newAnnotations: Seq[ChiselToFirrtlAnnotations] = Seq.empty) {
 
   def firrtlAnnotations: Iterable[Annotation] =
     annotations.flatMap(_.toFirrtl.update(renames)) ++ newAnnotations.flatMap(
@@ -879,11 +880,15 @@ case class DefBlackBox(
     )
 
   def copy(
-    name:           String = name,
-    components:     Seq[Component] = components,
-    annotations:    Seq[ChiselAnnotation] = annotations,
-    renames:        RenameMap = renames,
-    newAnnotations: Seq[ChiselToFirrtlAnnotations] = newAnnotations
+    name:        String = name,
+    components:  Seq[Component] = components,
+    annotations: Seq[ChiselAnnotation] = annotations,
+    renames:     RenameMap = renames
   ) = Circuit(name, components, annotations, renames, newAnnotations)
 
+}
+object Circuit {
+  def unapply(c: Circuit): Option[(String, Seq[Component], Seq[ChiselAnnotation], RenameMap)] = {
+    Some((c.name, c.components, c.annotations, c.renames))
+  }
 }

--- a/core/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -14,6 +14,7 @@ import _root_.firrtl.annotations.Annotation
 import scala.collection.immutable.NumericRange
 import scala.math.BigDecimal.RoundingMode
 import scala.annotation.nowarn
+import dataclass.{data, since}
 
 case class PrimOp(name: String) {
   override def toString: String = name
@@ -861,14 +862,28 @@ case class DefBlackBox(
   params: Map[String, Param])
     extends Component
 
-case class Circuit(
-  name:           String,
-  components:     Seq[Component],
-  annotations:    Seq[ChiselAnnotation],
-  renames:        RenameMap,
-  newAnnotations: Seq[ChiselToFirrtlAnnotations] = Seq.empty) {
+@data class Circuit(
+  name:       String,
+  components: Seq[Component],
+  @deprecated("Do not use annotations val of Circuit directly - use firrtlAnnotations instead. Will be removed in a future release",
+    "Chisel 3.5")
+  annotations: Seq[ChiselAnnotation],
+  renames:     RenameMap,
+  @deprecated("Do not use newAnnotations val of Circuit directly - use firrtlAnnotations instead. Will be removed in a future release",
+    "Chisel 3.5")
+  @since newAnnotations: Seq[ChiselToFirrtlAnnotations] = Seq.empty) {
+
   def firrtlAnnotations: Iterable[Annotation] =
     annotations.flatMap(_.toFirrtl.update(renames)) ++ newAnnotations.flatMap(
       _.toFirrtlAnnotations.flatMap(_.update(renames))
     )
+
+  def copy(
+    name:           String = name,
+    components:     Seq[Component] = components,
+    annotations:    Seq[ChiselAnnotation] = annotations,
+    renames:        RenameMap = renames,
+    newAnnotations: Seq[ChiselToFirrtlAnnotations] = newAnnotations
+  ) = Circuit(name, components, annotations, renames, newAnnotations)
+
 }

--- a/core/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -861,7 +861,15 @@ case class DefBlackBox(
   params: Map[String, Param])
     extends Component
 
-case class Circuit(name: String, components: Seq[Component], annotations: Seq[ChiselAnnotation], renames: RenameMap) {
-  def firrtlAnnotations: Iterable[Annotation] = annotations.flatMap(_.toFirrtl.update(renames))
-
+case class Circuit(
+  name:           String,
+  components:     Seq[Component],
+  annotations:    Seq[ChiselAnnotation],
+  newAnnotations: Seq[ChiselToFirrtlAnnotations],
+  renames:        RenameMap) {
+  println(s"NewAnnoSize = ${newAnnotations.size}")
+  def firrtlAnnotations: Iterable[Annotation] =
+    annotations.flatMap(_.toFirrtl.update(renames)) ++ newAnnotations.flatMap(
+      _.toFirrtlAnnotations.flatMap(_.update(renames))
+    )
 }

--- a/src/test/scala/chiselTests/NewAnnotationsSpec.scala
+++ b/src/test/scala/chiselTests/NewAnnotationsSpec.scala
@@ -1,0 +1,75 @@
+package chiselTests
+import chisel3._
+import chisel3.experimental.{annotate, ChiselToFirrtlAnnotations}
+import chisel3.stage.{ChiselGeneratorAnnotation, ChiselStage}
+import firrtl.stage.FirrtlCircuitAnnotation
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+import firrtl.transforms.NoDedupAnnotation
+import firrtl.transforms.DontTouchAnnotation
+
+class NewAnnotationsSpec extends AnyFreeSpec with Matchers {
+
+  class MuchUsedModule extends Module {
+    val io = IO(new Bundle {
+      val in = Input(UInt(16.W))
+      val out = Output(UInt(16.W))
+    })
+    io.out := io.in +% 1.U
+  }
+
+  class UsesMuchUsedModule extends Module {
+    val io = IO(new Bundle {
+      val in = Input(UInt(16.W))
+      val out = Output(UInt(16.W))
+    })
+
+    val mod0 = Module(new MuchUsedModule)
+    val mod1 = Module(new MuchUsedModule)
+    val mod2 = Module(new MuchUsedModule)
+    val mod3 = Module(new MuchUsedModule)
+
+    mod0.io.in := io.in
+    mod1.io.in := mod0.io.out
+    mod2.io.in := mod1.io.out
+    mod3.io.in := mod2.io.out
+    io.out := mod3.io.out
+
+    // Give two annotations as single element of the seq - ensures previous API works by wrapping into a seq.
+    annotate(new ChiselToFirrtlAnnotations { def toFirrtlAnnotations = Seq(new NoDedupAnnotation(mod1.toNamed)) })
+    annotate(new ChiselToFirrtlAnnotations { def toFirrtlAnnotations = Seq(new NoDedupAnnotation(mod3.toNamed)) })
+
+    // Pass multiple annotations in the same seq - should get emitted out correctly.
+    annotate(new ChiselToFirrtlAnnotations {
+      def toFirrtlAnnotations =
+        Seq(new DontTouchAnnotation(mod1.io.in.toNamed), new DontTouchAnnotation(mod1.io.out.toNamed))
+    })
+  }
+
+  val stage = new ChiselStage
+  "Ensure all annotations continue to be passed / digested correctly with the new API" - {
+    "NoDedup and DontTouch work as expected" in {
+      val dutAnnos = stage
+        .execute(
+          Array("-X", "low", "--target-dir", "test_run_dir"),
+          Seq(ChiselGeneratorAnnotation(() => new UsesMuchUsedModule))
+        )
+
+      val dontTouchAnnos = dutAnnos.collect { case DontTouchAnnotation(target) => target.serialize }
+      val dontTouchAnnosCombined = dontTouchAnnos.mkString(",")
+      require(dontTouchAnnos.size == 2, s"Exactly two DontTouch Annotations expected but got $dontTouchAnnos ")
+      dontTouchAnnosCombined should include("~UsesMuchUsedModule|MuchUsedModule_1>io_in")
+      dontTouchAnnosCombined should include("~UsesMuchUsedModule|MuchUsedModule_1>io_out")
+
+      val lowFirrtl = dutAnnos.collectFirst {
+        case FirrtlCircuitAnnotation(circuit) => circuit.serialize
+      }
+        .getOrElse(fail())
+      lowFirrtl should include("module MuchUsedModule :")
+      lowFirrtl should include("module MuchUsedModule_1 :")
+      lowFirrtl should include("module MuchUsedModule_3 :")
+      (lowFirrtl should not).include("module MuchUsedModule_2 :")
+      (lowFirrtl should not).include("module MuchUsedModule_4 :")
+    }
+  }
+}

--- a/src/test/scala/chiselTests/NewAnnotationsSpec.scala
+++ b/src/test/scala/chiselTests/NewAnnotationsSpec.scala
@@ -1,6 +1,6 @@
 package chiselTests
 import chisel3._
-import chisel3.experimental.{annotate, ChiselToFirrtlAnnotations}
+import chisel3.experimental.{annotate, ChiselMultiAnnotation}
 import chisel3.stage.{ChiselGeneratorAnnotation, ChiselStage}
 import firrtl.stage.FirrtlCircuitAnnotation
 import org.scalatest.freespec.AnyFreeSpec
@@ -36,12 +36,12 @@ class NewAnnotationsSpec extends AnyFreeSpec with Matchers {
     io.out := mod3.io.out
 
     // Give two annotations as single element of the seq - ensures previous API works by wrapping into a seq.
-    annotate(new ChiselToFirrtlAnnotations { def toFirrtlAnnotations = Seq(new NoDedupAnnotation(mod1.toNamed)) })
-    annotate(new ChiselToFirrtlAnnotations { def toFirrtlAnnotations = Seq(new NoDedupAnnotation(mod3.toNamed)) })
+    annotate(new ChiselMultiAnnotation { def toFirrtl = Seq(new NoDedupAnnotation(mod1.toNamed)) })
+    annotate(new ChiselMultiAnnotation { def toFirrtl = Seq(new NoDedupAnnotation(mod3.toNamed)) })
 
     // Pass multiple annotations in the same seq - should get emitted out correctly.
-    annotate(new ChiselToFirrtlAnnotations {
-      def toFirrtlAnnotations =
+    annotate(new ChiselMultiAnnotation {
+      def toFirrtl =
         Seq(new DontTouchAnnotation(mod1.io.in.toNamed), new DontTouchAnnotation(mod1.io.out.toNamed))
     })
   }


### PR DESCRIPTION
### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement
- new feature / API 
- 
<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->


#### High level Changes
- With the intent to ensure no existing code breaks / needs an update - a different variable (called newAnnotations) was used. Also wherever this is used a default value of Seq.empty was provided in the function argument list - again to avoid updating existing code. 
-  A new trait called `ChiselMultiAnnotaiton` was created with `toFirrtl` method - which returns a Seq of Annotations. 

@jackkoenig  this is based on our agreed upon strategy (creating a totally new trait as opposed to adding a new method in the existing one) 

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->
No impact to current code. The current API is useful to generate annotations  containing information which will only be available after a module elaborates.  However this is limited since we can only generate a single annotation per call. In some cases we need ability to generate a Seq of annotations. 

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->
No change to generated verilog. 

#### Desired Merge Strategy
- Squash
<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
New API to convert a single `Chisel Annotation` into a Seq of `FirrtlAnnotations` 

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
