### PR TITLE
Implement DecoupledIO.map utility

### DIFF
--- a/src/main/scala/chisel3/util/Decoupled.scala
+++ b/src/main/scala/chisel3/util/Decoupled.scala
@@ -99,7 +99,21 @@ object ReadyValidIO {
   * of ready or valid.
   * @param gen the type of data to be wrapped in DecoupledIO
   */
-class DecoupledIO[+T <: Data](gen: T) extends ReadyValidIO[T](gen)
+class DecoupledIO[+T <: Data](gen: T) extends ReadyValidIO[T](gen) {
+  /** Applies the supplied functor to the bits of this interface, returning a new 
+    * typed DecoupledIO interface.
+    * @param f The function to apply to this DecoupledIO's 'bits' with return type B
+    * @return a new DecoupledIO of type B 
+    */
+  def map[B <: Data](f: T => B): DecoupledIO[B] = {
+    val _map_bits = f(bits)
+    val _map = Wire(Decoupled(chiselTypeOf(_map_bits)))
+    _map.bits := _map_bits
+    _map.valid := valid
+    ready := _map.ready
+    _map
+  }
+}
 
 /** This factory adds a decoupled handshaking protocol to a data bundle. */
 object Decoupled {

--- a/src/main/scala/chisel3/util/Decoupled.scala
+++ b/src/main/scala/chisel3/util/Decoupled.scala
@@ -100,10 +100,11 @@ object ReadyValidIO {
   * @param gen the type of data to be wrapped in DecoupledIO
   */
 class DecoupledIO[+T <: Data](gen: T) extends ReadyValidIO[T](gen) {
-  /** Applies the supplied functor to the bits of this interface, returning a new 
+
+  /** Applies the supplied functor to the bits of this interface, returning a new
     * typed DecoupledIO interface.
     * @param f The function to apply to this DecoupledIO's 'bits' with return type B
-    * @return a new DecoupledIO of type B 
+    * @return a new DecoupledIO of type B
     */
   def map[B <: Data](f: T => B): DecoupledIO[B] = {
     val _map_bits = f(bits)

--- a/src/main/scala/chisel3/util/util.scala
+++ b/src/main/scala/chisel3/util/util.scala
@@ -11,15 +11,4 @@ package object util {
   type ValidIO[+T <: Data] = chisel3.util.Valid[T]
   val ValidIO = chisel3.util.Valid
   val DecoupledIO = chisel3.util.Decoupled
-
-  implicit class DecoupledExtensions[A <: Data](x: DecoupledIO[A]) {
-    def map[B <: Data](f: A => B): DecoupledIO[B] = {
-      val _map_bits = f(x.bits)
-      val _map = Wire(Decoupled(chiselTypeOf(_map_bits)))
-      _map.bits := _map_bits
-      _map.valid := x.valid
-      x.ready := _map.ready
-      _map
-    }
-  }
 }

--- a/src/main/scala/chisel3/util/util.scala
+++ b/src/main/scala/chisel3/util/util.scala
@@ -11,4 +11,15 @@ package object util {
   type ValidIO[+T <: Data] = chisel3.util.Valid[T]
   val ValidIO = chisel3.util.Valid
   val DecoupledIO = chisel3.util.Decoupled
+
+  implicit class DecoupledExtensions[A <: Data](x: DecoupledIO[A]) {
+    def map[B <: Data](f: A => B): DecoupledIO[B] = {
+      val res = f(x.bits)
+      val wire = Wire(Decoupled(chiselTypeOf(res)))
+      wire.bits := res
+      wire.valid := x.valid
+      x.ready := wire.ready
+      wire
+    }
+  }
 }

--- a/src/main/scala/chisel3/util/util.scala
+++ b/src/main/scala/chisel3/util/util.scala
@@ -14,12 +14,12 @@ package object util {
 
   implicit class DecoupledExtensions[A <: Data](x: DecoupledIO[A]) {
     def map[B <: Data](f: A => B): DecoupledIO[B] = {
-      val res = f(x.bits)
-      val wire = Wire(Decoupled(chiselTypeOf(res)))
-      wire.bits := res
-      wire.valid := x.valid
-      x.ready := wire.ready
-      wire
+      val _map_bits = f(x.bits)
+      val _map = Wire(Decoupled(chiselTypeOf(_map_bits)))
+      _map.bits := _map_bits
+      _map.valid := x.valid
+      x.ready := _map.ready
+      _map
     }
   }
 }

--- a/src/test/scala/chiselTests/DecoupledSpec.scala
+++ b/src/test/scala/chiselTests/DecoupledSpec.scala
@@ -25,26 +25,64 @@ class DecoupledSpec extends ChiselFlatSpec {
         val deq = IO(Decoupled(UInt(8.W)))
         deq <> enq.map(_ + 1.U)
       })
-    )
+    ).serialize
 
-    chirrtl.serialize should include("""node _deq_res_T = add(enq.bits, UInt<1>("h1")""")
-    chirrtl.serialize should include("""node deq_res = tail(_deq_res_T, 1)""")
-    chirrtl.serialize should include("""deq_wire.bits <= deq_res""")
-    chirrtl.serialize should include("""deq <= deq_wire""")
+    // Check for data assignment
+    chirrtl should include("""node _deq_res_T = add(enq.bits, UInt<1>("h1")""")
+    chirrtl should include("""node deq_res = tail(_deq_res_T, 1)""")
+    chirrtl should include("""deq_wire.bits <= deq_res""")
+    chirrtl should include("""deq <= deq_wire""")
+
+    // Check for back-pressure (ready signal is driven in the opposite direction of bits + valid)
+    chirrtl should include("""enq.ready <= deq_wire.ready""")
   }
 
   "Decoupled.map" should "apply a function to a wrapped Bundle" in {
+    class TestBundle extends Bundle {
+      val foo  = UInt(8.W)
+      val bar  = UInt(8.W)
+      val fizz = Bool()
+      val buzz = Bool()
+    }
+
+    // Add one to foo, subtract one from bar, set fizz to false and buzz to true
+    def func(t: TestBundle): TestBundle = {
+      val res = Wire(new TestBundle)
+
+      res.foo  := t.foo + 1.U
+      res.bar  := t.bar - 1.U
+      res.fizz := false.B
+      res.buzz := true.B
+
+      res
+    }
+
     val chirrtl = ChiselStage.convert(
       ChiselStage.elaborate(new Module {
-        val enq = IO(Flipped(Decoupled(UInt(8.W))))
-        val deq = IO(Decoupled(UInt(8.W)))
-        deq <> enq.map(_ + 1.U)
+        val enq = IO(Flipped(Decoupled(new TestBundle)))
+        val deq = IO(Decoupled(new TestBundle))
+        deq <> enq.map(func)
       })
-    )
+    ).serialize
 
-    chirrtl.serialize should include("""node _deq_res_T = add(enq.bits, UInt<1>("h1")""")
-    chirrtl.serialize should include("""node deq_res = tail(_deq_res_T, 1)""")
-    chirrtl.serialize should include("""deq_wire.bits <= deq_res""")
-    chirrtl.serialize should include("""deq <= deq_wire""")
+    // Check for data assignment
+    chirrtl should include("""wire deq_res : { foo : UInt<8>, bar : UInt<8>, fizz : UInt<1>, buzz : UInt<1>}""")
+
+    chirrtl should include("""node _deq_res_res_foo_T = add(enq.bits, UInt<1>("h1")""")
+    chirrtl should include("""node _deq_res_res_foo_T_1 = tail(_deq_res_res_foo_T, 1)""")
+    chirrtl should include("""deq_res.foo = _deq_res_res_foo_T_1""")
+
+    chirrtl should include("""node _deq_res_res_bar_T = sub(enq.bits, UInt<1>("h1")""")
+    chirrtl should include("""node _deq_res_res_bar_T_1 = tail(_deq_res_res_bar_T, 1)""")
+    chirrtl should include("""deq_res.bar = _deq_res_res_bar_T_1""")
+
+    chirrtl should include("""deq_res.fizz = UInt<1>("h0")""")
+    chirrtl should include("""deq_res.buzz = UInt<1>("h1")""")
+
+    chirrtl should include("""deq_wire.bits <= deq_res""")
+    chirrtl should include("""deq <= deq_wire""")
+
+    // Check for back-pressure (ready signal is driven in the opposite direction of bits + valid)
+    chirrtl should include("""enq.ready <= deq_wire.ready""")
   }
 }

