### PR TITLE
Add OpaqueType support to Records

### DIFF
--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -925,11 +925,12 @@ trait VecLike[T <: Data] extends IndexedSeq[T] with HasId with SourceInfoDoc {
   */
 abstract class Record(private[chisel3] implicit val compileOptions: CompileOptions) extends Aggregate {
 
-  // Classes can override opaqueType if they want to "unbox" Records
-  //  that have maps with a single element. If opaqueType is
-  //  overridden to true, the subfield name of the record is
-  //  skipped and the Record name is used instead. See RecordSpec
-  //  for example usage and expected output
+  /** Classes can override opaqueType if they want to "unbox"
+    * Records that have maps with a single element. If opaqueType
+    * is overridden to true, the subfield name of the record is
+    * skipped and the Record name is used instead. See RecordSpec
+    * for example usage and expected output
+    */
   def opaqueType: Boolean = false
 
   // Doing this earlier than onModuleClose allows field names to be available for prefixing the names
@@ -939,6 +940,7 @@ abstract class Record(private[chisel3] implicit val compileOptions: CompileOptio
     // identifier; however, Namespace sanitizes identifiers to make them legal for Firrtl/Verilog
     // which can cause collisions
     val _namespace = Namespace.empty
+    assert(!opaqueType || elements.size == 1, "opaqueType cannot be true when the size of elements is not 1")
     for ((name, elt) <- elements) { elt.setRef(this, _namespace.name(name, leadingDigitOk = true), unbox = opaqueType) }
   }
 

--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -925,11 +925,17 @@ trait VecLike[T <: Data] extends IndexedSeq[T] with HasId with SourceInfoDoc {
   */
 abstract class Record(private[chisel3] implicit val compileOptions: CompileOptions) extends Aggregate {
 
-  /** Classes can override opaqueType if they want to "unbox"
-    * Records that have maps with a single element. If opaqueType
-    * is overridden to true, the subfield name of the record is
-    * skipped and the Record name is used instead. See RecordSpec
-    * for example usage and expected output
+  /** Indicates if this Record represents an "Opaque Type"
+    *
+    * Opaque types provide a mechanism for user-defined types 
+    * that do not impose any "boxing" overhead in the emitted FIRRTL and Verilog.
+    * You can think about an opaque type Record as a box around
+    * a single element that only exists at Chisel elaboration time.
+    * Put another way, if opaqueType is overridden to true, 
+    * The Record may only contain a single element with an empty name
+    * and there will be no `_` in the name for that element in the emitted Verilog.
+    *
+    * @see RecordSpec in Chisel's tests for example usage and expected output
     */
   def opaqueType: Boolean = false
 

--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -940,7 +940,10 @@ abstract class Record(private[chisel3] implicit val compileOptions: CompileOptio
     // identifier; however, Namespace sanitizes identifiers to make them legal for Firrtl/Verilog
     // which can cause collisions
     val _namespace = Namespace.empty
-    assert(!opaqueType || elements.size == 1, "opaqueType cannot be true when the size of elements is not 1")
+    assert(
+      !opaqueType || elements.size == 1,
+      s"Size of elements must be 1 if opaqueType == true, not ${elements.size}: ${elements.keys.mkString(", ")}"
+    )
     for ((name, elt) <- elements) { elt.setRef(this, _namespace.name(name, leadingDigitOk = true), unbox = opaqueType) }
   }
 

--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -934,7 +934,7 @@ abstract class Record(private[chisel3] implicit val compileOptions: CompileOptio
     // identifier; however, Namespace sanitizes identifiers to make them legal for Firrtl/Verilog
     // which can cause collisions
     val _namespace = Namespace.empty
-    for ((name, elt) <- elements) { elt.setRef(this, _namespace.name(name, leadingDigitOk = true)) }
+    for ((name, elt) <- elements) { elt.setRef(this, _namespace.name(name, leadingDigitOk = true), unbox = opaqueType) }
   }
 
   private[chisel3] override def bind(target: Binding, parentDirection: SpecifiedDirection): Unit = {

--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -927,11 +927,11 @@ abstract class Record(private[chisel3] implicit val compileOptions: CompileOptio
 
   /** Indicates if this Record represents an "Opaque Type"
     *
-    * Opaque types provide a mechanism for user-defined types 
+    * Opaque types provide a mechanism for user-defined types
     * that do not impose any "boxing" overhead in the emitted FIRRTL and Verilog.
     * You can think about an opaque type Record as a box around
     * a single element that only exists at Chisel elaboration time.
-    * Put another way, if opaqueType is overridden to true, 
+    * Put another way, if opaqueType is overridden to true,
     * The Record may only contain a single element with an empty name
     * and there will be no `_` in the name for that element in the emitted Verilog.
     *

--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -925,6 +925,11 @@ trait VecLike[T <: Data] extends IndexedSeq[T] with HasId with SourceInfoDoc {
   */
 abstract class Record(private[chisel3] implicit val compileOptions: CompileOptions) extends Aggregate {
 
+  // Classes can override opaqueType if they want to "unbox" Records
+  //  that have maps with a single element. If opaqueType is 
+  //  overriden to true, the subfield names of the record are
+  //  skipped, and the Record name is used instead. See RecordSpec
+  //  for example usage and expected output
   def opaqueType: Boolean = false
 
   // Doing this earlier than onModuleClose allows field names to be available for prefixing the names

--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -926,9 +926,9 @@ trait VecLike[T <: Data] extends IndexedSeq[T] with HasId with SourceInfoDoc {
 abstract class Record(private[chisel3] implicit val compileOptions: CompileOptions) extends Aggregate {
 
   // Classes can override opaqueType if they want to "unbox" Records
-  //  that have maps with a single element. If opaqueType is 
-  //  overriden to true, the subfield names of the record are
-  //  skipped, and the Record name is used instead. See RecordSpec
+  //  that have maps with a single element. If opaqueType is
+  //  overridden to true, the subfield name of the record is
+  //  skipped and the Record name is used instead. See RecordSpec
   //  for example usage and expected output
   def opaqueType: Boolean = false
 

--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -925,6 +925,8 @@ trait VecLike[T <: Data] extends IndexedSeq[T] with HasId with SourceInfoDoc {
   */
 abstract class Record(private[chisel3] implicit val compileOptions: CompileOptions) extends Aggregate {
 
+  def opaqueType: Boolean = false
+
   // Doing this earlier than onModuleClose allows field names to be available for prefixing the names
   // of hardware created when connecting to one of these elements
   private def setElementRefs(): Unit = {

--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -940,9 +940,9 @@ abstract class Record(private[chisel3] implicit val compileOptions: CompileOptio
     // identifier; however, Namespace sanitizes identifiers to make them legal for Firrtl/Verilog
     // which can cause collisions
     val _namespace = Namespace.empty
-    assert(
-      !opaqueType || elements.size == 1,
-      s"Size of elements must be 1 if opaqueType == true, not ${elements.size}: ${elements.keys.mkString(", ")}"
+    require(
+      !opaqueType || (elements.size == 1 && elements.head._1 == ""),
+      s"Opaque types must have exactly one element with an empty name, not ${elements.size}: ${elements.keys.mkString(", ")}"
     )
     for ((name, elt) <- elements) { elt.setRef(this, _namespace.name(name, leadingDigitOk = true), unbox = opaqueType) }
   }

--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -950,7 +950,9 @@ abstract class Record(private[chisel3] implicit val compileOptions: CompileOptio
       !opaqueType || (elements.size == 1 && elements.head._1 == ""),
       s"Opaque types must have exactly one element with an empty name, not ${elements.size}: ${elements.keys.mkString(", ")}"
     )
-    for ((name, elt) <- elements) { elt.setRef(this, _namespace.name(name, leadingDigitOk = true), unbox = opaqueType) }
+    for ((name, elt) <- elements) {
+      elt.setRef(this, _namespace.name(name, leadingDigitOk = true), opaque = opaqueType)
+    }
   }
 
   private[chisel3] override def bind(target: Binding, parentDirection: SpecifiedDirection): Unit = {

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -219,8 +219,8 @@ private[chisel3] trait HasId extends InstanceId {
       _refVar = imm
     }
   }
-  private[chisel3] def setRef(parent: HasId, name: String, unbox: Boolean = false): Unit = {
-    if (!unbox) setRef(Slot(Node(parent), name))
+  private[chisel3] def setRef(parent: HasId, name: String, opaque: Boolean = false): Unit = {
+    if (!opaque) setRef(Slot(Node(parent), name))
     else setRef(OpaqueSlot(Node(parent), name))
   }
 

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -219,13 +219,13 @@ private[chisel3] trait HasId extends InstanceId {
       _refVar = imm
     }
   }
-  private[chisel3] def setRef(parent: HasId, name:  String, unbox: Boolean = false): Unit = {
+  private[chisel3] def setRef(parent: HasId, name: String, unbox: Boolean = false): Unit = {
     if (!unbox) setRef(Slot(Node(parent), name))
     else setRef(OpaqueSlot(Node(parent), name))
   }
 
-  private[chisel3] def setRef(parent: HasId, index: Int):    Unit = setRef(Index(Node(parent), ILit(index)))
-  private[chisel3] def setRef(parent: HasId, index: UInt):   Unit = setRef(Index(Node(parent), index.ref))
+  private[chisel3] def setRef(parent: HasId, index: Int):  Unit = setRef(Index(Node(parent), ILit(index)))
+  private[chisel3] def setRef(parent: HasId, index: UInt): Unit = setRef(Index(Node(parent), index.ref))
   private[chisel3] def getRef:       Arg = _ref.get
   private[chisel3] def getOptionRef: Option[Arg] = _ref
 

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -219,7 +219,11 @@ private[chisel3] trait HasId extends InstanceId {
       _refVar = imm
     }
   }
-  private[chisel3] def setRef(parent: HasId, name:  String): Unit = setRef(Slot(Node(parent), name))
+  private[chisel3] def setRef(parent: HasId, name:  String, unbox: Boolean = false): Unit = {
+    if (!unbox) setRef(Slot(Node(parent), name))
+    else setRef(UnboxedSlot(Node(parent), name))
+  }
+
   private[chisel3] def setRef(parent: HasId, index: Int):    Unit = setRef(Index(Node(parent), ILit(index)))
   private[chisel3] def setRef(parent: HasId, index: UInt):   Unit = setRef(Index(Node(parent), index.ref))
   private[chisel3] def getRef:       Arg = _ref.get
@@ -470,6 +474,7 @@ private[chisel3] object Builder extends LazyLogging {
     def buildAggName(id: HasId): Option[String] = {
       def getSubName(field: Data): Option[String] = field.getOptionRef.flatMap {
         case Slot(_, field)       => Some(field) // Record
+        case UnboxedSlot(_, field) => None // Record with single element
         case Index(_, ILit(n))    => Some(n.toString) // Vec static indexing
         case Index(_, ULit(n, _)) => Some(n.toString) // Vec lit indexing
         case Index(_, _: Node) => None // Vec dynamic indexing

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -221,7 +221,7 @@ private[chisel3] trait HasId extends InstanceId {
   }
   private[chisel3] def setRef(parent: HasId, name:  String, unbox: Boolean = false): Unit = {
     if (!unbox) setRef(Slot(Node(parent), name))
-    else setRef(UnboxedSlot(Node(parent), name))
+    else setRef(OpaqueSlot(Node(parent), name))
   }
 
   private[chisel3] def setRef(parent: HasId, index: Int):    Unit = setRef(Index(Node(parent), ILit(index)))
@@ -474,7 +474,7 @@ private[chisel3] object Builder extends LazyLogging {
     def buildAggName(id: HasId): Option[String] = {
       def getSubName(field: Data): Option[String] = field.getOptionRef.flatMap {
         case Slot(_, field)       => Some(field) // Record
-        case UnboxedSlot(_, field) => None // Record with single element
+        case OpaqueSlot(_, field) => None // Record with single element
         case Index(_, ILit(n))    => Some(n.toString) // Vec static indexing
         case Index(_, ULit(n, _)) => Some(n.toString) // Vec lit indexing
         case Index(_, _: Node) => None // Vec dynamic indexing

--- a/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
@@ -68,8 +68,8 @@ private[chisel3] object Converter {
       fir.Reference(name, fir.UnknownType)
     case Slot(imm, name) =>
       fir.SubField(convert(imm, ctx, info), name, fir.UnknownType)
-    case UnboxedSlot(imm, name) =>
-      fir.Reference(name)
+    case OpaqueSlot(imm, name) =>
+      convert(imm, ctx, info)
     case Index(imm, ILit(idx)) =>
       fir.SubIndex(convert(imm, ctx, info), castToInt(idx, "Index"), fir.UnknownType)
     case Index(imm, value) =>

--- a/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
@@ -303,7 +303,7 @@ private[chisel3] object Converter {
     case d: Interval   => fir.IntervalType(d.range.lowerBound, d.range.upperBound, d.range.firrtlBinaryPoint)
     case d: Analog     => fir.AnalogType(convert(d.width))
     case d: Vec[_] => fir.VectorType(extractType(d.sample_element, clearDir, info), d.length)
-    case d: Record =>  {
+    case d: Record => {
       val childClearDir = clearDir ||
         d.specifiedDirection == SpecifiedDirection.Input || d.specifiedDirection == SpecifiedDirection.Output
       def eltField(elt: Data): fir.Field = (childClearDir, firrtlUserDirOf(elt)) match {
@@ -319,7 +319,7 @@ private[chisel3] object Converter {
         extractType(d.elements.head._2, true, info)
     }
   }
-  
+
   def convert(name: String, param: Param): fir.Param = param match {
     case IntParam(value)    => fir.IntParam(name, value)
     case DoubleParam(value) => fir.DoubleParam(name, value)

--- a/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
@@ -69,7 +69,7 @@ private[chisel3] object Converter {
     case Slot(imm, name) =>
       fir.SubField(convert(imm, ctx, info), name, fir.UnknownType)
     case UnboxedSlot(imm, name) =>
-      fir.Reference(name, fir.UnknownType)
+      fir.Reference(name)
     case Index(imm, ILit(idx)) =>
       fir.SubIndex(convert(imm, ctx, info), castToInt(idx, "Index"), fir.UnknownType)
     case Index(imm, value) =>
@@ -303,7 +303,7 @@ private[chisel3] object Converter {
     case d: Interval   => fir.IntervalType(d.range.lowerBound, d.range.upperBound, d.range.firrtlBinaryPoint)
     case d: Analog     => fir.AnalogType(convert(d.width))
     case d: Vec[_] => fir.VectorType(extractType(d.sample_element, clearDir, info), d.length)
-    case d: Record =>
+    case d: Record =>  {
       val childClearDir = clearDir ||
         d.specifiedDirection == SpecifiedDirection.Input || d.specifiedDirection == SpecifiedDirection.Output
       def eltField(elt: Data): fir.Field = (childClearDir, firrtlUserDirOf(elt)) match {
@@ -313,9 +313,13 @@ private[chisel3] object Converter {
         case (false, SpecifiedDirection.Flip | SpecifiedDirection.Input) =>
           fir.Field(getRef(elt, info).name, fir.Flip, extractType(elt, false, info))
       }
-      fir.BundleType(d.elements.toIndexedSeq.reverse.map { case (_, e) => eltField(e) })
+      if (!d.opaqueType)
+        fir.BundleType(d.elements.toIndexedSeq.reverse.map { case (_, e) => eltField(e) })
+      else
+        extractType(d.elements.head._2, true, info)
+    }
   }
-
+  
   def convert(name: String, param: Param): fir.Param = param match {
     case IntParam(value)    => fir.IntParam(name, value)
     case DoubleParam(value) => fir.DoubleParam(name, value)

--- a/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
@@ -68,6 +68,8 @@ private[chisel3] object Converter {
       fir.Reference(name, fir.UnknownType)
     case Slot(imm, name) =>
       fir.SubField(convert(imm, ctx, info), name, fir.UnknownType)
+    case UnboxedSlot(imm, name) =>
+      fir.Reference(name, fir.UnknownType)
     case Index(imm, ILit(idx)) =>
       fir.SubIndex(convert(imm, ctx, info), castToInt(idx, "Index"), fir.UnknownType)
     case Index(imm, value) =>

--- a/core/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -93,12 +93,11 @@ object Arg {
     case Some(Slot(Node(imm), name))         => s"${earlyLocalName(imm)}.$name"
     case Some(OpaqueSlot(Node(imm), name))   => s"${earlyLocalName(imm)}"
     case Some(arg)                           => arg.name
-    case None => {
+    case None =>
       id match {
-        case data: Data => data._computeName(Some("?")).get;
+        case data: Data => data._computeName(Some("?")).get
         case _ => "?"
       }
-    }
   }
 }
 
@@ -195,10 +194,8 @@ case class Ref(name: String) extends Arg
   * @param name the name of the port
   */
 case class ModuleIO(mod: BaseModule, name: String) extends Arg {
-  override def contextualName(ctx: Component): String = {
-    if (mod eq ctx.id) { println(s"port: name $name"); name }
-    else { println(s"port: ${mod.getRef.name}.$name"); s"${mod.getRef.name}.$name" }
-  }
+  override def contextualName(ctx: Component): String =
+    if (mod eq ctx.id) name else s"${mod.getRef.name}.$name"
 }
 
 /** Ports of cloned modules (CloneModuleAsRecord)

--- a/core/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -92,8 +92,7 @@ object Arg {
       s"${earlyLocalName(imm)}[${earlyLocalName(imm)}]"
     case Some(Index(Node(imm), arg))         => s"${earlyLocalName(imm)}[${arg.localName}]"
     case Some(Slot(Node(imm), name))         => s"${earlyLocalName(imm)}.$name"
-    case Some(UnboxedSlot(Node(imm), name)) => {
-    println(s"in earlylocalname; imm: $imm, name: $name, ${earlyLocalName(imm)}"); s"${earlyLocalName(imm)}"}
+    case Some(OpaqueSlot(Node(imm), name)) => s"${earlyLocalName(imm)}"
     case Some(arg)                           => arg.name
     case None => {
       id match {
@@ -225,7 +224,7 @@ case class Slot(imm: Node, name: String) extends Arg {
   }
 }
 
-case class UnboxedSlot(imm: Node, name: String) extends Arg {
+case class OpaqueSlot(imm: Node, name: String) extends Arg {
   override def contextualName(ctx: Component): String = imm.name
   override def localName: String = imm.name
 }

--- a/core/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -88,19 +88,14 @@ case class Node(id: HasId) extends Arg {
 
 object Arg {
   def earlyLocalName(id: HasId): String = id.getOptionRef match {
-    case Some(Index(Node(imm), Node(value))) =>
-      s"${earlyLocalName(imm)}[${earlyLocalName(imm)}]"
-    case Some(Index(Node(imm), arg))       => s"${earlyLocalName(imm)}[${arg.localName}]"
-    case Some(Slot(Node(imm), name))       => s"${earlyLocalName(imm)}.$name"
-    case Some(OpaqueSlot(Node(imm), name)) => s"${earlyLocalName(imm)}"
-    case Some(arg)                         => arg.name
+    case Some(Index(Node(imm), Node(value))) => s"${earlyLocalName(imm)}[${earlyLocalName(imm)}]"
+    case Some(Index(Node(imm), arg))         => s"${earlyLocalName(imm)}[${arg.localName}]"
+    case Some(Slot(Node(imm), name))         => s"${earlyLocalName(imm)}.$name"
+    case Some(OpaqueSlot(Node(imm), name))   => s"${earlyLocalName(imm)}"
+    case Some(arg)                           => arg.name
     case None => {
       id match {
-        case data: Data => {
-          val k = data._computeName(Some("?")).get;
-          println(k);
-          k
-        }
+        case data: Data => data._computeName(Some("?")).get;
         case _ => "?"
       }
     }

--- a/core/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -88,15 +88,21 @@ case class Node(id: HasId) extends Arg {
 
 object Arg {
   def earlyLocalName(id: HasId): String = id.getOptionRef match {
-    case Some(Index(Node(imm), Node(value))) => s"${earlyLocalName(imm)}[${earlyLocalName(imm)}]"
+    case Some(Index(Node(imm), Node(value))) => 
+      s"${earlyLocalName(imm)}[${earlyLocalName(imm)}]"
     case Some(Index(Node(imm), arg))         => s"${earlyLocalName(imm)}[${arg.localName}]"
     case Some(Slot(Node(imm), name))         => s"${earlyLocalName(imm)}.$name"
+    case Some(UnboxedSlot(Node(imm), name)) => {
+    println(s"in earlylocalname; imm: $imm, name: $name, ${earlyLocalName(imm)}"); s"${earlyLocalName(imm)}"}
     case Some(arg)                           => arg.name
-    case None =>
+    case None => {
       id match {
-        case data: Data => data._computeName(Some("?")).get
+        case data: Data => {val k = data._computeName(Some("?")).get;
+      println(k);
+    k}
         case _ => "?"
       }
+    }
   }
 }
 
@@ -193,8 +199,9 @@ case class Ref(name: String) extends Arg
   * @param name the name of the port
   */
 case class ModuleIO(mod: BaseModule, name: String) extends Arg {
-  override def contextualName(ctx: Component): String =
-    if (mod eq ctx.id) name else s"${mod.getRef.name}.$name"
+  override def contextualName(ctx: Component): String = {
+    if (mod eq ctx.id) {println(s"port: name $name"); name} else {println(s"port: ${mod.getRef.name}.$name"); s"${mod.getRef.name}.$name"}
+  }
 }
 
 /** Ports of cloned modules (CloneModuleAsRecord)
@@ -219,8 +226,8 @@ case class Slot(imm: Node, name: String) extends Arg {
 }
 
 case class UnboxedSlot(imm: Node, name: String) extends Arg {
-  override def contextualName(ctx: Component): String = name
-  override def localName: String = name
+  override def contextualName(ctx: Component): String = imm.name
+  override def localName: String = imm.name
 }
 
 

--- a/core/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -88,17 +88,19 @@ case class Node(id: HasId) extends Arg {
 
 object Arg {
   def earlyLocalName(id: HasId): String = id.getOptionRef match {
-    case Some(Index(Node(imm), Node(value))) => 
+    case Some(Index(Node(imm), Node(value))) =>
       s"${earlyLocalName(imm)}[${earlyLocalName(imm)}]"
-    case Some(Index(Node(imm), arg))         => s"${earlyLocalName(imm)}[${arg.localName}]"
-    case Some(Slot(Node(imm), name))         => s"${earlyLocalName(imm)}.$name"
+    case Some(Index(Node(imm), arg))       => s"${earlyLocalName(imm)}[${arg.localName}]"
+    case Some(Slot(Node(imm), name))       => s"${earlyLocalName(imm)}.$name"
     case Some(OpaqueSlot(Node(imm), name)) => s"${earlyLocalName(imm)}"
-    case Some(arg)                           => arg.name
+    case Some(arg)                         => arg.name
     case None => {
       id match {
-        case data: Data => {val k = data._computeName(Some("?")).get;
-      println(k);
-    k}
+        case data: Data => {
+          val k = data._computeName(Some("?")).get;
+          println(k);
+          k
+        }
         case _ => "?"
       }
     }
@@ -199,7 +201,8 @@ case class Ref(name: String) extends Arg
   */
 case class ModuleIO(mod: BaseModule, name: String) extends Arg {
   override def contextualName(ctx: Component): String = {
-    if (mod eq ctx.id) {println(s"port: name $name"); name} else {println(s"port: ${mod.getRef.name}.$name"); s"${mod.getRef.name}.$name"}
+    if (mod eq ctx.id) { println(s"port: name $name"); name }
+    else { println(s"port: ${mod.getRef.name}.$name"); s"${mod.getRef.name}.$name" }
   }
 }
 
@@ -228,7 +231,6 @@ case class OpaqueSlot(imm: Node, name: String) extends Arg {
   override def contextualName(ctx: Component): String = imm.name
   override def localName: String = imm.name
 }
-
 
 case class Index(imm: Arg, value: Arg) extends Arg {
   def name: String = s"[$value]"

--- a/core/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -218,6 +218,12 @@ case class Slot(imm: Node, name: String) extends Arg {
   }
 }
 
+case class UnboxedSlot(imm: Node, name: String) extends Arg {
+  override def contextualName(ctx: Component): String = name
+  override def localName: String = name
+}
+
+
 case class Index(imm: Arg, value: Arg) extends Arg {
   def name: String = s"[$value]"
   override def contextualName(ctx: Component): String = s"${imm.contextualName(ctx)}[${value.contextualName(ctx)}]"

--- a/src/test/scala/chiselTests/RecordSpec.scala
+++ b/src/test/scala/chiselTests/RecordSpec.scala
@@ -108,6 +108,56 @@ trait RecordSpecUtils {
     require(DataMirror.checkTypeEquivalence(wire0, wire1))
     require(!DataMirror.checkTypeEquivalence(wire1, wire2))
   }
+
+  class SingleElementRecord extends Record {
+    private val underlying = UInt(8.W)
+    val elements = SeqMap("" -> underlying)
+    override def opaqueType = elements.size == 1
+    override def cloneType: this.type = this
+
+    def +(that: SingleElementRecord): SingleElementRecord = {
+      val _w = Wire(new SingleElementRecord)
+      _w.underlying := this.underlying + that.underlying
+      _w
+    }
+  }
+
+  class SingleElementRecordModule extends Module {
+    val in1 = IO(Input(new SingleElementRecord))
+    val in2 = IO(Input(new SingleElementRecord))
+    val out = IO(Output(new SingleElementRecord))
+
+    out := in1 + in2
+  }
+
+  class NamedSingleElementRecord extends Record {
+    private val underlying = UInt(8.W)
+    val elements = SeqMap("unused" -> underlying)
+
+    override def opaqueType = elements.size == 1
+    override def cloneType: this.type = this
+  }
+
+  class NamedSingleElementModule extends Module {
+    val in = IO(Input(new NamedSingleElementRecord))
+    val out = IO(Output(new NamedSingleElementRecord))
+    out := in
+  }
+
+  class ErroneousOverride extends Record {
+    private val underlyingA = UInt(8.W)
+    private val underlyingB = UInt(8.W)
+    val elements = SeqMap("x" -> underlyingA, "y" -> underlyingB)
+
+    override def opaqueType = true
+    override def cloneType: this.type = this
+  }
+
+  class ErroneousOverrideModule extends Module {
+    val in = IO(Input(new ErroneousOverride))
+    val out = IO(Output(new ErroneousOverride))
+    out := in
+  }
 }
 
 class RecordSpec extends ChiselFlatSpec with RecordSpecUtils with Utils {
@@ -146,68 +196,23 @@ class RecordSpec extends ChiselFlatSpec with RecordSpecUtils with Utils {
     e.getMessage should include("contains aliased fields named (bar,foo)")
   }
 
-  they should "be OpaqueType for single element maps" in {
-    class SingleElementRecord extends Record {
-      private val underlying = UInt(8.W)
-      val elements = SeqMap("" -> underlying)
-      override def opaqueType = elements.size == 1
-      override def cloneType: this.type = this
-
-      def +(that: SingleElementRecord): SingleElementRecord = {
-        val _w = Wire(new SingleElementRecord)
-        _w.underlying := this.underlying + that.underlying
-        _w
-      }
-    }
-
-    class NamedSingleElementRecord extends Record {
-      private val underlying = UInt(8.W)
-      val elements = SeqMap("unused" -> underlying)
-
-      override def opaqueType = elements.size == 1
-      override def cloneType: this.type = this
-    }
-
-    class ErroneousOverride extends Record {
-      private val underlyingA = UInt(8.W)
-      private val underlyingB = UInt(8.W)
-      val elements = SeqMap("x" -> underlyingA, "y" -> underlyingB)
-
-      override def opaqueType = true
-      override def cloneType: this.type = this
-    }
-
-    val singleElementChirrtl = ChiselStage.emitChirrtl {
-      new Module {
-        val in1 = IO(Input(new SingleElementRecord))
-        val in2 = IO(Input(new SingleElementRecord))
-        val out = IO(Output(new SingleElementRecord))
-
-        out := in1 + in2
-      }
-    }
+  they should "be OpaqueType for maps with single unnamed elements" in {
+    val singleElementChirrtl = ChiselStage.emitChirrtl { new SingleElementRecordModule }
     singleElementChirrtl should include("input in1 : UInt<8>")
     singleElementChirrtl should include("input in2 : UInt<8>")
     singleElementChirrtl should include("add(in1, in2)")
+  }
 
-    (the[AssertionError] thrownBy extractCause[AssertionError] {
-      ChiselStage.elaborate {
-        new Module {
-          val in = IO(Input(new ErroneousOverride))
-          val out = IO(Output(new ErroneousOverride))
-          out := in
-        }
-      }
-    }).getMessage should include("Size of elements must be 1 if opaqueType == true")
+  they should "throw an error when map contains a named element and opaqueType is overriden to true" in {
+    (the[Exception] thrownBy extractCause[Exception] {
+      ChiselStage.elaborate { new NamedSingleElementModule }
+    }).getMessage should include("Opaque types must have exactly one element with an empty name")
+  }
 
-    val namedElementChirrtl = ChiselStage.emitChirrtl {
-      new Module {
-        val in = IO(Input(new NamedSingleElementRecord))
-        val out = IO(Output(new SingleElementRecord))
-        out := in
-      }
-    }
-    namedElementChirrtl should include("input in : UInt<8>")
+  they should "throw an error when map contains more than one element and opaqueType is overriden to true" in {
+    (the[Exception] thrownBy extractCause[Exception] {
+      ChiselStage.elaborate { new ErroneousOverrideModule }
+    }).getMessage should include("Opaque types must have exactly one element with an empty name")
   }
 
   they should "follow UInt serialization/deserialization API" in {

--- a/src/test/scala/chiselTests/RecordSpec.scala
+++ b/src/test/scala/chiselTests/RecordSpec.scala
@@ -190,7 +190,7 @@ class RecordSpec extends ChiselFlatSpec with RecordSpecUtils with Utils {
           out := in
         }
       }
-    }).getMessage should include("opaqueType is true")
+    }).getMessage should include("opaqueType cannot be true")
   }
 
   they should "follow UInt serialization/deserialization API" in {

--- a/src/test/scala/chiselTests/RecordSpec.scala
+++ b/src/test/scala/chiselTests/RecordSpec.scala
@@ -146,8 +146,8 @@ class RecordSpec extends ChiselFlatSpec with RecordSpecUtils with Utils {
     e.getMessage should include("contains aliased fields named (bar,foo)")
   }
 
-  they should "unbox Record for single element maps" in {
-   class SingleElementRecord extends Record {
+  they should "be OpaqueType for single element maps" in {
+    class SingleElementRecord extends Record {
       private val underlying = UInt(8.W)
       val elements = SeqMap("" -> underlying)
       override def opaqueType = elements.size == 1
@@ -159,19 +159,19 @@ class RecordSpec extends ChiselFlatSpec with RecordSpecUtils with Utils {
         _w
       }
     }
-    val x = () => new Module {
+
+    val chirrtl = ChiselStage.emitChirrtl {
+      new Module {
         val in1 = IO(Input(new SingleElementRecord))
         val in2 = IO(Input(new SingleElementRecord))
         val out = IO(Output(new SingleElementRecord))
 
         out := in1 + in2
+      }
     }
-    val chirrtl = ChiselStage.emitChirrtl(x())
-    /* val elaboration = ChiselStage.elaborate(x()) */
-    /* val verilog = ChiselStage.emitVerilog(x()) */
-    println(chirrtl)
-    /* println(elaboration) */
-    /* println(verilog) */
+    chirrtl should include("input in1 : UInt<8>")
+    chirrtl should include("input in2 : UInt<8>")
+    chirrtl should include("add(in1, in2)")
   }
 
   they should "follow UInt serialization/deserialization API" in {

--- a/src/test/scala/chiselTests/RecordSpec.scala
+++ b/src/test/scala/chiselTests/RecordSpec.scala
@@ -160,8 +160,6 @@ trait RecordSpecUtils {
     val out = IO(Output(new ErroneousOverride))
     out := in
   }
-
-  var m: SingleElementRecordModule = _
 }
 
 class RecordSpec extends ChiselFlatSpec with RecordSpecUtils with Utils {
@@ -220,12 +218,14 @@ class RecordSpec extends ChiselFlatSpec with RecordSpecUtils with Utils {
   }
 
   they should "work with .toTarget" in {
+    var m: SingleElementRecordModule = _
     ChiselStage.elaborate { m = new SingleElementRecordModule; m }
     val q = m.in1.toTarget.toString
     assert(q == "~SingleElementRecordModule|SingleElementRecordModule>in1")
   }
 
   they should "NOT work with .toTarget on non-data OpaqueType Record" in {
+    var m: SingleElementRecordModule = _
     ChiselStage.elaborate { m = new SingleElementRecordModule; m }
     a[ChiselException] shouldBe thrownBy { m.r.toTarget }
   }

--- a/src/test/scala/chiselTests/RecordSpec.scala
+++ b/src/test/scala/chiselTests/RecordSpec.scala
@@ -146,6 +146,31 @@ class RecordSpec extends ChiselFlatSpec with RecordSpecUtils with Utils {
     e.getMessage should include("contains aliased fields named (bar,foo)")
   }
 
+  they should "unbox Record for single element maps" in {
+   class SingleElementRecord extends Record {
+      private val underlying = UInt(8.W)
+      val elements = SeqMap("" -> underlying)
+      override def opaqueType = elements.size == 1
+      override def cloneType: this.type = this
+
+      def +(that: SingleElementRecord): SingleElementRecord = {
+        val _w = Wire(new SingleElementRecord)
+        _w.underlying := this.underlying + that.underlying
+        _w
+      }
+    }
+    val chirrtl = ChiselStage.emitChirrtl{
+      new Module {
+        val in1 = IO(Input(new SingleElementRecord))
+        val in2 = IO(Input(new SingleElementRecord))
+        val out = IO(Output(new SingleElementRecord))
+
+        out := in1 + in2
+      }
+    }
+    println(chirrtl)
+  }
+
   they should "follow UInt serialization/deserialization API" in {
     assertTesterPasses { new RecordSerializationTest }
   }

--- a/src/test/scala/chiselTests/RecordSpec.scala
+++ b/src/test/scala/chiselTests/RecordSpec.scala
@@ -162,7 +162,6 @@ trait RecordSpecUtils {
   }
 
   var m: SingleElementRecordModule = _
-  ChiselStage.elaborate { m = new SingleElementRecordModule; m }
 }
 
 class RecordSpec extends ChiselFlatSpec with RecordSpecUtils with Utils {
@@ -221,11 +220,13 @@ class RecordSpec extends ChiselFlatSpec with RecordSpecUtils with Utils {
   }
 
   they should "work with .toTarget" in {
+    ChiselStage.elaborate { m = new SingleElementRecordModule; m }
     val q = m.in1.toTarget.toString
     assert(q == "~SingleElementRecordModule|SingleElementRecordModule>in1")
   }
 
   they should "NOT work with .toTarget on non-data OpaqueType Record" in {
+    ChiselStage.elaborate { m = new SingleElementRecordModule; m }
     a[ChiselException] shouldBe thrownBy { m.r.toTarget }
   }
 

--- a/src/test/scala/chiselTests/RecordSpec.scala
+++ b/src/test/scala/chiselTests/RecordSpec.scala
@@ -127,6 +127,8 @@ trait RecordSpecUtils {
     val in2 = IO(Input(new SingleElementRecord))
     val out = IO(Output(new SingleElementRecord))
 
+    val r = new SingleElementRecord
+
     out := in1 + in2
   }
 
@@ -158,6 +160,9 @@ trait RecordSpecUtils {
     val out = IO(Output(new ErroneousOverride))
     out := in
   }
+
+  var m: SingleElementRecordModule = _
+  ChiselStage.elaborate { m = new SingleElementRecordModule; m }
 }
 
 class RecordSpec extends ChiselFlatSpec with RecordSpecUtils with Utils {
@@ -213,6 +218,15 @@ class RecordSpec extends ChiselFlatSpec with RecordSpecUtils with Utils {
     (the[Exception] thrownBy extractCause[Exception] {
       ChiselStage.elaborate { new ErroneousOverrideModule }
     }).getMessage should include("Opaque types must have exactly one element with an empty name")
+  }
+
+  they should "work with .toTarget" in {
+    val q = m.in1.toTarget.toString
+    assert(q == "~SingleElementRecordModule|SingleElementRecordModule>in1")
+  }
+
+  they should "NOT work with .toTarget on non-data OpaqueType Record" in {
+    a[ChiselException] shouldBe thrownBy { m.r.toTarget }
   }
 
   they should "follow UInt serialization/deserialization API" in {

--- a/src/test/scala/chiselTests/RecordSpec.scala
+++ b/src/test/scala/chiselTests/RecordSpec.scala
@@ -159,16 +159,19 @@ class RecordSpec extends ChiselFlatSpec with RecordSpecUtils with Utils {
         _w
       }
     }
-    val chirrtl = ChiselStage.emitChirrtl{
-      new Module {
+    val x = () => new Module {
         val in1 = IO(Input(new SingleElementRecord))
         val in2 = IO(Input(new SingleElementRecord))
         val out = IO(Output(new SingleElementRecord))
 
         out := in1 + in2
-      }
     }
+    val chirrtl = ChiselStage.emitChirrtl(x())
+    /* val elaboration = ChiselStage.elaborate(x()) */
+    /* val verilog = ChiselStage.emitVerilog(x()) */
     println(chirrtl)
+    /* println(elaboration) */
+    /* println(verilog) */
   }
 
   they should "follow UInt serialization/deserialization API" in {


### PR DESCRIPTION
`OpaqueType` allows simplifying `Record` references when the `Record` subtypes have single map elements

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
 - new feature/API               

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->
New override for Records for single element types
#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->
If `Record.opaqueType` is overridden to `true`, the generated CHIRRTL will substitute name of the `Record` for that of the subfield, and substitute type of the subfield for type of the `Record`

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
- Squash: The PR will be squashed and merged (choose this if you have no preference.
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
Add new override in Record to support opaque types

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
