### PR TITLE
Add ability to suppress enum cast warnings

### DIFF
--- a/core/src/main/scala/chisel3/StrongEnum.scala
+++ b/core/src/main/scala/chisel3/StrongEnum.scala
@@ -413,7 +413,7 @@ private object UnsafeEnum extends EnumFactory
 object suppressEnumCastWarning {
 
   /**
-    * Execute @block while suppressing enum cast warnings.
+    * Execute block while suppressing enum cast warnings.
     */
   def apply[T](block: => T): T = {
     val parentWarn = Builder.suppressEnumCastWarning

--- a/core/src/main/scala/chisel3/StrongEnum.scala
+++ b/core/src/main/scala/chisel3/StrongEnum.scala
@@ -410,11 +410,24 @@ private[chisel3] class UnsafeEnum(override val width: Width) extends EnumType(Un
 }
 private object UnsafeEnum extends EnumFactory
 
+/** Suppress enum cast warnings
+ *
+ * Users should use [[EnumFactory.safe <EnumType>.safe]] when possible.
+ *
+ * This is primarily used for casting from [[UInt]] to a Bundle type that contains an Enum.
+ * {{{
+ * class MyBundle extends Bundle {
+ *   val addr = UInt(8.W)
+ *   val op = OpEnum()
+ * }
+ *
+ * // Since this is a cast to a Bundle, cannot use OpCode.safe                                                                                    
+ * val bundle = suppressEnumCastWarning {
+ *   someUInt.asTypeOf(new MyBundle)
+ * }
+ * }}}
+ */
 object suppressEnumCastWarning {
-
-  /**
-    * Execute block while suppressing enum cast warnings.
-    */
   def apply[T](block: => T): T = {
     val parentWarn = Builder.suppressEnumCastWarning
 

--- a/core/src/main/scala/chisel3/StrongEnum.scala
+++ b/core/src/main/scala/chisel3/StrongEnum.scala
@@ -411,22 +411,22 @@ private[chisel3] class UnsafeEnum(override val width: Width) extends EnumType(Un
 private object UnsafeEnum extends EnumFactory
 
 /** Suppress enum cast warnings
- *
- * Users should use [[EnumFactory.safe <EnumType>.safe]] when possible.
- *
- * This is primarily used for casting from [[UInt]] to a Bundle type that contains an Enum.
- * {{{
- * class MyBundle extends Bundle {
- *   val addr = UInt(8.W)
- *   val op = OpEnum()
- * }
- *
- * // Since this is a cast to a Bundle, cannot use OpCode.safe                                                                                    
- * val bundle = suppressEnumCastWarning {
- *   someUInt.asTypeOf(new MyBundle)
- * }
- * }}}
- */
+  *
+  * Users should use [[EnumFactory.safe <EnumType>.safe]] when possible.
+  *
+  * This is primarily used for casting from [[UInt]] to a Bundle type that contains an Enum.
+  * {{{
+  * class MyBundle extends Bundle {
+  *   val addr = UInt(8.W)
+  *   val op = OpEnum()
+  * }
+  *
+  * // Since this is a cast to a Bundle, cannot use OpCode.safe                                                                                    
+  * val bundle = suppressEnumCastWarning {
+  *   someUInt.asTypeOf(new MyBundle)
+  * }
+  * }}}
+  */
 object suppressEnumCastWarning {
   def apply[T](block: => T): T = {
     val parentWarn = Builder.suppressEnumCastWarning

--- a/core/src/main/scala/chisel3/StrongEnum.scala
+++ b/core/src/main/scala/chisel3/StrongEnum.scala
@@ -411,6 +411,10 @@ private[chisel3] class UnsafeEnum(override val width: Width) extends EnumType(Un
 private object UnsafeEnum extends EnumFactory
 
 object suppressEnumCastWarning {
+
+  /**
+    * Execute @block while suppressing enum cast warnings.
+    */
   def apply[T](block: => T): T = {
     val parentWarn = Builder.suppressEnumCastWarning
 

--- a/core/src/main/scala/chisel3/StrongEnum.scala
+++ b/core/src/main/scala/chisel3/StrongEnum.scala
@@ -421,7 +421,7 @@ private object UnsafeEnum extends EnumFactory
   *   val op = OpEnum()
   * }
   *
-  * // Since this is a cast to a Bundle, cannot use OpCode.safe                                                                                    
+  * // Since this is a cast to a Bundle, cannot use OpCode.safe
   * val bundle = suppressEnumCastWarning {
   *   someUInt.asTypeOf(new MyBundle)
   * }

--- a/core/src/main/scala/chisel3/StrongEnum.scala
+++ b/core/src/main/scala/chisel3/StrongEnum.scala
@@ -339,7 +339,7 @@ abstract class EnumFactory {
     } else if (n.getWidth > this.getWidth) {
       throwException(s"The UInt being cast to $enumTypeName is wider than $enumTypeName's width ($getWidth)")
     } else {
-      if (warn && !this.isTotal) {
+      if (!Builder.suppressEnumCastWarning && warn && !this.isTotal) {
         Builder.warning(
           s"Casting non-literal UInt to $enumTypeName. You can use $enumTypeName.safe to cast without this warning."
         )
@@ -409,3 +409,16 @@ private[chisel3] class UnsafeEnum(override val width: Width) extends EnumType(Un
   override def cloneType: this.type = new UnsafeEnum(width).asInstanceOf[this.type]
 }
 private object UnsafeEnum extends EnumFactory
+
+object suppressEnumCastWarning {
+  def apply[T](block: => T): T = {
+    val parentWarn = Builder.suppressEnumCastWarning
+
+    Builder.suppressEnumCastWarning = true
+
+    val res = block // execute block
+
+    Builder.suppressEnumCastWarning = parentWarn
+    res
+  }
+}

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -409,6 +409,7 @@ private[chisel3] object Builder extends LazyLogging {
     dynamicContextVar.value.get
   }
 
+  // Used to suppress warnings when casting from a UInt to an Enum
   var suppressEnumCastWarning: Boolean = false
 
   // Returns the current dynamic context

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -392,6 +392,7 @@ private[chisel3] class DynamicContext(
   var currentReset:         Option[Reset] = None
   val errors = new ErrorLog
   val namingStack = new NamingStack
+
   // Used to indicate if this is the top-level module of full elaboration, or from a Definition
   var inDefinition: Boolean = false
 }
@@ -407,6 +408,8 @@ private[chisel3] object Builder extends LazyLogging {
     require(dynamicContextVar.value.isDefined, "must be inside Builder context")
     dynamicContextVar.value.get
   }
+
+  var suppressEnumCastWarning: Boolean = false
 
   // Returns the current dynamic context
   def captureContext(): DynamicContext = dynamicContext

--- a/docs/src/explanations/chisel-enum.md
+++ b/docs/src/explanations/chisel-enum.md
@@ -175,7 +175,7 @@ class SuppressedFromUInt extends Module {
   val in = IO(Input(UInt(7.W)))
   val out = IO(Output(Opcode()))
   suppressEnumCastWarning {
-    val value = Opcode.safe(in)
+    val value = Opcode(in)
     out := value
   }
 }

--- a/docs/src/explanations/chisel-enum.md
+++ b/docs/src/explanations/chisel-enum.md
@@ -168,15 +168,21 @@ val (log2, _) = grabLog(ChiselStage.emitChirrtl(new SafeFromUInt))
 println(s"```\n$log2```")
 ```
 
-You can also suppress the warning by using `suppressEnumCastWarning`:
+You can also suppress the warning by using `suppressEnumCastWarning`. This is
+primarily used for casting from [[UInt]] to a Bundle type that contains an
+Enum, where the [[UInt]] is known to be valid for the Bundle type.
 
 ```scala mdoc
+class MyBundle extends Bundle {
+  val addr = UInt(8.W)
+  val op = Opcode()
+}
+
 class SuppressedFromUInt extends Module {
-  val in = IO(Input(UInt(7.W)))
-  val out = IO(Output(Opcode()))
+  val in = IO(Input(UInt(15.W)))
+  val out = IO(Output(new MyBundle()))
   suppressEnumCastWarning {
-    val value = Opcode(in)
-    out := value
+    out := in.asTypeOf(new MyBundle)
   }
 }
 ```

--- a/docs/src/explanations/chisel-enum.md
+++ b/docs/src/explanations/chisel-enum.md
@@ -17,6 +17,7 @@ import chisel3._
 import chisel3.util._
 import chisel3.stage.ChiselStage
 import chisel3.experimental.ChiselEnum
+import chisel3.experimental.suppressEnumCastWarning
 ```
 
 ```scala mdoc:invisible
@@ -165,6 +166,19 @@ Now there will be no warning:
 ```scala mdoc:passthrough
 val (log2, _) = grabLog(ChiselStage.emitChirrtl(new SafeFromUInt))
 println(s"```\n$log2```")
+```
+
+You can also suppress the warning by using `suppressEnumCastWarning`:
+
+```scala mdoc
+class SuppressedFromUInt extends Module {
+  val in = IO(Input(UInt(7.W)))
+  val out = IO(Output(Opcode()))
+  suppressEnumCastWarning {
+    val value = Opcode.safe(in)
+    out := value
+  }
+}
 ```
 
 ## Testing

--- a/docs/src/explanations/chisel-enum.md
+++ b/docs/src/explanations/chisel-enum.md
@@ -187,6 +187,11 @@ class SuppressedFromUInt extends Module {
 }
 ```
 
+```scala mdoc:invisible
+val (log3, _) = grabLog(ChiselStage.emitChirrtl(new SuppressedFromUInt))
+assert(log3.isEmpty)
+```
+
 ## Testing
 
 The _Type_ of the enums values is `<ChiselEnum Object>.Type` which can be useful for passing the values

--- a/src/test/scala/chiselTests/StrongEnum.scala
+++ b/src/test/scala/chiselTests/StrongEnum.scala
@@ -5,6 +5,7 @@ package chiselTests
 import chisel3._
 import chisel3.experimental.ChiselEnum
 import chisel3.experimental.AffectsChiselPrefix
+import chisel3.experimental.suppressEnumCastWarning
 import chisel3.internal.firrtl.UnknownWidth
 import chisel3.stage.{ChiselGeneratorAnnotation, ChiselStage}
 import chisel3.util._
@@ -513,6 +514,23 @@ class StrongEnumSpec extends ChiselFlatSpec with Utils {
 
   it should "correctly check if the enumeration is one of the values in a given sequence" in {
     assertTesterPasses(new IsOneOfTester)
+  }
+
+  it should "suppress warning using suppressEnumCastWarning" in {
+    object TestEnum extends ChiselEnum {
+      val e0, e1, e2 = Value
+    }
+
+    class MyModule extends Module {
+      val in = IO(Input(UInt(2.W)))
+      val out = IO(Output(TestEnum()))
+      suppressEnumCastWarning {
+        val res = TestEnum(in)
+        out := res
+      }
+    }
+    val (log, _) = grabLog(ChiselStage.elaborate(new MyModule))
+    (log should not).include("warn")
   }
 }
 

--- a/src/test/scala/chiselTests/StrongEnum.scala
+++ b/src/test/scala/chiselTests/StrongEnum.scala
@@ -482,6 +482,46 @@ class StrongEnumSpec extends ChiselFlatSpec with Utils {
     (log should not).include("warn")
   }
 
+  it should "suppress warning using suppressEnumCastWarning" in {
+    object TestEnum extends ChiselEnum {
+      val e0, e1, e2 = Value
+    }
+
+    class MyModule extends Module {
+      val in = IO(Input(UInt(2.W)))
+      val out = IO(Output(TestEnum()))
+      suppressEnumCastWarning {
+        val res = TestEnum(in)
+        out := res
+      }
+    }
+    val (log, _) = grabLog(ChiselStage.elaborate(new MyModule))
+    (log should not).include("warn")
+  }
+
+  it should "suppress exactly one warning using suppressEnumCastWarning" in {
+    object TestEnum1 extends ChiselEnum {
+      val e0, e1, e2 = Value
+    }
+    object TestEnum2 extends ChiselEnum {
+      val e0, e1, e2 = Value
+    }
+
+    class MyModule extends Module {
+      val in = IO(Input(UInt(2.W)))
+      val out1 = IO(Output(TestEnum1()))
+      val out2 = IO(Output(TestEnum2()))
+      suppressEnumCastWarning {
+        out1 := TestEnum1(in)
+      }
+      out2 := TestEnum2(in)
+    }
+    val (log, _) = grabLog(ChiselStage.elaborate(new MyModule))
+    log should include("warn")
+    log should include("TestEnum2") // not suppressed
+    (log should not).include("TestEnum1") // suppressed
+  }
+
   "Casting a UInt to an Enum with .safe" should "NOT warn" in {
     object MyEnum extends ChiselEnum {
       val e0, e1, e2 = Value
@@ -514,23 +554,6 @@ class StrongEnumSpec extends ChiselFlatSpec with Utils {
 
   it should "correctly check if the enumeration is one of the values in a given sequence" in {
     assertTesterPasses(new IsOneOfTester)
-  }
-
-  it should "suppress warning using suppressEnumCastWarning" in {
-    object TestEnum extends ChiselEnum {
-      val e0, e1, e2 = Value
-    }
-
-    class MyModule extends Module {
-      val in = IO(Input(UInt(2.W)))
-      val out = IO(Output(TestEnum()))
-      suppressEnumCastWarning {
-        val res = TestEnum(in)
-        out := res
-      }
-    }
-    val (log, _) = grabLog(ChiselStage.elaborate(new MyModule))
-    (log should not).include("warn")
   }
 }
 


### PR DESCRIPTION
Casting a UInt to an Enum causes an unsuppressable warning. In some cases the designer can guarantee that the UInt is in fact a valid enum state (for example the UInt was created by casting an Enum value, or has been otherwise verified). In those cases it should be possible for the designer to suppress the warning. Sometimes a cast happens through another function like `asTypeOf`, so using `.safe` to avoid the warning is not practical.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
- new feature/API

#### API Impact

This adds a new object for suppressing enum cast warnings.

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

#### Backend Code Generation Impact

No change.

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

#### Desired Merge Strategy

Squash.

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

The `suppressEnumCastWarning` object can be used to prevent a block from generating enum cast warnings.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
