### PR TITLE
Backport of eager error messages for annotations (3.5.x) (#2700)

### DIFF
--- a/src/main/scala/chisel3/util/experimental/ForceNames.scala
+++ b/src/main/scala/chisel3/util/experimental/ForceNames.scala
@@ -3,6 +3,7 @@
 package chisel3.util.experimental
 
 import chisel3.experimental.{annotate, ChiselAnnotation, RunFirrtlTransform}
+import chisel3.internal.Builder
 import firrtl.Mappers._
 import firrtl._
 import firrtl.annotations._
@@ -24,6 +25,7 @@ object forceName {
     * @param name Name to force to
     */
   def apply[T <: chisel3.Element](signal: T, name: String): T = {
+    if (!signal.isSynthesizable) Builder.deprecated(s"Using forceName '$name' on non-hardware value $signal")
     annotate(new ChiselAnnotation with RunFirrtlTransform {
       def toFirrtl = ForceNameAnnotation(signal.toTarget, name)
       override def transformClass: Class[_ <: Transform] = classOf[ForceNamesTransform]
@@ -37,6 +39,7 @@ object forceName {
     * @param signal Signal to name
     */
   def apply[T <: chisel3.Element](signal: T): T = {
+    if (!signal.isSynthesizable) Builder.deprecated(s"Using forceName on non-hardware value $signal")
     annotate(new ChiselAnnotation with RunFirrtlTransform {
       def toFirrtl = ForceNameAnnotation(signal.toTarget, signal.toTarget.ref)
       override def transformClass: Class[_ <: Transform] = classOf[ForceNamesTransform]

--- a/src/main/scala/chisel3/util/experimental/decode/decoder.scala
+++ b/src/main/scala/chisel3/util/experimental/decode/decoder.scala
@@ -6,6 +6,7 @@ import chisel3._
 import chisel3.experimental.{annotate, ChiselAnnotation}
 import chisel3.util.{pla, BitPat}
 import chisel3.util.experimental.{getAnnotations, BitSet}
+import chisel3.internal.Builder
 import firrtl.annotations.Annotation
 import logger.LazyLogging
 
@@ -30,6 +31,8 @@ object decoder extends LazyLogging {
       val (plaInput, plaOutput) =
         pla(minimizedTable.table.toSeq, BitPat(minimizedTable.default.value.U(minimizedTable.default.getWidth.W)))
 
+      if (!plaOutput.isSynthesizable)
+        Builder.deprecated(s"Using DecodeTableAnnotation on non-hardware value $plaOutput")
       annotate(new ChiselAnnotation {
         override def toFirrtl: Annotation =
           DecodeTableAnnotation(plaOutput.toTarget, truthTable.toString, minimizedTable.toString)

--- a/src/main/scala/chisel3/util/experimental/decode/decoder.scala
+++ b/src/main/scala/chisel3/util/experimental/decode/decoder.scala
@@ -31,8 +31,7 @@ object decoder extends LazyLogging {
       val (plaInput, plaOutput) =
         pla(minimizedTable.table.toSeq, BitPat(minimizedTable.default.value.U(minimizedTable.default.getWidth.W)))
 
-      if (!plaOutput.isSynthesizable)
-        Builder.deprecated(s"Using DecodeTableAnnotation on non-hardware value $plaOutput")
+      assert(plaOutput.isSynthesizable, s"Using DecodeTableAnnotation on non-hardware value $plaOutput")
       annotate(new ChiselAnnotation {
         override def toFirrtl: Annotation =
           DecodeTableAnnotation(plaOutput.toTarget, truthTable.toString, minimizedTable.toString)

--- a/src/test/scala/chiselTests/experimental/ForceNames.scala
+++ b/src/test/scala/chiselTests/experimental/ForceNames.scala
@@ -59,7 +59,7 @@ object ForceNamesHierarchy {
   }
 }
 
-class ForceNamesSpec extends ChiselFlatSpec {
+class ForceNamesSpec extends ChiselFlatSpec with Utils {
 
   def run[T <: RawModule](
     dut:        => T,
@@ -109,5 +109,20 @@ class ForceNamesSpec extends ChiselFlatSpec {
         Seq(ForceNameAnnotation(ReferenceTarget("BundleName", "BundleName", Nil, "in", Nil), "inn"))
       )
     }
+  }
+
+  "Force Name of non-hardware value" should "warn" in {
+    class Example extends Module {
+      val tpe = UInt(8.W)
+      forceName(tpe, "foobar")
+
+      val in = IO(Input(tpe))
+      val out = IO(Output(tpe))
+      out := in
+    }
+
+    val (log, foo) = grabLog(chisel3.stage.ChiselStage.elaborate(new Example))
+    log should include("deprecated")
+    log should include("Using forceName 'foobar' on non-hardware value UInt<8>")
   }
 }


### PR DESCRIPTION
This is a backport of #2700 for 3.5.x using deprecation warnings instead of errors.