--- a/src/test/scala/chiselTests/DecoupledSpec.scala
+++ b/src/test/scala/chiselTests/DecoupledSpec.scala
@@ -30,13 +30,13 @@ class DecoupledSpec extends ChiselFlatSpec {
       .serialize
 
     // Check for data assignment
-    chirrtl should include("""node _deq_res_T = add(enq.bits, UInt<1>("h1")""")
-    chirrtl should include("""node deq_res = tail(_deq_res_T, 1)""")
-    chirrtl should include("""deq_wire.bits <= deq_res""")
-    chirrtl should include("""deq <= deq_wire""")
+    chirrtl should include("""node _deq_map_bits_T = add(enq.bits, UInt<1>("h1")""")
+    chirrtl should include("""node _deq_map_bits = tail(_deq_map_bits_T, 1)""")
+    chirrtl should include("""_deq_map.bits <= _deq_map_bits""")
+    chirrtl should include("""deq <= _deq_map""")
 
     // Check for back-pressure (ready signal is driven in the opposite direction of bits + valid)
-    chirrtl should include("""enq.ready <= deq_wire.ready""")
+    chirrtl should include("""enq.ready <= _deq_map.ready""")
   }
 
   "Decoupled.map" should "apply a function to a wrapped Bundle" in {
@@ -70,23 +70,23 @@ class DecoupledSpec extends ChiselFlatSpec {
       .serialize
 
     // Check for data assignment
-    chirrtl should include("""wire deq_res : { foo : UInt<8>, bar : UInt<8>, fizz : UInt<1>, buzz : UInt<1>}""")
+    chirrtl should include("""wire _deq_map_bits : { foo : UInt<8>, bar : UInt<8>, fizz : UInt<1>, buzz : UInt<1>}""")
 
-    chirrtl should include("""node _deq_res_res_foo_T = add(enq.bits.foo, UInt<1>("h1")""")
-    chirrtl should include("""node _deq_res_res_foo_T_1 = tail(_deq_res_res_foo_T, 1)""")
-    chirrtl should include("""deq_res.foo <= _deq_res_res_foo_T_1""")
+    chirrtl should include("""node _deq_map_bits_res_foo_T = add(enq.bits.foo, UInt<1>("h1")""")
+    chirrtl should include("""node _deq_map_bits_res_foo_T_1 = tail(_deq_map_bits_res_foo_T, 1)""")
+    chirrtl should include("""_deq_map_bits.foo <= _deq_map_bits_res_foo_T_1""")
 
-    chirrtl should include("""node _deq_res_res_bar_T = sub(enq.bits.bar, UInt<1>("h1")""")
-    chirrtl should include("""node _deq_res_res_bar_T_1 = tail(_deq_res_res_bar_T, 1)""")
-    chirrtl should include("""deq_res.bar <= _deq_res_res_bar_T_1""")
+    chirrtl should include("""node _deq_map_bits_res_bar_T = sub(enq.bits.bar, UInt<1>("h1")""")
+    chirrtl should include("""node _deq_map_bits_res_bar_T_1 = tail(_deq_map_bits_res_bar_T, 1)""")
+    chirrtl should include("""_deq_map_bits.bar <= _deq_map_bits_res_bar_T_1""")
 
-    chirrtl should include("""deq_res.fizz <= UInt<1>("h0")""")
-    chirrtl should include("""deq_res.buzz <= UInt<1>("h1")""")
+    chirrtl should include("""_deq_map_bits.fizz <= UInt<1>("h0")""")
+    chirrtl should include("""_deq_map_bits.buzz <= UInt<1>("h1")""")
 
-    chirrtl should include("""deq_wire.bits <= deq_res""")
-    chirrtl should include("""deq <= deq_wire""")
+    chirrtl should include("""_deq_map.bits <= _deq_map_bits""")
+    chirrtl should include("""deq <= _deq_map""")
 
     // Check for back-pressure (ready signal is driven in the opposite direction of bits + valid)
-    chirrtl should include("""enq.ready <= deq_wire.ready""")
+    chirrtl should include("""enq.ready <= _deq_map.ready""")
   }
 }

