### PR TITLE
Provide a better error message for use of .toTarget on non-hardware value

### DIFF
--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -239,8 +239,10 @@ private[chisel3] trait HasId extends InstanceId {
 
   private def refName(c: Component): String = _ref match {
     case Some(arg) => arg.fullName(c)
-    case None =>
-      throwException("You cannot access the .instanceName or .toTarget of non-hardware Data")
+    case None => {
+      val nameGuess = _computeName(None).get
+      throwException(s"You cannot access the .instanceName or .toTarget of non-hardware Data: '$nameGuess', in module '$parentPathName'")
+    }
   }
 
   // Helper for reifying views if they map to a single Target

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -242,12 +242,12 @@ private[chisel3] trait HasId extends InstanceId {
     case None => {
       val nameGuess = _computeName(None) match {
         case Some(name) => s": '$name'"
-        case None => ""
+        case None       => ""
       }
       val parentGuess = _parent match {
         case Some(ViewParent) => s", in module '${reifyParent.pathName}'"
-        case Some(p) => s", in module '${p.pathName}'"
-        case None => ""
+        case Some(p)          => s", in module '${p.pathName}'"
+        case None             => ""
       }
       throwException("You cannot access the .instanceName or .toTarget of non-hardware Data" + nameGuess + parentGuess)
     }

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -240,8 +240,16 @@ private[chisel3] trait HasId extends InstanceId {
   private def refName(c: Component): String = _ref match {
     case Some(arg) => arg.fullName(c)
     case None => {
-      val nameGuess = _computeName(None).get
-      throwException(s"You cannot access the .instanceName or .toTarget of non-hardware Data: '$nameGuess', in module '$parentPathName'")
+      val nameGuess = _computeName(None) match {
+        case Some(name) => s": '$name'"
+        case None => ""
+      }
+      val parentGuess = _parent match {
+        case Some(ViewParent) => s", in module '${reifyParent.pathName}'"
+        case Some(p) => s", in module '${p.pathName}'"
+        case None => ""
+      }
+      throwException("You cannot access the .instanceName or .toTarget of non-hardware Data" + nameGuess + parentGuess)
     }
   }
 

--- a/src/test/scala/chiselTests/ToTargetSpec.scala
+++ b/src/test/scala/chiselTests/ToTargetSpec.scala
@@ -44,7 +44,7 @@ class ToTargetSpec extends ChiselFlatSpec with Utils {
     assert(q == s"~$mn|Queue")
   }
 
-  it should "error on non-hardware types with information" in {
+  it should "error on non-hardware types and provide information" in {
     class Example extends Module {
       val tpe = UInt(8.W)
 

--- a/src/test/scala/chiselTests/ToTargetSpec.scala
+++ b/src/test/scala/chiselTests/ToTargetSpec.scala
@@ -58,6 +58,8 @@ class ToTargetSpec extends ChiselFlatSpec with Utils {
       chisel3.stage.ChiselStage.elaborate { e = new Example; e }
       e.tpe.toTarget
     }
-    e.getMessage should include("You cannot access the .instanceName or .toTarget of non-hardware Data: 'tpe', in module 'Example'")
+    e.getMessage should include(
+      "You cannot access the .instanceName or .toTarget of non-hardware Data: 'tpe', in module 'Example'"
+    )
   }
 }

--- a/src/test/scala/chiselTests/ToTargetSpec.scala
+++ b/src/test/scala/chiselTests/ToTargetSpec.scala
@@ -43,4 +43,21 @@ class ToTargetSpec extends ChiselFlatSpec with Utils {
     val q = m.q.toTarget.toString
     assert(q == s"~$mn|Queue")
   }
+
+  it should "error on non-hardware types with information" in {
+    class Example extends Module {
+      val tpe = UInt(8.W)
+
+      val in = IO(Input(tpe))
+      val out = IO(Output(tpe))
+      out := in
+    }
+
+    val e = the[ChiselException] thrownBy extractCause[ChiselException] {
+      var e: Example = null
+      chisel3.stage.ChiselStage.elaborate { e = new Example; e }
+      e.tpe.toTarget
+    }
+    e.getMessage should include("You cannot access the .instanceName or .toTarget of non-hardware Data: 'tpe', in module 'Example'")
+  }
 }


### PR DESCRIPTION
Error messages from using `.toTarget` on a non-hardware type now provide the name of the value and the parent module. I will also open a separate version of this PR for 3.5.x that uses a deprecation warning instead of an error.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
- code cleanup
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact
Error messages for `.toTarget` now provide the name of the value and the parent module.
<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

#### Backend Code Generation Impact
None
<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
- Squash
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

Error messages from using `.toTarget` on a non-hardware type now provide the name of the value and the parent module.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
