### PR TITLE
Remove remaining chiselNames

### DIFF
--- a/src/main/scala/chisel3/compatibility.scala
+++ b/src/main/scala/chisel3/compatibility.scala
@@ -617,7 +617,6 @@ package object Chisel {
     /** Generates a 16-bit linear feedback shift register, returning the register contents.
       * @param increment optional control to gate when the LFSR updates.
       */
-    @chiselName
     def apply(increment: Bool = true.B): UInt =
       VecInit(
         FibonacciLFSR

--- a/src/main/scala/chisel3/compatibility.scala
+++ b/src/main/scala/chisel3/compatibility.scala
@@ -4,7 +4,6 @@
   *  while moving to the more standard package naming convention `chisel3` (lowercase c).
   */
 import chisel3._ // required for implicit conversions.
-import chisel3.experimental.chiselName
 import chisel3.util.random.FibonacciLFSR
 import chisel3.stage.{phases, ChiselCircuitAnnotation, ChiselOutputFileAnnotation, ChiselStage}
 

--- a/src/main/scala/chisel3/util/Decoupled.scala
+++ b/src/main/scala/chisel3/util/Decoupled.scala
@@ -7,7 +7,6 @@ package chisel3.util
 
 import chisel3._
 import chisel3.experimental.{requireIsChiselType, DataMirror, Direction}
-import chisel3.internal.naming._ // can't use chisel3_ version because of compile order
 
 import scala.annotation.nowarn
 

--- a/src/main/scala/chisel3/util/Decoupled.scala
+++ b/src/main/scala/chisel3/util/Decoupled.scala
@@ -121,7 +121,6 @@ object Decoupled {
     *
     * @note unsafe (and will error) on the producer (input) side of an IrrevocableIO
     */
-  @chiselName
   def apply[T <: Data](irr: IrrevocableIO[T]): DecoupledIO[T] = {
     require(
       DataMirror.directionOf(irr.bits) == Direction.Output,
@@ -388,7 +387,6 @@ object Queue {
     *   consumer.io.in <> Queue(producer.io.out, 16)
     * }}}
     */
-  @chiselName
   def irrevocable[T <: Data](
     enq:            ReadyValidIO[T],
     entries:        Int = 2,


### PR DESCRIPTION
A couple of `@chiselName` uses weren't covered by #2627 so this PR removes these as well.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
- code cleanup

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->
no impact

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->
no impact

#### Desired Merge Strategy
squash and merge

#### Release Notes

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