--- a/src/test/scala/chiselTests/DecoupledSpec.scala
+++ b/src/test/scala/chiselTests/DecoupledSpec.scala
@@ -72,16 +72,16 @@ class DecoupledSpec extends ChiselFlatSpec {
     // Check for data assignment
     chirrtl should include("""wire deq_res : { foo : UInt<8>, bar : UInt<8>, fizz : UInt<1>, buzz : UInt<1>}""")
 
-    chirrtl should include("""node _deq_res_res_foo_T = add(enq.bits, UInt<1>("h1")""")
+    chirrtl should include("""node _deq_res_res_foo_T = add(enq.bits.foo, UInt<1>("h1")""")
     chirrtl should include("""node _deq_res_res_foo_T_1 = tail(_deq_res_res_foo_T, 1)""")
-    chirrtl should include("""deq_res.foo = _deq_res_res_foo_T_1""")
+    chirrtl should include("""deq_res.foo <= _deq_res_res_foo_T_1""")
 
-    chirrtl should include("""node _deq_res_res_bar_T = sub(enq.bits, UInt<1>("h1")""")
+    chirrtl should include("""node _deq_res_res_bar_T = sub(enq.bits.bar, UInt<1>("h1")""")
     chirrtl should include("""node _deq_res_res_bar_T_1 = tail(_deq_res_res_bar_T, 1)""")
-    chirrtl should include("""deq_res.bar = _deq_res_res_bar_T_1""")
+    chirrtl should include("""deq_res.bar <= _deq_res_res_bar_T_1""")
 
-    chirrtl should include("""deq_res.fizz = UInt<1>("h0")""")
-    chirrtl should include("""deq_res.buzz = UInt<1>("h1")""")
+    chirrtl should include("""deq_res.fizz <= UInt<1>("h0")""")
+    chirrtl should include("""deq_res.buzz <= UInt<1>("h1")""")
 
     chirrtl should include("""deq_wire.bits <= deq_res""")
     chirrtl should include("""deq <= deq_wire""")

--- a/src/test/scala/chiselTests/DecoupledSpec.scala
+++ b/src/test/scala/chiselTests/DecoupledSpec.scala
@@ -17,4 +17,34 @@ class DecoupledSpec extends ChiselFlatSpec {
       assert(io.asUInt.widthOption.get === 4)
     })
   }
