### PR TITLE
3.5x: Make explicit copy constructors for ExplicitCompileOptions

### DIFF
--- a/core/src/main/scala/chisel3/CompileOptions.scala
+++ b/core/src/main/scala/chisel3/CompileOptions.scala
@@ -82,7 +82,30 @@ object ExplicitCompileOptions {
     explicitInvalidate = false,
     inferModuleReset = false
   ) {
+    override def migrateInferModuleReset = false
+
     override def emitStrictConnects = false
+
+    override def copy(
+      connectFieldsMustMatch:    Boolean = false,
+      declaredTypeMustBeUnbound: Boolean = false,
+      dontTryConnectionsSwapped: Boolean = false,
+      dontAssumeDirectionality:  Boolean = false,
+      checkSynthesizable:        Boolean = false,
+      explicitInvalidate:        Boolean = false,
+      inferModuleReset:          Boolean = false
+    ) = new CompileOptionsClass(
+      connectFieldsMustMatch,
+      declaredTypeMustBeUnbound,
+      dontTryConnectionsSwapped,
+      dontAssumeDirectionality,
+      checkSynthesizable,
+      explicitInvalidate,
+      inferModuleReset
+    ) {
+      override def migrateInferModuleReset = false
+      override def emitStrictConnects = false
+    }
   }
 
   // Collection of "strict" connection compile options, preferred for new code.
@@ -94,5 +117,30 @@ object ExplicitCompileOptions {
     checkSynthesizable = true,
     explicitInvalidate = true,
     inferModuleReset = true
-  )
+  ) {
+
+    override def migrateInferModuleReset = false
+    override def emitStrictConnects = true
+
+    override def copy(
+      connectFieldsMustMatch:    Boolean = true,
+      declaredTypeMustBeUnbound: Boolean = true,
+      dontTryConnectionsSwapped: Boolean = true,
+      dontAssumeDirectionality:  Boolean = true,
+      checkSynthesizable:        Boolean = true,
+      explicitInvalidate:        Boolean = true,
+      inferModuleReset:          Boolean = true
+    ) = new CompileOptionsClass(
+      connectFieldsMustMatch,
+      declaredTypeMustBeUnbound,
+      dontTryConnectionsSwapped,
+      dontAssumeDirectionality,
+      checkSynthesizable,
+      explicitInvalidate,
+      inferModuleReset
+    ) {
+      override def migrateInferModuleReset = false
+      override def emitStrictConnects = true
+    }
+  }
 }

--- a/src/test/scala/chiselTests/CompileOptionsTest.scala
+++ b/src/test/scala/chiselTests/CompileOptionsTest.scala
@@ -163,4 +163,32 @@ class CompileOptionsSpec extends ChiselFlatSpec with Utils {
     }
   }
 
+  "Strict.copy()" should "be equivalent in all CompileOptions traits" in {
+    import chisel3.ExplicitCompileOptions.Strict
+    val copiedCompileOptions = Strict.copy()
+    assert(copiedCompileOptions.connectFieldsMustMatch == Strict.connectFieldsMustMatch)
+    assert(copiedCompileOptions.declaredTypeMustBeUnbound == Strict.declaredTypeMustBeUnbound)
+    assert(copiedCompileOptions.dontTryConnectionsSwapped == Strict.dontTryConnectionsSwapped)
+    assert(copiedCompileOptions.dontAssumeDirectionality == Strict.dontAssumeDirectionality)
+    assert(copiedCompileOptions.checkSynthesizable == Strict.checkSynthesizable)
+    assert(copiedCompileOptions.explicitInvalidate == Strict.explicitInvalidate)
+    assert(copiedCompileOptions.inferModuleReset == Strict.inferModuleReset)
+    assert(copiedCompileOptions.migrateInferModuleReset == Strict.migrateInferModuleReset)
+    assert(copiedCompileOptions.emitStrictConnects == Strict.emitStrictConnects)
+  }
+
+  "NotStrict.copy()" should "be equivalent in all CompileOptions traits" in {
+    import chisel3.ExplicitCompileOptions.NotStrict
+    val copiedCompileOptions = NotStrict.copy()
+    assert(copiedCompileOptions.connectFieldsMustMatch == NotStrict.connectFieldsMustMatch)
+    assert(copiedCompileOptions.declaredTypeMustBeUnbound == NotStrict.declaredTypeMustBeUnbound)
+    assert(copiedCompileOptions.dontTryConnectionsSwapped == NotStrict.dontTryConnectionsSwapped)
+    assert(copiedCompileOptions.dontAssumeDirectionality == NotStrict.dontAssumeDirectionality)
+    assert(copiedCompileOptions.checkSynthesizable == NotStrict.checkSynthesizable)
+    assert(copiedCompileOptions.explicitInvalidate == NotStrict.explicitInvalidate)
+    assert(copiedCompileOptions.inferModuleReset == NotStrict.inferModuleReset)
+    assert(copiedCompileOptions.migrateInferModuleReset == NotStrict.migrateInferModuleReset)
+    assert(copiedCompileOptions.emitStrictConnects == NotStrict.emitStrictConnects)
+  }
+
 }


### PR DESCRIPTION
This is being PR-ed to 3.5.x and woudl then be backported to master. If this is not accepted to this branch there isn't a reason to have it on master.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [ ] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [ ] Did you state the API impact?
- [ ] Did you specify the code generation impact?
- [ ] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
  - bug fix            
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

This restores an API which is currently broken. Previously if you called `.copy()` on a `CompileOptionsClass` you'd reasonably expect that all the elements defined by the `CompileOptions` trait would be copied over. But that is not the case for the two `CompileOptionsClass`es `Strict` and `NotStrict`. This PR overrides their copy constructors to make it feel like you are copying them even for the fields from `CompileOptions` that are not exposed to `CompileOptionsClass`.

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

Not really a change on verilog other than restoring expected behavior

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
  - Squash: The PR will be squashed and merged (choose this if you have no preference. 
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

Make explicit copy constructors for ExplicitCompileOptions Strict and NotStrict.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
