### PR TITLE
Unify Chisel2 and chisel3 directionality

### DIFF
--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -527,8 +527,7 @@ package experimental {
       //   even for chisel3 code.
       // This assigns the explicit directions required by both semantics on all Bundles.
       // This recursively walks the tree, and assigns directions if no explicit
-      //   direction given by upper-levels (override Input / Output) AND element is
-      //   directly inside a compatibility Bundle determined by compile options.
+      //   direction given by upper-levels (override Input / Output)
       def assignCompatDir(data: Data): Unit = {
         data match {
           case data: Element => data._assignCompatibilityExplicitDirection

--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -543,9 +543,9 @@ package experimental {
                     vec.getElements.foreach(assignCompatDir(_))
                 }
               case SpecifiedDirection.Input | SpecifiedDirection.Output =>
-                // forced assign, nothing to do
-                // Note this is because Input and Output recurse down their types to align all fields to that SpecifiedDirection
-                // Thus, no implicit assigment is necessary.
+              // forced assign, nothing to do
+              // Note this is because Input and Output recurse down their types to align all fields to that SpecifiedDirection
+              // Thus, no implicit assigment is necessary.
             }
         }
       }

--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -522,33 +522,35 @@ package experimental {
       */
     protected def _bindIoInPlace(iodef: Data): Unit = {
       // Compatibility code: Chisel2 did not require explicit direction on nodes
-      // (unspecified treated as output, and flip on nothing was input).
-      // This sets assigns the explicit directions required by newer semantics on
-      // Bundles defined in compatibility mode.
+      //   (unspecified treated as output, and flip on nothing was input).
+      // However, we are going to go back to Chisel2 semantics, so we need to make it work
+      //   even for chisel3 code.
+      // This assigns the explicit directions required by both semantics on all Bundles.
       // This recursively walks the tree, and assigns directions if no explicit
-      // direction given by upper-levels (override Input / Output) AND element is
-      // directly inside a compatibility Bundle determined by compile options.
+      //   direction given by upper-levels (override Input / Output) AND element is
+      //   directly inside a compatibility Bundle determined by compile options.
       def assignCompatDir(data: Data, insideCompat: Boolean): Unit = {
         data match {
-          case data: Element if insideCompat => data._assignCompatibilityExplicitDirection
-          case data: Element => // Not inside a compatibility Bundle, nothing to be done
+          case data: Element => data._assignCompatibilityExplicitDirection
           case data: Aggregate =>
             data.specifiedDirection match {
               // Recurse into children to ensure explicit direction set somewhere
               case SpecifiedDirection.Unspecified | SpecifiedDirection.Flip =>
                 data match {
                   case record: Record =>
-                    val compatRecord = !record.compileOptions.dontAssumeDirectionality
-                    record.getElements.foreach(assignCompatDir(_, compatRecord))
+                    record.getElements.foreach(assignCompatDir(_))
                   case vec: Vec[_] =>
-                    vec.getElements.foreach(assignCompatDir(_, insideCompat))
+                    vec.getElements.foreach(assignCompatDir(_))
                 }
-              case SpecifiedDirection.Input | SpecifiedDirection.Output => // forced assign, nothing to do
+              case SpecifiedDirection.Input | SpecifiedDirection.Output =>
+                // forced assign, nothing to do
+                // Note this is because Input and Output recurse down their types to align all fields to that SpecifiedDirection
+                // Thus, no implicit assigment is necessary.
             }
         }
       }
 
-      assignCompatDir(iodef, false)
+      assignCompatDir(iodef)
 
       iodef.bind(PortBinding(this))
       _ports += iodef

--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -529,7 +529,7 @@ package experimental {
       // This recursively walks the tree, and assigns directions if no explicit
       //   direction given by upper-levels (override Input / Output) AND element is
       //   directly inside a compatibility Bundle determined by compile options.
-      def assignCompatDir(data: Data, insideCompat: Boolean): Unit = {
+      def assignCompatDir(data: Data): Unit = {
         data match {
           case data: Element => data._assignCompatibilityExplicitDirection
           case data: Aggregate =>

--- a/src/test/scala/chiselTests/Direction.scala
+++ b/src/test/scala/chiselTests/Direction.scala
@@ -83,15 +83,13 @@ class DirectionSpec extends ChiselPropSpec with Matchers with Utils {
     })
   }
 
-  property("Empty Vecs with no direction on the sample_element *should* cause direction errors") {
-    an[Exception] should be thrownBy extractCause[Exception] {
-      ChiselStage.elaborate(new Module {
-        val io = IO(new Bundle {
-          val foo = Input(UInt(8.W))
-          val x = Vec(0, UInt(8.W))
-        })
+  property("Empty Vecs with no direction on the sample_element should not cause direction errors, as Chisel and chisel3 directions are merged") {
+    ChiselStage.elaborate(new Module {
+      val io = IO(new Bundle {
+        val foo = Input(UInt(8.W))
+        val x = Vec(0, UInt(8.W))
       })
-    }
+    })
   }
 
   property("Empty Bundles should not cause direction errors") {
@@ -117,15 +115,13 @@ class DirectionSpec extends ChiselPropSpec with Matchers with Utils {
     })
   }
 
-  property("Explicitly directioned but empty Bundles should cause direction errors") {
-    an[Exception] should be thrownBy extractCause[Exception] {
-      ChiselStage.elaborate(new Module {
-        val io = IO(new Bundle {
-          val foo = UInt(8.W)
-          val x = Input(new Bundle {})
-        })
+  property("Explicitly directioned but empty Bundles should not cause direction errors because Chisel and chisel3 directionality are merged") {
+    ChiselStage.elaborate(new Module {
+      val io = IO(new Bundle {
+        val foo = UInt(8.W)
+        val x = Input(new Bundle {})
       })
-    }
+    })
   }
 
   import chisel3.experimental.{DataMirror, Direction}

--- a/src/test/scala/chiselTests/Direction.scala
+++ b/src/test/scala/chiselTests/Direction.scala
@@ -83,7 +83,9 @@ class DirectionSpec extends ChiselPropSpec with Matchers with Utils {
     })
   }
 
-  property("Empty Vecs with no direction on the sample_element should not cause direction errors, as Chisel and chisel3 directions are merged") {
+  property(
+    "Empty Vecs with no direction on the sample_element should not cause direction errors, as Chisel and chisel3 directions are merged"
+  ) {
     ChiselStage.elaborate(new Module {
       val io = IO(new Bundle {
         val foo = Input(UInt(8.W))
@@ -115,7 +117,9 @@ class DirectionSpec extends ChiselPropSpec with Matchers with Utils {
     })
   }
 
-  property("Explicitly directioned but empty Bundles should not cause direction errors because Chisel and chisel3 directionality are merged") {
+  property(
+    "Explicitly directioned but empty Bundles should not cause direction errors because Chisel and chisel3 directionality are merged"
+  ) {
     ChiselStage.elaborate(new Module {
       val io = IO(new Bundle {
         val foo = UInt(8.W)

--- a/src/test/scala/chiselTests/Direction.scala
+++ b/src/test/scala/chiselTests/Direction.scala
@@ -341,19 +341,11 @@ class DirectionSpec extends ChiselPropSpec with Matchers with Utils {
     }
 
     val emitted: String = ChiselStage.emitChirrtl(new MyModule)
-    val firrtl:  String = ChiselStage.convert(new MyModule).serialize
 
     // Check that emitted directions are correct.
-    Seq(emitted, firrtl).foreach { o =>
-      {
-        // Chisel Emitter formats spacing a little differently than the
-        // FIRRTL Emitter :-(
-        val s = o.replace("{b", "{ b")
-        assert(s.contains("input incoming : { bits : UInt<3>, valid : UInt<1>, flip ready : UInt<1>}"))
-        assert(s.contains("output outgoing : { bits : UInt<3>, valid : UInt<1>, flip ready : UInt<1>}"))
-        assert(s.contains("outgoing <= incoming"))
-      }
-    }
+    assert(emitted.contains("input incoming : { bits : UInt<3>, valid : UInt<1>, flip ready : UInt<1>}"))
+    assert(emitted.contains("output outgoing : { bits : UInt<3>, valid : UInt<1>, flip ready : UInt<1>}"))
+    assert(emitted.contains("outgoing <= incoming"))
   }
   property("Can now mix Input/Output and Flipped within the same bundle") {
     class Decoupled extends Bundle {
@@ -376,24 +368,15 @@ class DirectionSpec extends ChiselPropSpec with Matchers with Utils {
     }
 
     val emitted: String = ChiselStage.emitChirrtl(new MyModule)
-    val firrtl:  String = ChiselStage.convert(new MyModule).serialize
 
-    // Check that emitted directions are correct.
-    Seq(emitted, firrtl).foreach { o =>
-      {
-        // Chisel Emitter formats spacing a little differently than the
-        // FIRRTL Emitter :-(
-        val s = o.replace("{b", "{ b").replace("{p", "{ p")
-        assert(
-          s.contains(
-            "input io : { producer : { bits : UInt<3>, valid : UInt<1>, flip ready : UInt<1>}, flip consumer : { bits : UInt<3>, valid : UInt<1>, flip ready : UInt<1>}, flip monitor : { bits : UInt<3>, valid : UInt<1>, ready : UInt<1>}, driver : { bits : UInt<3>, valid : UInt<1>, ready : UInt<1>}}"
-          )
-        )
-        assert(s.contains("io.consumer <= io.producer"))
-        assert(s.contains("io.monitor.bits <= io.driver.bits"))
-        assert(s.contains("io.monitor.valid <= io.driver.valid"))
-        assert(s.contains("io.monitor.ready <= io.driver.ready"))
-      }
-    }
+    assert(
+      emitted.contains(
+        "input io : { producer : { bits : UInt<3>, valid : UInt<1>, flip ready : UInt<1>}, flip consumer : { bits : UInt<3>, valid : UInt<1>, flip ready : UInt<1>}, flip monitor : { bits : UInt<3>, valid : UInt<1>, ready : UInt<1>}, driver : { bits : UInt<3>, valid : UInt<1>, ready : UInt<1>}}"
+      )
+    )
+    assert(emitted.contains("io.consumer <= io.producer"))
+    assert(emitted.contains("io.monitor.bits <= io.driver.bits"))
+    assert(emitted.contains("io.monitor.valid <= io.driver.valid"))
+    assert(emitted.contains("io.monitor.ready <= io.driver.ready"))
   }
 }


### PR DESCRIPTION
## Background: `Chisel._` vs `chisel3._` directionality

In `Chisel._`, `IO` has an implicit output direction, and `Flipped` is used for two things:

 1) Define relative direction of a field with respect to its parent bundle
 2) To change the implicit output to an implicit input of IO

```scala
val io = IO(new Bundle { // implicit output
  val x = Flipped(UInt()) // x is flipped relative to bundle, so it is an input
  val y = UInt() // y is aligned relative to bundle, so it is an output
})
```

You can declare an input port using the (2) kind of Flipped:

```scala
val io = IO(Flipped(new Bundle { // implicit input
  val x = Flipped(UInt()) // x is flipped relative to bundle, so it is an output
  val y = UInt() // y is aligned relative to bundle, so it is an input
}))
```

In `chisel3`, `IO` does not have an implicit direction, but `Input` and `Output` are specified on types, which coerce all subfields of the type to the same direction. `Flipped` inverts the absolute direction so `Input -> Output` and `Output -> Input`.

```scala
val io = IO(new Bundle { // no implicit direction
  val x = Input(UInt()) // x is an input
  val y = Output(UInt()) // y is an output
}))
```

You can switch directions with `Flipped`:

```scala
val io = IO(Flipped(new Bundle { // Swap all absolute directions
  val x = Input(UInt()) // x is flipped so it is an output
  val y = Output(UInt()) // y is flipped so it is an input
})))
```

## Unifying directionality with new primitives

Both mechanisms of describing field directions can be unified with the following (conceptual) primitives:

- `Flipped`: a field's relative direction is reversed with respect to its parent bundle
- `Aligned`: a field's relative direction is the same with respect to its parent bundle (is implicit)
- `Outgoing`: an IO whose implicit direction is output
- `Incoming`: an IO whose implicit direction is input
- `stripFlipsOf`: a type-generator that aligns all subfields, recursively
- `reverseFlipsOf`: a type-generator that flips all subfields, recursively

Expressing Chisel._ semantics:

- `IO(new Bundle))` becomes `Outgoing(new Bundle)`
- `IO(Flipped(new Bundle))` becomes `Incoming(new Bundle)`; note that `Outgoing(reverseFlipsOf(new Bundle))` is the same, but I think it makes sense to have `Incoming` as well.
- `new Bundle { val x = UInt() }` is `new Bundle { val x = Aligned(UInt()) }`, or unchanged as `Aligned` is implicit
- `new Bundle { val x = Flipped(UInt()) }` is unchanged

Expressing chisel3._ semantics:

- `IO(new Bundle))` becomes `Outgoing(new Bundle)`
- `IO(Flipped(new Bundle))` becomes `Incoming(new Bundle)`
- `new Bundle { val x = Output(UInt()) }` is `new Bundle { val x = Aligned(stripFlipsOf(UInt())) }`
- `new Bundle { val x = Input(UInt()) }` is `new Bundle { val x = Flipped(stripFlipsOf(UInt())) }`

## How this PR unifies these things

Just like we can express Chisel/chisel3 with new primitives, we can represent the new primitives with Chisel/chisel3 APIs. The only thing that was missing was (1) ALWAYS apply the implicit output from IO (or implicit input if a flip is there), and (2) enable mixing Input/Output with Flipped. This means that effectively, `Input` becomes `Flipped(stripsFlipsOf(..))` and `Output` becomes `Aligned(stripsFlipsOf(..))`, and now the semantics can coexist. Basically, this change defines how `Chisel._`'s relative directions resolve in `chisel3`. **This *should* not break any code, because previously it was an error.**

Future work will be to add the new primitives as they are, and refactor Input/Output etc to just call the new primitives. In the meantime, we can change the semantics so that this change is easier, and we can get rid of compatibility mode.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [N/A] Did you add appropriate documentation in `docs/src`? **Will do this later when we add more primitives**
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
 - new feature/API

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->
Adds an API, where you can now declare bundles that have both Flipped and Input/Output.

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

None


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
  - Squash: The PR will be squashed and merged (choose this if you have no preference.
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

Remove restriction that Bundles have to only declare fields with absolute directions (Input/Output) or relative directions (Flipped).

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [x] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
