### PR TITLE
Remove chiseltest from defaultVersions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,10 @@ enablePlugins(SiteScaladocPlugin)
 val defaultVersions = Map(
   "firrtl" -> "edu.berkeley.cs" %% "firrtl" % "1.6-SNAPSHOT",
   "treadle" -> "edu.berkeley.cs" %% "treadle" % "1.6-SNAPSHOT",
-  "chiseltest" -> "edu.berkeley.cs" %% "chiseltest" % "0.6-SNAPSHOT"
+  // chiseltest intentionally excluded so that release automation does not try to set its version
+  // The projects using chiseltest are not published, but SBT resolves dependencies for all projects
+  // when doing publishing and will not find a chiseltest release since chiseltest depends on
+  // chisel3
 )
 
 lazy val commonSettings = Seq(
@@ -243,7 +246,7 @@ lazy val integrationTests = (project in file("integration-tests"))
   .settings(usePluginSettings: _*)
   .settings(
     Seq(
-      libraryDependencies += defaultVersions("chiseltest") % "test"
+      libraryDependencies += "edu.berkeley.cs" %% "chiseltest" % "0.6-SNAPSHOT" % "test"
     )
   )
 


### PR DESCRIPTION
Release automation tries to bump chiseltest which causes issues due to
SBT trying to resolve all dependencies (even for projects that will not
be published, like integrationTests).

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [NA] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [NA] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

 - code cleanup   


#### API Impact

None

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

 - Squash

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
