### PR TITLE
Show equivalent warnings/errors only once

### DIFF
--- a/core/src/main/scala/chisel3/internal/Error.scala
+++ b/core/src/main/scala/chisel3/internal/Error.scala
@@ -177,21 +177,24 @@ private[chisel3] object ErrorLog {
 }
 
 private[chisel3] class ErrorLog {
-
-  def getLoc: String = {
-    getUserLineNumber match {
+  def getLoc(loc: Option[StackTraceElement]): String = {
+    loc match {
       case Some(elt: StackTraceElement) => s"${elt.getFileName}:${elt.getLineNumber}"
       case None => "(unknown)"
     }
   }
 
   /** Log an error message */
-  def error(m: => String): Unit =
-    errors += (((m, getLoc), new Error(m, getUserLineNumber)))
+  def error(m: => String): Unit = {
+    val loc = getUserLineNumber
+    errors += (((m, getLoc(loc)), new Error(m, loc)))
+  }
 
   /** Log a warning message */
-  def warning(m: => String): Unit =
-    errors += (((m, getLoc), new Warning(m, getUserLineNumber)))
+  def warning(m: => String): Unit = {
+    val loc = getUserLineNumber
+    errors += (((m, getLoc(loc)), new Warning(m, loc)))
+  }
 
   /** Log a warning message without a source locator. This is used when the
     * locator wouldn't be helpful (e.g., due to lazy values).
@@ -208,7 +211,7 @@ private[chisel3] class ErrorLog {
   def deprecated(m: => String, location: Option[String]): Unit = {
     val sourceLoc = location match {
       case Some(loc) => loc
-      case None      => getLoc
+      case None      => getLoc(getUserLineNumber)
     }
 
     val thisEntry = (m, sourceLoc)

--- a/core/src/main/scala/chisel3/internal/Error.scala
+++ b/core/src/main/scala/chisel3/internal/Error.scala
@@ -193,9 +193,11 @@ private[chisel3] class ErrorLog {
   def warning(m: => String): Unit =
     errors += (((m, getLoc), new Warning(m, getUserLineNumber)))
 
-  /** Log a warning message without a source locator */
+  /** Log a warning message without a source locator. This is used when the
+    * locator wouldn't be helpful (e.g., due to lazy values).
+    */
   def warningNoLoc(m: => String): Unit =
-    errors += (((m, getLoc), new Warning(m, None)))
+    errors += (((m, ""), new Warning(m, None)))
 
   /** Emit an informational message */
   @deprecated("This method will be removed in 3.5", "3.4")
@@ -206,7 +208,7 @@ private[chisel3] class ErrorLog {
   def deprecated(m: => String, location: Option[String]): Unit = {
     val sourceLoc = location match {
       case Some(loc) => loc
-      case None => getLoc
+      case None      => getLoc
     }
 
     val thisEntry = (m, sourceLoc)

--- a/core/src/main/scala/chisel3/internal/Error.scala
+++ b/core/src/main/scala/chisel3/internal/Error.scala
@@ -178,18 +178,24 @@ private[chisel3] object ErrorLog {
 
 private[chisel3] class ErrorLog {
 
+  def getLoc: String = {
+    getUserLineNumber match {
+      case Some(elt: StackTraceElement) => s"${elt.getFileName}:${elt.getLineNumber}"
+      case None => "(unknown)"
+    }
+  }
+
   /** Log an error message */
   def error(m: => String): Unit =
-    errors += new Error(m, getUserLineNumber)
+    errors += (((m, getLoc), new Error(m, getUserLineNumber)))
 
   /** Log a warning message */
   def warning(m: => String): Unit =
-    errors += new Warning(m, getUserLineNumber)
+    errors += (((m, getLoc), new Warning(m, getUserLineNumber)))
 
   /** Log a warning message without a source locator */
-  def warningNoLoc(m: => String): Unit = {
-    errors += new Warning(m, None)
-  }
+  def warningNoLoc(m: => String): Unit =
+    errors += (((m, getLoc), new Warning(m, None)))
 
   /** Emit an informational message */
   @deprecated("This method will be removed in 3.5", "3.4")
@@ -200,11 +206,7 @@ private[chisel3] class ErrorLog {
   def deprecated(m: => String, location: Option[String]): Unit = {
     val sourceLoc = location match {
       case Some(loc) => loc
-      case None =>
-        getUserLineNumber match {
-          case Some(elt: StackTraceElement) => s"${elt.getFileName}:${elt.getLineNumber}"
-          case None => "(unknown)"
-        }
+      case None => getLoc
     }
 
     val thisEntry = (m, sourceLoc)
@@ -217,7 +219,7 @@ private[chisel3] class ErrorLog {
       case ((message, sourceLoc), count) =>
         logger.warn(s"${ErrorLog.depTag} $sourceLoc ($count calls): $message")
     }
-    errors.foreach(e => logger.error(e.toString))
+    errors.foreach(e => logger.error(e._2.toString))
 
     if (!deprecations.isEmpty) {
       logger.warn(
@@ -233,8 +235,8 @@ private[chisel3] class ErrorLog {
       logger.warn(s"""${ErrorLog.warnTag}     scalacOptions := Seq("-unchecked", "-deprecation")""")
     }
 
-    val allErrors = errors.filter(_.isFatal)
-    val allWarnings = errors.filter(!_.isFatal)
+    val allErrors = errors.filter(_._2.isFatal)
+    val allWarnings = errors.filter(!_._2.isFatal)
 
     if (!allWarnings.isEmpty && !allErrors.isEmpty) {
       logger.warn(
@@ -289,7 +291,7 @@ private[chisel3] class ErrorLog {
       .headOption
   }
 
-  private val errors = ArrayBuffer[LogEntry]()
+  private val errors = LinkedHashMap[(String, String), LogEntry]()
   private val deprecations = LinkedHashMap[(String, String), Int]()
 
   private val startTime = System.currentTimeMillis

--- a/src/test/scala/chiselTests/WarningSpec.scala
+++ b/src/test/scala/chiselTests/WarningSpec.scala
@@ -6,6 +6,7 @@ import chisel3._
 import chisel3.util._
 import chisel3.stage.{ChiselGeneratorAnnotation, ChiselStage}
 import chisel3.experimental.ChiselEnum
+import chisel3.experimental.EnumType
 import chiselTests.ChiselFlatSpec
 
 class WarningSpec extends ChiselFlatSpec with Utils {
@@ -20,7 +21,11 @@ class WarningSpec extends ChiselFlatSpec with Utils {
       val in = IO(Input(UInt(2.W)))
       val out1 = IO(Output(MyEnum()))
       val out2 = IO(Output(MyEnum()))
-      out1 := MyEnum(in); out2 := MyEnum(in)
+      def func(out: EnumType): Unit = {
+        out := MyEnum(in)
+      }
+      func(out1)
+      func(out2)
     }
     val (log, _) = grabLog(ChiselStage.elaborate(new MyModule))
     def countSubstring(s: String, sub: String) =

--- a/src/test/scala/chiselTests/WarningSpec.scala
+++ b/src/test/scala/chiselTests/WarningSpec.scala
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiselTests
+
+import chisel3._
+import chisel3.util._
+import chisel3.stage.{ChiselGeneratorAnnotation, ChiselStage}
+import chisel3.experimental.ChiselEnum
+import chiselTests.ChiselFlatSpec
+
+class WarningSpec extends ChiselFlatSpec with Utils {
+  behavior.of("Warnings")
+
+  "Warnings" should "be de-duplicated" in {
+    object MyEnum extends ChiselEnum {
+      val e0, e1, e2 = Value
+    }
+
+    class MyModule extends Module {
+      val in = IO(Input(UInt(2.W)))
+      val out1 = IO(Output(MyEnum()))
+      val out2 = IO(Output(MyEnum()))
+      out1 := MyEnum(in); out2 := MyEnum(in)
+    }
+    val (log, _) = grabLog(ChiselStage.elaborate(new MyModule))
+    def countSubstring(s: String, sub: String) =
+      s.sliding(sub.length).count(_ == sub)
+    countSubstring(log, "Casting non-literal UInt") should be(1)
+  }
+}


### PR DESCRIPTION
Sometimes one line of source code can end up generating the same warning or error multiple times. With this change, multiple equivalent warnings/errors generated from the same source code location will only be shown once. This de-duplication uses the same approach as the de-duplication that currently exists for deprecation warnings.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
- new feature/API

#### API Impact

Multiple equivalent warnings generated from the same location will now only be shown once.

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

#### Backend Code Generation Impact

No codegen change.

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

#### Desired Merge Strategy

Squash

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

Multiple equivalent warnings generated from the same location will now only be shown once.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
