### PR TITLE
Remove Tuesday from Dev Meeting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ If you are migrating from Chisel2, see [the migration guide](https://www.chisel-
 
 ### Chisel Dev Meeting
 
-Chisel/FIRRTL development meetings happen every Monday and Tuesday from 1100--1200 PT.
+Chisel/FIRRTL development meetings happen every Monday from 1100--1200 PT.
 
 Call-in info and meeting notes are available [here](https://docs.google.com/document/d/1BLP2DYt59DqI-FgFCcjw8Ddl4K-WU0nHmQu0sZ_wAGo/).
 


### PR DESCRIPTION
We no longer meet on Tuesdays, only Mondays.

Marked for backporting so this shows up on the website.

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [NA] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [NA] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [NA] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

   - documentation 
   
#### API Impact

No impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

  - Squash

#### Release Notes


### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