+
+  "Decoupled.map" should "apply a function to a wrapped Data" in {
+    val chirrtl = ChiselStage.convert(
+      ChiselStage.elaborate(new Module {
+        val enq = IO(Flipped(Decoupled(UInt(8.W))))
+        val deq = IO(Decoupled(UInt(8.W)))
+        deq <> enq.map(_ + 1.U)
+      })
+    )
+
+    chirrtl.serialize should include("""node _deq_res_T = add(enq.bits, UInt<1>("h1")""")
+    chirrtl.serialize should include("""node deq_res = tail(_deq_res_T, 1)""")
+    chirrtl.serialize should include("""deq_wire.bits <= deq_res""")
+    chirrtl.serialize should include("""deq <= deq_wire""")
+  }
+
+  "Decoupled.map" should "apply a function to a wrapped Bundle" in {
+    val chirrtl = ChiselStage.convert(
+      ChiselStage.elaborate(new Module {
+        val enq = IO(Flipped(Decoupled(UInt(8.W))))
+        val deq = IO(Decoupled(UInt(8.W)))
+        deq <> enq.map(_ + 1.U)
+      })
+    )
+
+    chirrtl.serialize should include("""node _deq_res_T = add(enq.bits, UInt<1>("h1")""")
+    chirrtl.serialize should include("""node deq_res = tail(_deq_res_T, 1)""")
+    chirrtl.serialize should include("""deq_wire.bits <= deq_res""")
+    chirrtl.serialize should include("""deq <= deq_wire""")
+  }
 }

