### PR TITLE
Add lexical scope checks to Assert, Assume and Printf

### DIFF
--- a/core/src/main/scala/chisel3/Data.scala
+++ b/core/src/main/scala/chisel3/Data.scala
@@ -672,7 +672,7 @@ abstract class Data extends HasId with NamedComponent with SourceInfoDoc {
     */
   private[chisel3] def typeEquivalent(that: Data): Boolean
 
-  private def requireVisible(): Unit = {
+  private[chisel3] def requireVisible(): Unit = {
     val mod = topBindingOpt.flatMap(_.location)
     topBindingOpt match {
       case Some(tb: TopBinding) if (mod == Builder.currentModule) =>

--- a/core/src/main/scala/chisel3/Printable.scala
+++ b/core/src/main/scala/chisel3/Printable.scala
@@ -147,7 +147,7 @@ object Printable {
     }
 
     message match {
-      case Some(x) => getData(x).map(_.requireVisible())
+      case Some(x) => getData(x).foreach(_.requireVisible())
       case _       =>
     }
   }

--- a/core/src/main/scala/chisel3/Printable.scala
+++ b/core/src/main/scala/chisel3/Printable.scala
@@ -45,6 +45,8 @@ import java.util.{MissingFormatArgumentException, UnknownFormatConversionExcepti
 // TODO Should we provide more functions like map and mkPrintable?
 sealed abstract class Printable {
 
+  val context = internal.Builder.currentModule
+
   /** Unpack into format String and a List of String arguments (identifiers)
     * @note This must be called after elaboration when Chisel nodes actually
     *   have names

--- a/core/src/main/scala/chisel3/Printable.scala
+++ b/core/src/main/scala/chisel3/Printable.scala
@@ -45,8 +45,6 @@ import java.util.{MissingFormatArgumentException, UnknownFormatConversionExcepti
 // TODO Should we provide more functions like map and mkPrintable?
 sealed abstract class Printable {
 
-  val context = internal.Builder.currentModule
-
   /** Unpack into format String and a List of String arguments (identifiers)
     * @note This must be called after elaboration when Chisel nodes actually
     *   have names

--- a/core/src/main/scala/chisel3/Printable.scala
+++ b/core/src/main/scala/chisel3/Printable.scala
@@ -135,7 +135,7 @@ object Printable {
     StringContext(bufEscapeBackSlash.toSeq: _*).cf(data: _*)
   }
 
-  private[chisel3] def checkScope(message: Option[Printable]): Unit = {
+  private[chisel3] def checkScope(message: Printable): Unit = {
     def getData(x: Printable): Seq[Data] = {
       x match {
         case y: FirrtlFormat => Seq(y.bits)
@@ -145,11 +145,7 @@ object Printable {
         case _             => Seq() // Handles subtypes PString and Percent
       }
     }
-
-    message match {
-      case Some(x) => getData(x).foreach(_.requireVisible())
-      case _       =>
-    }
+    getData(message).foreach(_.requireVisible())
   }
 }
 

--- a/core/src/main/scala/chisel3/Printable.scala
+++ b/core/src/main/scala/chisel3/Printable.scala
@@ -136,6 +136,23 @@ object Printable {
     val bufEscapeBackSlash = buf.map(_.replace("\\", "\\\\"))
     StringContext(bufEscapeBackSlash.toSeq: _*).cf(data: _*)
   }
+
+  private[chisel3] def checkScope(message: Option[Printable]): Unit = {
+    def getData(x: Printable): Seq[Data] = {
+      x match {
+        case y: FirrtlFormat => Seq(y.bits)
+        case Name(d)       => Seq(d)
+        case FullName(d)   => Seq(d)
+        case Printables(p) => p.flatMap(getData(_)).toSeq
+        case _             => Seq() // Handles subtypes PString and Percent
+      }
+    }
+
+    message match {
+      case Some(x) => getData(x).map(_.requireVisible())
+      case _       =>
+    }
+  }
 }
 
 case class Printables(pables: Iterable[Printable]) extends Printable {

--- a/core/src/main/scala/chisel3/Printf.scala
+++ b/core/src/main/scala/chisel3/Printf.scala
@@ -108,6 +108,14 @@ object printf {
   ): Printf = {
     val clock = Builder.forcedClock
     val printfId = new Printf(pable)
+
+    if (Builder.currentModule != pable.context) {
+      val currentModuleString = Builder.currentModule.map(_.name).getOrElse("(unknown module)")
+      Builder.error(
+        s"Printable was built in a different module ${pable.context.map(_.name).getOrElse("(unknown module)")} than where it was invoked ($currentModuleString)"
+      )
+    }
+
     pushCommand(chisel3.internal.firrtl.Printf(printfId, sourceInfo, clock.ref, pable))
     printfId
   }

--- a/core/src/main/scala/chisel3/Printf.scala
+++ b/core/src/main/scala/chisel3/Printf.scala
@@ -109,7 +109,7 @@ object printf {
     val clock = Builder.forcedClock
     val printfId = new Printf(pable)
 
-    Printable.checkScope(Some(pable))
+    Printable.checkScope(pable)
 
     pushCommand(chisel3.internal.firrtl.Printf(printfId, sourceInfo, clock.ref, pable))
     printfId

--- a/core/src/main/scala/chisel3/Printf.scala
+++ b/core/src/main/scala/chisel3/Printf.scala
@@ -100,23 +100,6 @@ object printf {
     printfId
   }
 
-  def checkScope(message: Option[Printable]): Unit = {
-    def getData(x: Printable): Seq[Data] = {
-      x match {
-        case y: FirrtlFormat => Seq(y.bits)
-        case Name(d)       => Seq(d)
-        case FullName(d)   => Seq(d)
-        case Printables(p) => p.flatMap(getData(_)).toSeq
-        case _             => Seq() // Handles subtypes PString and Percent
-      }
-    }
-
-    message match {
-      case Some(x) => getData(x).map(_.requireVisible())
-      case _       =>
-    }
-  }
-
   private[chisel3] def printfWithoutReset(
     pable: Printable
   )(
@@ -126,7 +109,7 @@ object printf {
     val clock = Builder.forcedClock
     val printfId = new Printf(pable)
 
-    checkScope(Some(pable))
+    Printable.checkScope(Some(pable))
 
     pushCommand(chisel3.internal.firrtl.Printf(printfId, sourceInfo, clock.ref, pable))
     printfId

--- a/core/src/main/scala/chisel3/VerificationStatement.scala
+++ b/core/src/main/scala/chisel3/VerificationStatement.scala
@@ -178,7 +178,7 @@ object assert extends VerifPrintMacrosDoc {
     compileOptions:      CompileOptions
   ): Assert = {
     val id = new Assert()
-    Printable.checkScope(message)
+    message.foreach(Printable.checkScope(_))
     when(!Module.reset.asBool()) {
       failureMessage("Assertion", line, cond, message)
       Builder.pushCommand(Verification(id, Formal.Assert, sourceInfo, Module.clock.ref, cond.ref, ""))
@@ -344,7 +344,7 @@ object assume extends VerifPrintMacrosDoc {
     compileOptions:      CompileOptions
   ): Assume = {
     val id = new Assume()
-    Printable.checkScope(message)
+    message.foreach(Printable.checkScope(_))
     when(!Module.reset.asBool()) {
       failureMessage("Assumption", line, cond, message)
       Builder.pushCommand(Verification(id, Formal.Assume, sourceInfo, Module.clock.ref, cond.ref, ""))

--- a/src/test/scala/chiselTests/Assert.scala
+++ b/src/test/scala/chiselTests/Assert.scala
@@ -92,8 +92,8 @@ class PrintableScopeTester extends Module {
   val w = Wire(UInt(8.W))
   w := 255.U
 
-  val printableWire = p"$w"
-  val printablePort = p"$in"
+  val printableWire = cf"$w"
+  val printablePort = cf"$in"
 }
 
 class AssertPrintableWireScope extends BasicTester {

--- a/src/test/scala/chiselTests/Assert.scala
+++ b/src/test/scala/chiselTests/Assert.scala
@@ -73,6 +73,30 @@ class PrintableBadUnescapedPercentAssertTester extends BasicTester {
   stop()
 }
 
+class AssumePrintableFailingScope extends BasicTester {
+  ChiselStage.elaborate {
+    new Module {
+      val mod = Module(new PrintableScopeTester)
+      assume(1.U === 1.U, mod.printable)
+    }
+  }
+  stop()
+}
+
+class PrintableScopeTester extends Module {
+  val in = IO(Input(UInt(8.W)))
+  val out = IO(Output(UInt(8.W)))
+  out := in
+
+  val printable = p"${in}"
+}
+
+class AssertPrintableFailingScope extends BasicTester {
+  val mod = Module(new PrintableScopeTester)
+  assert(1.U === 2.U, mod.printable)
+  stop()
+}
+
 class PrintableAssumeTester extends Module {
   val in = IO(Input(UInt(8.W)))
   val out = IO(Output(UInt(8.W)))
@@ -94,6 +118,14 @@ class AssertSpec extends ChiselFlatSpec with Utils {
   "An assertion" should "not assert until we come out of reset" in {
     assertTesterPasses { new PipelinedResetTester }
   }
+  "Assert Printables" should "respect scope" in {
+    a[ChiselException] should be thrownBy { assertTesterPasses { new AssertPrintableFailingScope } }
+  }
+
+  "Assume Printables" should "respect scope" in {
+    a[ChiselException] should be thrownBy { assertTesterPasses { new AssumePrintableFailingScope } }
+  }
+
   "Assertions" should "allow the modulo operator % in the message" in {
     assertTesterPasses { new ModuloAssertTester }
   }

--- a/src/test/scala/chiselTests/Assert.scala
+++ b/src/test/scala/chiselTests/Assert.scala
@@ -104,13 +104,14 @@ class AssertPrintableWireScope extends BasicTester {
 
 class AssertPrintablePortScope extends BasicTester {
   val mod = Module(new PrintableScopeTester)
-  assert(1.U === 2.U, mod.printablePort)
+  mod.in := 255.U
+  assert(1.U === 1.U, mod.printablePort)
   stop()
 }
 
 class AssertPrintableFailingWhenScope extends BasicTester {
   val mod = Module(new PrintableWhenScopeTester)
-  assert(1.U === 2.U, mod.printable)
+  assert(1.U === 1.U, mod.printable)
   stop()
 }
 
@@ -122,6 +123,7 @@ class AssumePrintableWireScope extends BasicTester {
 
 class AssumePrintablePortScope extends BasicTester {
   val mod = Module(new PrintableScopeTester)
+  mod.in := 255.U
   assume(1.U === 1.U, mod.printablePort)
   stop()
 }

--- a/src/test/scala/chiselTests/Assert.scala
+++ b/src/test/scala/chiselTests/Assert.scala
@@ -171,18 +171,18 @@ class AssertSpec extends ChiselFlatSpec with Utils {
     assertTesterPasses { new AssertPrintablePortScope }
   }
   "Assert Printables" should "respect wire scoping" in {
-    a[ChiselException] should be thrownBy { assertTesterPasses { new AssertPrintableWireScope } }
+    a[ChiselException] should be thrownBy { ChiselStage.elaborate(new AssertPrintableWireScope) }
   }
   "Assume Printables" should "respect port scoping" in {
     assertTesterPasses { new AssumePrintablePortScope }
   }
 
   "Assume Printables" should "respect wire scoping" in {
-    a[ChiselException] should be thrownBy { assertTesterPasses { new AssumePrintableWireScope } }
+    a[ChiselException] should be thrownBy { ChiselStage.elaborate(new AssumePrintableWireScope) }
   }
 
   "Assert Printables" should "respect when scope" in {
-    a[ChiselException] should be thrownBy { assertTesterPasses { new AssertPrintableFailingWhenScope } }
+    a[ChiselException] should be thrownBy { ChiselStage.elaborate(new AssertPrintableFailingWhenScope) }
   }
 
   "Assertions" should "allow the modulo operator % in the message" in {

--- a/src/test/scala/chiselTests/Assert.scala
+++ b/src/test/scala/chiselTests/Assert.scala
@@ -103,42 +103,26 @@ class AssertPrintableWireScope extends BasicTester {
 }
 
 class AssertPrintablePortScope extends BasicTester {
-  ChiselStage.elaborate {
-    new Module {
-      val mod = Module(new PrintableScopeTester)
-      assert(1.U === 2.U, mod.printablePort)
-    }
-  }
+  val mod = Module(new PrintableScopeTester)
+  assert(1.U === 2.U, mod.printablePort)
   stop()
 }
 
 class AssertPrintableFailingWhenScope extends BasicTester {
-  ChiselStage.elaborate {
-    new Module {
-      val mod = Module(new PrintableWhenScopeTester)
-      assert(1.U === 2.U, mod.printable)
-    }
-  }
+  val mod = Module(new PrintableWhenScopeTester)
+  assert(1.U === 2.U, mod.printable)
   stop()
 }
 
 class AssumePrintableWireScope extends BasicTester {
-  ChiselStage.elaborate {
-    new Module {
-      val mod = Module(new PrintableScopeTester)
-      assume(1.U === 1.U, mod.printableWire)
-    }
-  }
+  val mod = Module(new PrintableScopeTester)
+  assume(1.U === 1.U, mod.printableWire)
   stop()
 }
 
 class AssumePrintablePortScope extends BasicTester {
-  ChiselStage.elaborate {
-    new Module {
-      val mod = Module(new PrintableScopeTester)
-      assume(1.U === 1.U, mod.printablePort)
-    }
-  }
+  val mod = Module(new PrintableScopeTester)
+  assume(1.U === 1.U, mod.printablePort)
   stop()
 }
 

--- a/src/test/scala/chiselTests/Printf.scala
+++ b/src/test/scala/chiselTests/Printf.scala
@@ -4,6 +4,7 @@ package chiselTests
 
 import chisel3._
 import chisel3.testers.BasicTester
+import chisel3.stage.ChiselStage
 
 class SinglePrintfTester() extends BasicTester {
   val x = 254.U
@@ -28,6 +29,24 @@ class ASCIIPrintableTester extends BasicTester {
   stop()
 }
 
+class ScopeTesterModule extends Module {
+  val in = IO(Input(UInt(8.W)))
+  val out = IO(Output(UInt(8.W)))
+  out := in
+
+  val p = p"$in"
+}
+
+class PrintablePrintfScopeTester extends BasicTester {
+  ChiselStage.elaborate {
+    new Module {
+      val mod = Module(new ScopeTesterModule)
+      printf(mod.p)
+    }
+  }
+  stop()
+}
+
 class PrintfSpec extends ChiselFlatSpec {
   "A printf with a single argument" should "run" in {
     assertTesterPasses { new SinglePrintfTester }
@@ -40,5 +59,8 @@ class PrintfSpec extends ChiselFlatSpec {
   }
   "A printf with Printable ASCII characters 1-127" should "run" in {
     assertTesterPasses { new ASCIIPrintableTester }
+  }
+  "A printf with Printable with invalid scope" should "error" in {
+    a[ChiselException] should be thrownBy { assertTesterPasses { new PrintablePrintfScopeTester } }
   }
 }

--- a/src/test/scala/chiselTests/Printf.scala
+++ b/src/test/scala/chiselTests/Printf.scala
@@ -34,7 +34,11 @@ class ScopeTesterModule extends Module {
   val out = IO(Output(UInt(8.W)))
   out := in
 
-  val p = p"$in"
+  val w = Wire(UInt(8.W))
+  w := 125.U
+
+  val p = cf"$in"
+  val wp = cf"$w"
 }
 
 class PrintablePrintfScopeTester extends BasicTester {
@@ -42,6 +46,16 @@ class PrintablePrintfScopeTester extends BasicTester {
     new Module {
       val mod = Module(new ScopeTesterModule)
       printf(mod.p)
+    }
+  }
+  stop()
+}
+
+class PrintablePrintfWireScopeTester extends BasicTester {
+  ChiselStage.elaborate {
+    new Module {
+      val mod = Module(new ScopeTesterModule)
+      printf(mod.wp)
     }
   }
   stop()
@@ -60,7 +74,10 @@ class PrintfSpec extends ChiselFlatSpec {
   "A printf with Printable ASCII characters 1-127" should "run" in {
     assertTesterPasses { new ASCIIPrintableTester }
   }
-  "A printf with Printable with invalid scope" should "error" in {
-    a[ChiselException] should be thrownBy { assertTesterPasses { new PrintablePrintfScopeTester } }
+  "A printf with Printable" should "respect port scopes" in {
+    assertTesterPasses { new PrintablePrintfScopeTester }
+  }
+  "A printf with Printable" should "respect wire scopes" in {
+    a[ChiselException] should be thrownBy { assertTesterPasses { new PrintablePrintfWireScopeTester } }
   }
 }


### PR DESCRIPTION
When passing a `Printable` to `assert`, `assume` or `printf`, the scope of where the `Printable` was constructed should be the same as where it is being referenced. This is currently not checked, which makes it possible to construct cases where invalid FIRRTL is generated. Specifically, if the `Printable` is constructed in an inner module and referenced from an outer module, the resulting FIRRTL can have references to objects like wires or temporaries that are local to the inner module. 

For example, the following snippet

```
class InnerPrintable extends Module {
  val in = IO(Input(UInt(8.W)))
  val out = IO(Output(UInt(8.W)))

  val w = Wire(UInt(8.W))
  w := 255.U
  val p = p"$w"

  out := in
}

ChiselStage.emitChirrtl { 
  new Module {
    val mod = Module(new InnerPrintable)
    printf(mod.p)
  }
}
```
outputs the problematic FIRRTL `printf`

```
  module InnerPrintable:
    input clock : Clock
    ...

    wire w : UInt<8>
    w <= UInt<8>("hff")
    ...

module Outer_Anon :
    input clock : Clock
    ...

    node _T = bits(reset, 0, 0)
    node _T_1 = eq(_T, UInt<1>("h0"))
    when _T_1 : 
      printf(clock, UInt<1>("h1"), "%d", w) : printf
```
where the wire `w` internal to `InnerPrintable` is being accessed outside of its scope.

This PR adds checks to `assert`, `assume` and `printf` to ensure that the Builder scopes at `Printable` construction and reference are the same.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
  - bug fix                            

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->
N/A

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->
Printfs, asserts and assumes will not be present in the generated Verilog if the Printable scopes are invalid.

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
  - Squash: The PR will be squashed and merged (choose this if you have no preference. 
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
Printables (and other objects?) used in printf, assert and assume can now only be referenced in the scopes in which they were constructed

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
