### PR TITLE
Fix OpaqueSlot handling of contextual names

### DIFF
--- a/core/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -220,7 +220,7 @@ case class Slot(imm: Node, name: String) extends Arg {
 }
 
 case class OpaqueSlot(imm: Node) extends Arg {
-  override def contextualName(ctx: Component): String = imm.name
+  override def contextualName(ctx: Component): String = imm.contextualName(ctx)
   override def name: String = imm.name
 }
 


### PR DESCRIPTION
We need to ensure that contextual names stay contextual (ie. sensitive
to the module context which is important for naming ports).

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [NA] Did you add text to be included in the Release Notes for this change?

This is a bug fix in a not-yet-released feature

#### Type of Improvement

 - bug fix    

#### API Impact

No impact, just a minor bug fix

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

   - Squash

#### Release Notes


### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