--- a/src/test/scala/chiselTests/DecoupledSpec.scala
+++ b/src/test/scala/chiselTests/DecoupledSpec.scala
@@ -19,13 +19,15 @@ class DecoupledSpec extends ChiselFlatSpec {
   }
 
   "Decoupled.map" should "apply a function to a wrapped Data" in {
-    val chirrtl = ChiselStage.convert(
-      ChiselStage.elaborate(new Module {
-        val enq = IO(Flipped(Decoupled(UInt(8.W))))
-        val deq = IO(Decoupled(UInt(8.W)))
-        deq <> enq.map(_ + 1.U)
-      })
-    ).serialize
+    val chirrtl = ChiselStage
+      .convert(
+        ChiselStage.elaborate(new Module {
+          val enq = IO(Flipped(Decoupled(UInt(8.W))))
+          val deq = IO(Decoupled(UInt(8.W)))
+          deq <> enq.map(_ + 1.U)
+        })
+      )
+      .serialize
 
     // Check for data assignment
     chirrtl should include("""node _deq_res_T = add(enq.bits, UInt<1>("h1")""")
@@ -39,8 +41,8 @@ class DecoupledSpec extends ChiselFlatSpec {
 
   "Decoupled.map" should "apply a function to a wrapped Bundle" in {
     class TestBundle extends Bundle {
-      val foo  = UInt(8.W)
-      val bar  = UInt(8.W)
+      val foo = UInt(8.W)
+      val bar = UInt(8.W)
       val fizz = Bool()
       val buzz = Bool()
     }
@@ -49,21 +51,23 @@ class DecoupledSpec extends ChiselFlatSpec {
     def func(t: TestBundle): TestBundle = {
       val res = Wire(new TestBundle)
 
-      res.foo  := t.foo + 1.U
-      res.bar  := t.bar - 1.U
+      res.foo := t.foo + 1.U
+      res.bar := t.bar - 1.U
       res.fizz := false.B
       res.buzz := true.B
 
       res
     }
 
-    val chirrtl = ChiselStage.convert(
-      ChiselStage.elaborate(new Module {
-        val enq = IO(Flipped(Decoupled(new TestBundle)))
-        val deq = IO(Decoupled(new TestBundle))
-        deq <> enq.map(func)
-      })
-    ).serialize
+    val chirrtl = ChiselStage
+      .convert(
+        ChiselStage.elaborate(new Module {
+          val enq = IO(Flipped(Decoupled(new TestBundle)))
+          val deq = IO(Decoupled(new TestBundle))
+          deq <> enq.map(func)
+        })
+      )
+      .serialize
 
     // Check for data assignment
     chirrtl should include("""wire deq_res : { foo : UInt<8>, bar : UInt<8>, fizz : UInt<1>, buzz : UInt<1>}""")

--- a/src/test/scala/chiselTests/DecoupledSpec.scala
+++ b/src/test/scala/chiselTests/DecoupledSpec.scala
@@ -20,14 +20,11 @@ class DecoupledSpec extends ChiselFlatSpec {
 
   "Decoupled.map" should "apply a function to a wrapped Data" in {
     val chirrtl = ChiselStage
-      .convert(
-        ChiselStage.elaborate(new Module {
-          val enq = IO(Flipped(Decoupled(UInt(8.W))))
-          val deq = IO(Decoupled(UInt(8.W)))
-          deq <> enq.map(_ + 1.U)
-        })
-      )
-      .serialize
+      .emitChirrtl(new Module {
+        val enq = IO(Flipped(Decoupled(UInt(8.W))))
+        val deq = IO(Decoupled(UInt(8.W)))
+        deq <> enq.map(_ + 1.U)
+      })
 
     // Check for data assignment
     chirrtl should include("""node _deq_map_bits_T = add(enq.bits, UInt<1>("h1")""")
@@ -60,14 +57,11 @@ class DecoupledSpec extends ChiselFlatSpec {
     }
 
     val chirrtl = ChiselStage
-      .convert(
-        ChiselStage.elaborate(new Module {
-          val enq = IO(Flipped(Decoupled(new TestBundle)))
-          val deq = IO(Decoupled(new TestBundle))
-          deq <> enq.map(func)
-        })
-      )
-      .serialize
+      .emitChirrtl(new Module {
+        val enq = IO(Flipped(Decoupled(new TestBundle)))
+        val deq = IO(Decoupled(new TestBundle))
+        deq <> enq.map(func)
+      })
 
     // Check for data assignment
     chirrtl should include("""wire _deq_map_bits : { foo : UInt<8>, bar : UInt<8>, fizz : UInt<1>, buzz : UInt<1>}""")
@@ -97,14 +91,11 @@ class DecoupledSpec extends ChiselFlatSpec {
     }
 
     val chirrtl = ChiselStage
-      .convert(
-        ChiselStage.elaborate(new Module {
-          val enq = IO(Flipped(Decoupled(new TestBundle)))
-          val deq = IO(Decoupled(UInt(8.W)))
-          deq <> enq.map(bundle => bundle.foo & bundle.bar)
-        })
-      )
-      .serialize
+      .emitChirrtl(new Module {
+        val enq = IO(Flipped(Decoupled(new TestBundle)))
+        val deq = IO(Decoupled(UInt(8.W)))
+        deq <> enq.map(bundle => bundle.foo & bundle.bar)
+      })
 
     // Check that the _map wire wraps a UInt and not a TestBundle
     chirrtl should include("""wire _deq_map : { flip ready : UInt<1>, valid : UInt<1>, bits : UInt<8>}""")


### PR DESCRIPTION
Addresses #1072: Implements a new utility for `Decoupled` which applies a function to its data.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

- new feature/API

#### API Impact

- Adds `Decoupled.map` to apply a function to a `DecoupledIO` and return the new resulting `DecoupledIO`

#### Backend Code Generation Impact

- No change to verilog

#### Desired Merge Strategy

- Squash and merge

#### Release Notes

Implement `DecoupledIO.map` to apply a function to `DecoupledIO.bits`

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
