### PR TITLE
Added :<>=, :<=, :>=, :#=

### DIFF
--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -115,7 +115,6 @@ sealed abstract class Aggregate extends Data {
   }
 
   // Emits the FIRRTL `this <- that`, or `this is invalid` if that == DontCare
-  // Note that `this <= that` will be emitted if both `this` and `that` are not aggregate types
   private[chisel3] def firrtlPartialConnect(that: Data)(implicit sourceInfo: SourceInfo): Unit = {
     // If the source is a DontCare, generate a DefInvalid for the sink,
     //  otherwise, issue a Partial Connect.
@@ -280,6 +279,7 @@ sealed class Vec[T <: Data] private[chisel3] (gen: => T, val length: Int) extend
     *
     * @note the length of this Vec and that Seq must match
     * @param that the Seq to connect from
+    * @group connection
     */
   def <>(that: Seq[T])(implicit sourceInfo: SourceInfo, moduleCompileOptions: CompileOptions): Unit = {
     if (this.length != that.length)
@@ -302,6 +302,7 @@ sealed class Vec[T <: Data] private[chisel3] (gen: => T, val length: Int) extend
     * @note This is necessary in [[Aggregate]], rather than relying on [[Data.<>]], due to supporting the Seq
     * @note the length of this Vec and that Vec must match
     * @param that the Vec to connect from
+    * @group connection
     */
   def <>(that: Vec[T])(implicit sourceInfo: SourceInfo, moduleCompileOptions: CompileOptions): Unit =
     this.bulkConnect(that.asInstanceOf[Data])
@@ -315,6 +316,7 @@ sealed class Vec[T <: Data] private[chisel3] (gen: => T, val length: Int) extend
     *  - Equivalent to `this :<>= that`, with the additional restriction that the relative bundle field flips must match
     *
     * @note the length of this Vec must match the length of the input Seq
+    * @group connection
     */
   def :=(that: Seq[T])(implicit sourceInfo: SourceInfo, moduleCompileOptions: CompileOptions): Unit = {
     require(
@@ -335,6 +337,7 @@ sealed class Vec[T <: Data] private[chisel3] (gen: => T, val length: Int) extend
     *
     * @note This is necessary in [[Aggregate]], rather than relying on [[Data.:=]], due to supporting the Seq
     * @note the length of this Vec must match the length of the input Vec
+    * @group connection
     */
   def :=(that: Vec[T])(implicit sourceInfo: SourceInfo, moduleCompileOptions: CompileOptions): Unit = this.connect(that)
 

--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -274,7 +274,7 @@ sealed class Vec[T <: Data] private[chisel3] (gen: => T, val length: Int) extend
     *
     * For chisel3._, uses the [[BiConnect]] algorithm; sub-elements of `that` may end up driving sub-elements of `this`
     *  - Complicated semantics, will likely be deprecated in the future
-    * 
+    *
     * For Chisel._, emits the FIRRTL.<- operator
     *  - Equivalent to `this :<>= that` without the restrictions that bundle field names and vector sizes must match
     *
@@ -282,7 +282,10 @@ sealed class Vec[T <: Data] private[chisel3] (gen: => T, val length: Int) extend
     * @param that the Seq to connect from
     */
   def <>(that: Seq[T])(implicit sourceInfo: SourceInfo, moduleCompileOptions: CompileOptions): Unit = {
-    if (this.length != that.length) Builder.error(s"Vec (size ${this.length}) and Seq (size ${that.length}) being bulk connected have different lengths!")
+    if (this.length != that.length)
+      Builder.error(
+        s"Vec (size ${this.length}) and Seq (size ${that.length}) being bulk connected have different lengths!"
+      )
     for ((a, b) <- this.zip(that)) {
       a <> b
     }
@@ -292,7 +295,7 @@ sealed class Vec[T <: Data] private[chisel3] (gen: => T, val length: Int) extend
     *
     * For chisel3._, uses the [[BiConnect]] algorithm; sub-elements of `that` may end up driving sub-elements of `this`
     *  - Complicated semantics, hard to write quickly, will likely be deprecated in the future
-    * 
+    *
     * For Chisel._, emits the FIRRTL.<- operator
     *  - Equivalent to `this :<>= that` without the restrictions that bundle field names and vector sizes must match
     *
@@ -307,7 +310,7 @@ sealed class Vec[T <: Data] private[chisel3] (gen: => T, val length: Int) extend
     *
     * For chisel3._, this operator is mono-directioned; all sub-elements of `this` will be driven by sub-elements of `that`.
     *  - Equivalent to `this :#= that`
-    * 
+    *
     * For Chisel._, this operator connections bi-directionally via emitting the FIRRTL.<=
     *  - Equivalent to `this :<>= that`, with the additional restriction that the relative bundle field flips must match
     *
@@ -326,7 +329,7 @@ sealed class Vec[T <: Data] private[chisel3] (gen: => T, val length: Int) extend
     *
     * For chisel3._, this operator is mono-directioned; all sub-elements of `this` will be driven by sub-elements of `that`.
     *  - Equivalent to `this :#= that`
-    * 
+    *
     * For Chisel._, this operator connections bi-directionally via emitting the FIRRTL.<=
     *  - Equivalent to `this :<>= that`, with the additional restriction that the relative bundle field flips must match
     *

--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -104,13 +104,25 @@ sealed abstract class Aggregate extends Data {
 
   private[chisel3] def width: Width = getElements.map(_.width).foldLeft(0.W)(_ + _)
 
-  private[chisel3] def legacyConnect(that: Data)(implicit sourceInfo: SourceInfo): Unit = {
-    // If the source is a DontCare, generate a DefInvalid for the sink,
-    //  otherwise, issue a Connect.
+  // Emits the FIRRTL `this <= that`, or `this is invalid` if that == DontCare
+  private[chisel3] def firrtlConnect(that: Data)(implicit sourceInfo: SourceInfo): Unit = {
+    // If the source is a DontCare, generate a DefInvalid for the sink, otherwise, issue a Connect.
     if (that == DontCare) {
-      pushCommand(DefInvalid(sourceInfo, Node(this)))
+      pushCommand(DefInvalid(sourceInfo, lref))
     } else {
-      pushCommand(BulkConnect(sourceInfo, Node(this), Node(that)))
+      pushCommand(Connect(sourceInfo, lref, Node(that)))
+    }
+  }
+
+  // Emits the FIRRTL `this <- that`, or `this is invalid` if that == DontCare
+  // Note that `this <= that` will be emitted if both `this` and `that` are not aggregate types
+  private[chisel3] def firrtlPartialConnect(that: Data)(implicit sourceInfo: SourceInfo): Unit = {
+    // If the source is a DontCare, generate a DefInvalid for the sink,
+    //  otherwise, issue a Partial Connect.
+    if (that == DontCare) {
+      pushCommand(DefInvalid(sourceInfo, lref))
+    } else {
+      pushCommand(PartialConnect(sourceInfo, lref, Node(that)))
     }
   }
 
@@ -258,23 +270,46 @@ sealed class Vec[T <: Data] private[chisel3] (gen: => T, val length: Int) extend
   private[chisel3] final override def allElements: Seq[Element] =
     (sample_element +: self).flatMap(_.allElements)
 
-  /** Strong bulk connect, assigning elements in this Vec from elements in a Seq.
+  /** The "bulk connect operator", assigning elements in this Vec from elements in a Seq.
     *
-    * @note the length of this Vec must match the length of the input Seq
+    * For chisel3._, uses the [[BiConnect]] algorithm; sub-elements of `that` may end up driving sub-elements of `this`
+    *  - Complicated semantics, will likely be deprecated in the future
+    * 
+    * For Chisel._, emits the FIRRTL.<- operator
+    *  - Equivalent to `this :<>= that` without the restrictions that bundle field names and vector sizes must match
+    *
+    * @note the length of this Vec and that Seq must match
+    * @param that the Seq to connect from
     */
   def <>(that: Seq[T])(implicit sourceInfo: SourceInfo, moduleCompileOptions: CompileOptions): Unit = {
-    if (this.length != that.length) {
-      Builder.error("Vec and Seq being bulk connected have different lengths!")
-    }
-    for ((a, b) <- this.zip(that))
+    if (this.length != that.length) Builder.error(s"Vec (size ${this.length}) and Seq (size ${that.length}) being bulk connected have different lengths!")
+    for ((a, b) <- this.zip(that)) {
       a <> b
+    }
   }
 
-  // TODO: eliminate once assign(Seq) isn't ambiguous with assign(Data) since Vec extends Seq and Data
+  /** The "bulk connect operator", assigning elements in this Vec from elements in a Vec.
+    *
+    * For chisel3._, uses the [[BiConnect]] algorithm; sub-elements of `that` may end up driving sub-elements of `this`
+    *  - Complicated semantics, hard to write quickly, will likely be deprecated in the future
+    * 
+    * For Chisel._, emits the FIRRTL.<- operator
+    *  - Equivalent to `this :<>= that` without the restrictions that bundle field names and vector sizes must match
+    *
+    * @note This is necessary in [[Aggregate]], rather than relying on [[Data.<>]], due to supporting the Seq
+    * @note the length of this Vec and that Vec must match
+    * @param that the Vec to connect from
+    */
   def <>(that: Vec[T])(implicit sourceInfo: SourceInfo, moduleCompileOptions: CompileOptions): Unit =
     this.bulkConnect(that.asInstanceOf[Data])
 
-  /** Strong bulk connect, assigning elements in this Vec from elements in a Seq.
+  /** "The strong connect operator", assigning elements in this Vec from elements in a Seq.
+    *
+    * For chisel3._, this operator is mono-directioned; all sub-elements of `this` will be driven by sub-elements of `that`.
+    *  - Equivalent to `this :#= that`
+    * 
+    * For Chisel._, this operator connections bi-directionally via emitting the FIRRTL.<=
+    *  - Equivalent to `this :<>= that`, with the additional restriction that the relative bundle field flips must match
     *
     * @note the length of this Vec must match the length of the input Seq
     */
@@ -287,7 +322,17 @@ sealed class Vec[T <: Data] private[chisel3] (gen: => T, val length: Int) extend
       a := b
   }
 
-  // TODO: eliminate once assign(Seq) isn't ambiguous with assign(Data) since Vec extends Seq and Data
+  /** "The strong connect operator", assigning elements in this Vec from elements in a Vec.
+    *
+    * For chisel3._, this operator is mono-directioned; all sub-elements of `this` will be driven by sub-elements of `that`.
+    *  - Equivalent to `this :#= that`
+    * 
+    * For Chisel._, this operator connections bi-directionally via emitting the FIRRTL.<=
+    *  - Equivalent to `this :<>= that`, with the additional restriction that the relative bundle field flips must match
+    *
+    * @note This is necessary in [[Aggregate]], rather than relying on [[Data.:=]], due to supporting the Seq
+    * @note the length of this Vec must match the length of the input Vec
+    */
   def :=(that: Vec[T])(implicit sourceInfo: SourceInfo, moduleCompileOptions: CompileOptions): Unit = this.connect(that)
 
   /** Creates a dynamically indexed read or write accessor into the array.

--- a/core/src/main/scala/chisel3/Connectable.scala
+++ b/core/src/main/scala/chisel3/Connectable.scala
@@ -318,11 +318,12 @@ private[chisel3] object DirectionalConnectionFunctions {
   }
   def leafConnect(c: Data, p: Data, o: RelativeOrientation, op: ConnectionOperator)(implicit sourceInfo: SourceInfo): Unit = {
     require(!c.isInstanceOf[Aggregate] && !p.isInstanceOf[Aggregate])
-    (c, p, o, op.assignToConsumer, op.assignToProducer) match {
-      case (x: Analog, y: Analog, _, _, _) => assignAnalog(x, y)
-      case (x: Analog, DontCare, _, _, _) => assignAnalog(x, DontCare)
-      case (x, y, AlignedWithRoot, true, _) => c := p
-      case (x, y, FlippedWithRoot, _, true) => p := c
+    (c, p, o, op.assignToConsumer, op.assignToProducer, op.alwaysAssignToConsumer) match {
+      case (x: Analog, y: Analog, _, _, _, _) => assignAnalog(x, y)
+      case (x: Analog, DontCare, _, _, _, _) => assignAnalog(x, DontCare)
+      case (x, y, AlignedWithRoot, true, _, _) => c := p
+      case (x, y, FlippedWithRoot, _, true, _) => p := c
+      case (x, y, _, _, _, true) => c := p
       case other =>
     }
   }
@@ -384,6 +385,7 @@ private[chisel3] object DirectionalConnectionFunctions {
     val noWrongOrientations: Boolean
     val assignToConsumer: Boolean
     val assignToProducer: Boolean
+    val alwaysAssignToConsumer: Boolean
   }
   case object ColonLessEq extends ConnectionOperator {
     val noDangles: Boolean = false
@@ -391,6 +393,7 @@ private[chisel3] object DirectionalConnectionFunctions {
     val noWrongOrientations: Boolean = false
     val assignToConsumer: Boolean = true
     val assignToProducer: Boolean = false
+    val alwaysAssignToConsumer: Boolean = false
   }
   case object ColonGreaterEq extends ConnectionOperator {
     val noDangles: Boolean = false
@@ -398,6 +401,7 @@ private[chisel3] object DirectionalConnectionFunctions {
     val noWrongOrientations: Boolean = false
     val assignToConsumer: Boolean = false
     val assignToProducer: Boolean = true
+    val alwaysAssignToConsumer: Boolean = false
   }
   case object ColonLessGreaterEq extends ConnectionOperator {
     val noDangles: Boolean = true
@@ -405,6 +409,7 @@ private[chisel3] object DirectionalConnectionFunctions {
     val noWrongOrientations: Boolean = true
     val assignToConsumer: Boolean = true
     val assignToProducer: Boolean = true
+    val alwaysAssignToConsumer: Boolean = false
   }
   case object ColonHashEq extends ConnectionOperator {
     val noDangles: Boolean = true
@@ -412,6 +417,7 @@ private[chisel3] object DirectionalConnectionFunctions {
     val noWrongOrientations: Boolean = false
     val assignToConsumer: Boolean = true
     val assignToProducer: Boolean = false
+    val alwaysAssignToConsumer: Boolean = true
   }
 
   /** Determines the aligned/flipped of subMember with respect to activeRoot

--- a/core/src/main/scala/chisel3/Connectable.scala
+++ b/core/src/main/scala/chisel3/Connectable.scala
@@ -2,8 +2,11 @@
 
 package chisel3
 
-import internal.{Builder, BiConnect, prefix}
+import chisel3.internal.{Builder, BiConnect, prefix}
+import chisel3.internal.Builder.pushCommand
+import chisel3.internal.firrtl._
 import chisel3.internal.sourceinfo.SourceInfo
+import chisel3.experimental.{DataMirror, Analog}
 
 
 /** The default connection operators for Chisel hardware components */

--- a/core/src/main/scala/chisel3/Connectable.scala
+++ b/core/src/main/scala/chisel3/Connectable.scala
@@ -35,6 +35,7 @@ object Connectable {
       * @param consumer the left-hand-side of the connection; will always be driven by leaf connections, and never drive leaf connection ("aligned connection")
       * @param producer the right-hand-side of the connection; will always drive leaf connections, and never get driven by leaf connections ("aligned connection")
       * @param sourceInfo
+      * @group connection
       */
     final def :<=(producer: => T)(implicit sourceInfo: SourceInfo): Unit = {
       prefix(consumer) {
@@ -60,6 +61,7 @@ object Connectable {
       * @param consumer the left-hand-side of the connection; will always drive leaf connections, and never get driven by leaf connections ("flipped connection")
       * @param producer the right-hand-side of the connection; will always be driven by leaf connections, and never drive leaf connections ("flipped connection")
       * @param sourceInfo
+      * @group connection
       */
     final def :>=(producer: => T)(implicit sourceInfo: SourceInfo): Unit = {
       prefix(consumer) {
@@ -86,6 +88,7 @@ object Connectable {
       * @param consumer the left-hand-side of the connection (read above comment for more info)
       * @param producer the right-hand-side of the connection (read above comment for more info)
       * @param sourceInfo
+      * @group connection
       */
     final def :<>=(producer: => T)(implicit sourceInfo: SourceInfo): Unit = {
       prefix(consumer) {
@@ -128,6 +131,7 @@ object Connectable {
       * @param consumer the left-hand-side of the connection, all fields will be driven-to
       * @param producer the right-hand-side of the connection, all fields will be driving, none will be driven-to
       * @param sourceInfo
+      * @group connection
       */
     final def :#=(producer: => T)(implicit sourceInfo: SourceInfo): Unit = {
       consumer.:<=(producer)
@@ -159,6 +163,7 @@ object Connectable {
       * @param consumer the left-hand-side of the connection; will always be driven by leaf connections, and never drive leaf connection ("aligned connection")
       * @param producer the right-hand-side of the connection; will always drive leaf connections, and never get driven by leaf connections ("aligned connection")
       * @param sourceInfo
+      * @group connection
       */
     def :<=(producer: Seq[T])(implicit sourceInfo: SourceInfo): Unit = {
       if (consumer.length != producer.length)
@@ -186,6 +191,7 @@ object Connectable {
       * @param consumer the left-hand-side of the connection; will always drive leaf connections, and never get driven by leaf connections ("flipped connection")
       * @param producer the right-hand-side of the connection; will always be driven by leaf connections, and never drive leaf connections ("flipped connection")
       * @param sourceInfo
+      * @group connection
       */
     def :>=(producer: Seq[T])(implicit sourceInfo: SourceInfo): Unit = {
       if (consumer.length != producer.length)
@@ -214,6 +220,7 @@ object Connectable {
       * @param consumer the left-hand-side of the connection (read above comment for more info)
       * @param producer the right-hand-side of the connection (read above comment for more info)
       * @param sourceInfo
+      * @group connection
       */
     def :<>=(producer: Seq[T])(implicit sourceInfo: SourceInfo): Unit = {
       if (consumer.length != producer.length)
@@ -238,6 +245,7 @@ object Connectable {
       * @param consumer the left-hand-side of the connection, all fields will be driven-to
       * @param producer the right-hand-side of the connection, all fields will be driving, none will be driven-to
       * @param sourceInfo
+      * @group connection
       */
     def :#=(producer: Seq[T])(implicit sourceInfo: SourceInfo): Unit = {
       if (consumer.length != producer.length)

--- a/core/src/main/scala/chisel3/Connectable.scala
+++ b/core/src/main/scala/chisel3/Connectable.scala
@@ -340,8 +340,8 @@ private[chisel3] object DirectionalConnectionFunctions {
       case (path, Some(LeafConnection(Some((c, FlippedWithRoot)), None))) if(op.noDangles || op.mustMatch) => errors += (s"dangling consumer field $c")
       case (path, Some(LeafConnection(None, Some((p, AlignedWithRoot))))) if(op.noDangles || op.mustMatch) => errors += (s"dangling producer field $p")
       // Defaulting case
-      case (path, Some(LeafConnection(Some((c, AlignedWithRoot)), None))) if c.hasDefault => leafConnect(c, c.default, AlignedWithRoot, op)
-      case (path, Some(LeafConnection(None, Some((p, FlippedWithRoot))))) if p.hasDefault => leafConnect(p.default, p, FlippedWithRoot, op)
+      case (path, Some(LeafConnection(Some((c, AlignedWithRoot)), None))) if c.hasConnectableDefault => leafConnect(c, c.connectableDefault, AlignedWithRoot, op)
+      case (path, Some(LeafConnection(None, Some((p, FlippedWithRoot))))) if p.hasConnectableDefault => leafConnect(p.connectableDefault, p, FlippedWithRoot, op)
 
       // Non-defaulting case
       case (path, Some(LeafConnection(Some((c, AlignedWithRoot)), None))) if (op.noUnassigned && op.assignToConsumer) => errors += (s"unassigned consumer field $c")

--- a/core/src/main/scala/chisel3/Connectable.scala
+++ b/core/src/main/scala/chisel3/Connectable.scala
@@ -2,12 +2,11 @@
 
 package chisel3
 
-import chisel3.internal.{Builder, BiConnect, prefix}
+import chisel3.internal.{prefix, BiConnect, Builder}
 import chisel3.internal.Builder.pushCommand
 import chisel3.internal.firrtl._
 import chisel3.internal.sourceinfo.SourceInfo
-import chisel3.experimental.{DataMirror, Analog}
-
+import chisel3.experimental.{Analog, DataMirror}
 
 /** The default connection operators for Chisel hardware components */
 object Connectable {
@@ -19,7 +18,7 @@ object Connectable {
   implicit class ConnectableData[T <: Data](consumer: T) {
 
     /** The "aligned connection operator" between a producer and consumer.
-      * 
+      *
       * For `consumer :<= producer`, each of consumer's leaf fields WHO ARE ALIGNED WITH RESPECT TO CONSUMER are driven from the corresponding producer leaf field
       * All producer's leaf/branch alignments (with respect to producer) do not influence the connection.
       *
@@ -29,10 +28,10 @@ object Connectable {
       *    - All vector types are the same length
       *    - All bundle types have the same field names, but the flips of fields can be different between producer and consumer
       *  - The leaf fields that are ultimately assigned to, must be assignable. This means they cannot be module inputs or instance outputs.
-      * 
+      *
       * @note Connecting two [[Decoupled]]'s would connect `bits` and `valid` from producer to consumer, but leave `ready` unconnected
       * @note If the widths differ between consumer/producer, the assignment will still occur and truncation, if necessary, is implicit
-      * 
+      *
       * @param consumer the left-hand-side of the connection; will always be driven by leaf connections, and never drive leaf connection ("aligned connection")
       * @param producer the right-hand-side of the connection; will always drive leaf connections, and never get driven by leaf connections ("aligned connection")
       * @param sourceInfo
@@ -44,7 +43,7 @@ object Connectable {
     }
 
     /** The "flipped connection operator" between a producer and consumer.
-      * 
+      *
       * For `consumer :>= producer`, each of producers's leaf fields WHO ARE FLIPPED WITH RESPECT TO PRODUCER are driven from the corresponding consumer leaf field
       * All consumer's leaf/branch alignments (with respect to consumer) do not influence the connection.
       *
@@ -54,10 +53,10 @@ object Connectable {
       *    - All vector types are the same length
       *    - All bundle types have the same field names, but the flips of fields can be different
       *  - The leaf fields that are ultimately assigned to, must be assignable. This means they cannot be module inputs or instance outputs.
-      * 
+      *
       * @note Connecting two [[Decoupled]]'s would connect `ready` from consumer to producer, but leave `bits` and `valid` unconnected
       * @note If the widths differ between consumer/producer, the assignment will still occur and truncation, if necessary, is implicit
-      * 
+      *
       * @param consumer the left-hand-side of the connection; will always drive leaf connections, and never get driven by leaf connections ("flipped connection")
       * @param producer the right-hand-side of the connection; will always be driven by leaf connections, and never drive leaf connections ("flipped connection")
       * @param sourceInfo
@@ -69,15 +68,15 @@ object Connectable {
     }
 
     /** The "bi-direction connection operator", aka the "tur-duck-en operator"
-      * 
+      *
       * For `consumer :<>= producer`, both producer and consumer leafs could be driving or be driven-to:
       *   - consumer's fields aligned w.r.t. consumer will be driven by corresponding fields of producer
       *   - producer's fields flipped w.r.t. producer will be driven by corresponding fields of consumer
-      * 
+      *
       * Identical to calling both :<= and :>= in sequence (order is irrelevant), e.g.:
       *   consumer :<= producer
       *   consumer :>= producer
-      * 
+      *
       * @note Connecting two [[Decoupled]]'s would connect `bits` and `valid` from producer to consumer, and `ready` from consumer to producer.
       * @note This may have surprising-to-new-users behavior if the flips of consumer and producer do not match. Save yourself the headache and internalize what
       * :<= and :>= do, and then you'll be able to reason your way to understanding what's happening :)
@@ -90,14 +89,21 @@ object Connectable {
       */
     final def :<>=(producer: => T)(implicit sourceInfo: SourceInfo): Unit = {
       prefix(consumer) {
-        val canFirrtlConnect = try {
-          BiConnect.canFirrtlConnectData(consumer, producer, sourceInfo, DirectionalConnectionFunctions.compileOptions, Builder.referenceUserModule)
-        } catch {
-          // For some reason, an error is thrown if its a View; since this is purely an optimization, any actual error would get thrown
-          //  when calling DirectionConnectionFunctions.assign. Hence, we can just default to false to take the non-optimized emission path
-          case e: Throwable => false
-        }
-        if(canFirrtlConnect) {
+        val canFirrtlConnect =
+          try {
+            BiConnect.canFirrtlConnectData(
+              consumer,
+              producer,
+              sourceInfo,
+              DirectionalConnectionFunctions.compileOptions,
+              Builder.referenceUserModule
+            )
+          } catch {
+            // For some reason, an error is thrown if its a View; since this is purely an optimization, any actual error would get thrown
+            //  when calling DirectionConnectionFunctions.assign. Hence, we can just default to false to take the non-optimized emission path
+            case e: Throwable => false
+          }
+        if (canFirrtlConnect) {
           consumer.firrtlConnect(producer)
         } else {
           // cannot call :<= and :>= directly because otherwise prefix is called twice
@@ -108,13 +114,13 @@ object Connectable {
     }
 
     /** The "mono-direction connection operator", aka the "coercion operator"
-      * 
+      *
       * For `consumer :#= producer`, all leaf fields of consumer (regardless of relative flip) are driven by the corresponding leaf fields of producer (regardless of relative flip)
-      * 
+      *
       * Identical to calling :<= and :>=, but swapping consumer/producer for :>=: (order is irrelevant), e.g.:
       *   consumer :<= producer
       *   producer :>= consumer
-      * 
+      *
       * @note Connecting two [[Decoupled]]'s would connect `bits`, `valid`, AND `ready` from producer to consumer (despite `ready` being flipped)
       * @note Functionally equivalent to chisel3.:=, but different than Chisel.:=
       * @note If the widths differ between consumer/producer, the assignment will still occur and truncation, if necessary, is implicit
@@ -136,7 +142,7 @@ object Connectable {
   implicit class ConnectableVec[T <: Data](consumer: Vec[T]) {
 
     /** The "aligned connection operator" between a producer and consumer.
-      * 
+      *
       * For `consumer :<= producer`, each of consumer's leaf fields WHO ARE ALIGNED WITH RESPECT TO CONSUMER are driven from the corresponding producer leaf field
       * All producer's leaf/branch alignments (with respect to producer) do not influence the connection.
       *
@@ -146,21 +152,24 @@ object Connectable {
       *    - All vector types are the same length
       *    - All bundle types have the same field names, but the flips of fields can be different between producer and consumer
       *  - The leaf fields that are ultimately assigned to, must be assignable. This means they cannot be module inputs or instance outputs.
-      * 
+      *
       * @note Connecting two [[Decoupled]]'s would connect `bits` and `valid` from producer to consumer, but leave `ready` unconnected
       * @note If the widths differ between consumer/producer, the assignment will still occur and truncation, if necessary, is implicit
-      * 
+      *
       * @param consumer the left-hand-side of the connection; will always be driven by leaf connections, and never drive leaf connection ("aligned connection")
       * @param producer the right-hand-side of the connection; will always drive leaf connections, and never get driven by leaf connections ("aligned connection")
       * @param sourceInfo
       */
     def :<=(producer: Seq[T])(implicit sourceInfo: SourceInfo): Unit = {
-      if (consumer.length != producer.length) Builder.error(s"Vec (size ${consumer.length}) and Seq (size ${producer.length}) being connected have different lengths!")
+      if (consumer.length != producer.length)
+        Builder.error(
+          s"Vec (size ${consumer.length}) and Seq (size ${producer.length}) being connected have different lengths!"
+        )
       for ((a, b) <- consumer.zip(producer)) { a :<= b }
     }
 
     /** The "flipped connection operator" between a producer and consumer.
-      * 
+      *
       * For `consumer :>= producer`, each of producers's leaf fields WHO ARE FLIPPED WITH RESPECT TO PRODUCER are driven from the corresponding consumer leaf field
       * All consumer's leaf/branch alignments (with respect to consumer) do not influence the connection.
       *
@@ -170,29 +179,32 @@ object Connectable {
       *    - All vector types are the same length
       *    - All bundle types have the same field names, but the flips of fields can be different
       *  - The leaf fields that are ultimately assigned to, must be assignable. This means they cannot be module inputs or instance outputs.
-      * 
+      *
       * @note Connecting two [[Decoupled]]'s would connect `ready` from consumer to producer, but leave `bits` and `valid` unconnected
       * @note If the widths differ between consumer/producer, the assignment will still occur and truncation, if necessary, is implicit
-      * 
+      *
       * @param consumer the left-hand-side of the connection; will always drive leaf connections, and never get driven by leaf connections ("flipped connection")
       * @param producer the right-hand-side of the connection; will always be driven by leaf connections, and never drive leaf connections ("flipped connection")
       * @param sourceInfo
       */
     def :>=(producer: Seq[T])(implicit sourceInfo: SourceInfo): Unit = {
-      if (consumer.length != producer.length) Builder.error(s"Vec (size ${consumer.length}) and Seq (size ${producer.length}) being connected have different lengths!")
+      if (consumer.length != producer.length)
+        Builder.error(
+          s"Vec (size ${consumer.length}) and Seq (size ${producer.length}) being connected have different lengths!"
+        )
       for ((a, b) <- consumer.zip(producer)) { a :>= b }
     }
 
     /** The "bi-direction connection operator", aka the "tur-duck-en operator"
-      * 
+      *
       * For `consumer :<>= producer`, both producer and consumer leafs could be driving or be driven-to:
       *   - consumer's fields aligned w.r.t. consumer will be driven by corresponding fields of producer
       *   - producer's fields flipped w.r.t. producer will be driven by corresponding fields of consumer
-      * 
+      *
       * Identical to calling both :<= and :>= in sequence (order is irrelevant), e.g.:
       *   consumer :<= producer
       *   consumer :>= producer
-      * 
+      *
       * @note Connecting two [[Decoupled]]'s would connect `bits` and `valid` from producer to consumer, and `ready` from consumer to producer.
       * @note This may have surprising-to-new-users behavior if the flips of consumer and producer do not match. Save yourself the headache and internalize what
       * :<= and :>= do, and then you'll be able to reason your way to understanding what's happening :)
@@ -204,18 +216,21 @@ object Connectable {
       * @param sourceInfo
       */
     def :<>=(producer: Seq[T])(implicit sourceInfo: SourceInfo): Unit = {
-      if (consumer.length != producer.length) Builder.error(s"Vec (size ${consumer.length}) and Seq (size ${producer.length}) being connected have different lengths!")
+      if (consumer.length != producer.length)
+        Builder.error(
+          s"Vec (size ${consumer.length}) and Seq (size ${producer.length}) being connected have different lengths!"
+        )
       for ((a, b) <- consumer.zip(producer)) { a :<>= b }
     }
 
     /** The "mono-direction connection operator", aka the "coercion operator"
-      * 
+      *
       * For `consumer :#= producer`, all leaf fields of consumer (regardless of relative flip) are driven by the corresponding leaf fields of producer (regardless of relative flip)
-      * 
+      *
       * Identical to calling :<= and :>=, but swapping consumer/producer for :>=: (order is irrelevant), e.g.:
       *   consumer :<= producer
       *   producer :>= consumer
-      * 
+      *
       * @note Connecting two [[Decoupled]]'s would connect `bits`, `valid`, AND `ready` from producer to consumer (despite `ready` being flipped)
       * @note Functionally equivalent to chisel3.:=, but different than Chisel.:=
       * @note If the widths differ between consumer/producer, the assignment will still occur and truncation, if necessary, is implicit
@@ -225,7 +240,10 @@ object Connectable {
       * @param sourceInfo
       */
     def :#=(producer: Seq[T])(implicit sourceInfo: SourceInfo): Unit = {
-      if (consumer.length != producer.length) Builder.error(s"Vec (size ${consumer.length}) and Seq (size ${producer.length}) being connected have different lengths!")
+      if (consumer.length != producer.length)
+        Builder.error(
+          s"Vec (size ${consumer.length}) and Seq (size ${producer.length}) being connected have different lengths!"
+        )
       for ((a, b) <- consumer.zip(producer)) { a :#= b }
     }
   }
@@ -235,13 +253,13 @@ private[chisel3] object DirectionalConnectionFunctions {
   // Consumed by the := operator, set to what chisel3 will eventually become.
   implicit val compileOptions = new CompileOptions {
 
-    val connectFieldsMustMatch: Boolean = true
-    val declaredTypeMustBeUnbound: Boolean = true
-    val dontTryConnectionsSwapped: Boolean = false
-    val dontAssumeDirectionality: Boolean = true
-    val checkSynthesizable: Boolean = true
-    val explicitInvalidate: Boolean = true
-    val inferModuleReset: Boolean = true
+    val connectFieldsMustMatch:      Boolean = true
+    val declaredTypeMustBeUnbound:   Boolean = true
+    val dontTryConnectionsSwapped:   Boolean = false
+    val dontAssumeDirectionality:    Boolean = true
+    val checkSynthesizable:          Boolean = true
+    val explicitInvalidate:          Boolean = true
+    val inferModuleReset:            Boolean = true
     override def emitStrictConnects: Boolean = true
   }
 
@@ -256,7 +274,7 @@ private[chisel3] object DirectionalConnectionFunctions {
   case object ConsumerIsActive extends ActiveSide
 
   /** Assignment function which implements both :<= and :>=
-    * 
+    *
     * For example, given a connection like so:
     *  c :<= p
     * We can reason the following:
@@ -269,36 +287,37 @@ private[chisel3] object DirectionalConnectionFunctions {
     * @param activeSide indicates if the connection was a :<= (consumer is active) or :>= (producer is active)
     * @param sourceInfo source info for where the assignment occurred
     */
-  def assign(consumerRoot: Data,
-             producerRoot: Data,
-             activeSide: ActiveSide)(implicit sourceInfo: SourceInfo): Unit = {
+  def assign(consumerRoot: Data, producerRoot: Data, activeSide: ActiveSide)(implicit sourceInfo: SourceInfo): Unit = {
 
     val activeRoot = if (activeSide == ProducerIsActive) producerRoot else consumerRoot
-    require(activeRoot != DontCare, s"Cannot have the active side be a DontCare! Use _ := DontCare or _ :<= DontCare or DontCare :>= _")
+    require(
+      activeRoot != DontCare,
+      s"Cannot have the active side be a DontCare! Use _ := DontCare or _ :<= DontCare or DontCare :>= _"
+    )
 
     /** Determines the aligned/flipped of activeSubMember with respect to activeRoot
-      * 
+      *
       * Due to Chisel/chisel3 differences, its a little complicated to calculate the RelativeOrientation, as the information
       *   is captured with both ActualDirection and SpecifiedDirection. Fortunately, all this complexity is captured in this
       *   one function.
-      * 
+      *
       * References activeRoot, defined earlier in the function
       *
-      * @param activeSubMember a subfield/subindex of activeRoot (or sub-sub, or sub-sub-sub etc) 
+      * @param activeSubMember a subfield/subindex of activeRoot (or sub-sub, or sub-sub-sub etc)
       * @param orientation aligned/flipped of d's direct parent aggregate with respect to activeRoot
       * @return orientation aligned/flipped of d with respect to activeRoot
       */
     def deriveOrientation(activeSubMember: Data, orientation: RelativeOrientation): RelativeOrientation = {
       (activeRoot.direction, activeSubMember.direction, DataMirror.specifiedDirectionOf(activeSubMember)) match {
-        case (ActualDirection.Output,      ActualDirection.Output, _)                              => AlignedWithRoot
-        case (ActualDirection.Input,       ActualDirection.Input,  _)                              => AlignedWithRoot
-        case (ActualDirection.Output,      ActualDirection.Input,  _)                              => FlippedWithRoot
-        case (ActualDirection.Input,       ActualDirection.Output, _)                              => FlippedWithRoot
-        case (_,                           _,                      SpecifiedDirection.Unspecified) => orientation
-        case (_,                           _,                      SpecifiedDirection.Flip)        => orientation.invert
-        case (_,                           _,                      SpecifiedDirection.Output)      => orientation
-        case (_,                           _,                      SpecifiedDirection.Input)       => orientation.invert
-        case other => throw new Exception(s"Unexpected internal error! $other")
+        case (ActualDirection.Output, ActualDirection.Output, _) => AlignedWithRoot
+        case (ActualDirection.Input, ActualDirection.Input, _)   => AlignedWithRoot
+        case (ActualDirection.Output, ActualDirection.Input, _)  => FlippedWithRoot
+        case (ActualDirection.Input, ActualDirection.Output, _)  => FlippedWithRoot
+        case (_, _, SpecifiedDirection.Unspecified)              => orientation
+        case (_, _, SpecifiedDirection.Flip)                     => orientation.invert
+        case (_, _, SpecifiedDirection.Output)                   => orientation
+        case (_, _, SpecifiedDirection.Input)                    => orientation.invert
+        case other                                               => throw new Exception(s"Unexpected internal error! $other")
       }
     }
 
@@ -311,14 +330,14 @@ private[chisel3] object DirectionalConnectionFunctions {
     def recursiveAssign(consumer: Data, producer: Data, orientation: RelativeOrientation): Unit = {
       (consumer, producer) match {
         case (vc: Vec[_], vp: Vec[_]) => {
-          if(vc.size != vp.size) {
+          if (vc.size != vp.size) {
             Builder.error(s"Assignment between vectors of unequal length (${vc.size} != ${vp.size})")
           } else {
             (vc.zip(vp)).foreach { case (ec, ep) => recursiveAssign(ec, ep, orientation) }
           }
         }
         case (rc: Record, rp: Record) => {
-          if(!rc.elements.keySet.sameElements(rp.elements.keySet)) {
+          if (!rc.elements.keySet.sameElements(rp.elements.keySet)) {
             Builder.error(s"Assignment between ${consumer} and ${producer} must have identical fields")
           } else {
             val active = if (activeSide == ProducerIsActive) producer else consumer
@@ -336,21 +355,24 @@ private[chisel3] object DirectionalConnectionFunctions {
         // Active side must be vp due to earlier requirement
         case (DontCare, vp: Vec[_]) => vp.foreach { case ep => recursiveAssign(DontCare, ep, orientation) }
         // Active side must be rc due to earlier requirement
-        case (rc: Record, DontCare) => rc.elements.foreach { case (_, ec) => recursiveAssign(ec, DontCare, deriveOrientation(ec, orientation)) }
+        case (rc: Record, DontCare) =>
+          rc.elements.foreach { case (_, ec) => recursiveAssign(ec, DontCare, deriveOrientation(ec, orientation)) }
         // Active side must be rp due to earlier requirement
-        case (DontCare, rp: Record) => rp.elements.foreach { case (_, ep) => recursiveAssign(DontCare, ep, deriveOrientation(ep, orientation)) }
+        case (DontCare, rp: Record) =>
+          rp.elements.foreach { case (_, ep) => recursiveAssign(DontCare, ep, deriveOrientation(ep, orientation)) }
 
         // Analog cases
         case (ac: Analog, ap: Analog) => assignAnalog(ac, ap)
-        case (ac: Analog, DontCare)   => assignAnalog(ac, DontCare)
-        case (DontCare, ap: Analog)   => assignAnalog(ap, DontCare)
+        case (ac: Analog, DontCare) => assignAnalog(ac, DontCare)
+        case (DontCare, ap: Analog) => assignAnalog(ap, DontCare)
 
         // Only non-Analog Ground types are left
-        case _ => (orientation, activeSide) match {
-          case (AlignedWithRoot, ConsumerIsActive) => consumer := producer // assign leaf fields (UInt/etc)
-          case (FlippedWithRoot, ProducerIsActive) => producer := consumer // assign leaf fields (UInt/etc)
-          case _ =>
-        }
+        case _ =>
+          (orientation, activeSide) match {
+            case (AlignedWithRoot, ConsumerIsActive) => consumer := producer // assign leaf fields (UInt/etc)
+            case (FlippedWithRoot, ProducerIsActive) => producer := consumer // assign leaf fields (UInt/etc)
+            case _                                   =>
+          }
       }
     }
 

--- a/core/src/main/scala/chisel3/Connectable.scala
+++ b/core/src/main/scala/chisel3/Connectable.scala
@@ -1,0 +1,378 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chisel3
+
+import internal.{Builder, BiConnect, prefix}
+import chisel3.internal.sourceinfo.SourceInfo
+
+
+/** The default connection operators for Chisel hardware components */
+object Connectable {
+
+  /** ConnectableData Typeclass defines the following operators on all subclasses of Data: :<=, :>=, :<>=, :#=
+    *
+    * @param consumer the left-hand-side of the connection
+    */
+  implicit class ConnectableData[T <: Data](consumer: T) {
+
+    /** The "aligned connection operator" between a producer and consumer.
+      * 
+      * For `consumer :<= producer`, each of consumer's leaf fields WHO ARE ALIGNED WITH RESPECT TO CONSUMER are driven from the corresponding producer leaf field
+      * All producer's leaf/branch alignments (with respect to producer) do not influence the connection.
+      *
+      * The following restrictions apply:
+      *  - The Chisel type of consumer and producer must be the "same shape" recursively:
+      *    - All ground types are the same (UInt and UInt are same, SInt and UInt are not), but widths can be different
+      *    - All vector types are the same length
+      *    - All bundle types have the same field names, but the flips of fields can be different between producer and consumer
+      *  - The leaf fields that are ultimately assigned to, must be assignable. This means they cannot be module inputs or instance outputs.
+      * 
+      * @note Connecting two [[Decoupled]]'s would connect `bits` and `valid` from producer to consumer, but leave `ready` unconnected
+      * @note If the widths differ between consumer/producer, the assignment will still occur and truncation, if necessary, is implicit
+      * 
+      * @param consumer the left-hand-side of the connection; will always be driven by leaf connections, and never drive leaf connection ("aligned connection")
+      * @param producer the right-hand-side of the connection; will always drive leaf connections, and never get driven by leaf connections ("aligned connection")
+      * @param sourceInfo
+      */
+    final def :<=(producer: => T)(implicit sourceInfo: SourceInfo): Unit = {
+      prefix(consumer) {
+        DirectionalConnectionFunctions.assign(consumer, producer, DirectionalConnectionFunctions.ConsumerIsActive)
+      }
+    }
+
+    /** The "flipped connection operator" between a producer and consumer.
+      * 
+      * For `consumer :>= producer`, each of producers's leaf fields WHO ARE FLIPPED WITH RESPECT TO PRODUCER are driven from the corresponding consumer leaf field
+      * All consumer's leaf/branch alignments (with respect to consumer) do not influence the connection.
+      *
+      * The following restrictions apply:
+      *  - The Chisel type of consumer and producer must be the "same shape":
+      *    - All ground types are the same (UInt and UInt are same, SInt and UInt are not), but widths can be different
+      *    - All vector types are the same length
+      *    - All bundle types have the same field names, but the flips of fields can be different
+      *  - The leaf fields that are ultimately assigned to, must be assignable. This means they cannot be module inputs or instance outputs.
+      * 
+      * @note Connecting two [[Decoupled]]'s would connect `ready` from consumer to producer, but leave `bits` and `valid` unconnected
+      * @note If the widths differ between consumer/producer, the assignment will still occur and truncation, if necessary, is implicit
+      * 
+      * @param consumer the left-hand-side of the connection; will always drive leaf connections, and never get driven by leaf connections ("flipped connection")
+      * @param producer the right-hand-side of the connection; will always be driven by leaf connections, and never drive leaf connections ("flipped connection")
+      * @param sourceInfo
+      */
+    final def :>=(producer: => T)(implicit sourceInfo: SourceInfo): Unit = {
+      prefix(consumer) {
+        DirectionalConnectionFunctions.assign(consumer, producer, DirectionalConnectionFunctions.ProducerIsActive)
+      }
+    }
+
+    /** The "bi-direction connection operator", aka the "tur-duck-en operator"
+      * 
+      * For `consumer :<>= producer`, both producer and consumer leafs could be driving or be driven-to:
+      *   - consumer's fields aligned w.r.t. consumer will be driven by corresponding fields of producer
+      *   - producer's fields flipped w.r.t. producer will be driven by corresponding fields of consumer
+      * 
+      * Identical to calling both :<= and :>= in sequence (order is irrelevant), e.g.:
+      *   consumer :<= producer
+      *   consumer :>= producer
+      * 
+      * @note Connecting two [[Decoupled]]'s would connect `bits` and `valid` from producer to consumer, and `ready` from consumer to producer.
+      * @note This may have surprising-to-new-users behavior if the flips of consumer and producer do not match. Save yourself the headache and internalize what
+      * :<= and :>= do, and then you'll be able to reason your way to understanding what's happening :)
+      * @note If the types of consumer and producer also have identical relative flips, then we can emit FIRRTL.<= as it is a stricter version of chisel3.:<>=
+      * @note If the widths differ between consumer/producer, the assignment will still occur and truncation, if necessary, is implicit
+      *
+      * @param consumer the left-hand-side of the connection (read above comment for more info)
+      * @param producer the right-hand-side of the connection (read above comment for more info)
+      * @param sourceInfo
+      */
+    final def :<>=(producer: => T)(implicit sourceInfo: SourceInfo): Unit = {
+      prefix(consumer) {
+        val canFirrtlConnect = try {
+          BiConnect.canFirrtlConnectData(consumer, producer, sourceInfo, DirectionalConnectionFunctions.compileOptions, Builder.referenceUserModule)
+        } catch {
+          // For some reason, an error is thrown if its a View; since this is purely an optimization, any actual error would get thrown
+          //  when calling DirectionConnectionFunctions.assign. Hence, we can just default to false to take the non-optimized emission path
+          case e: Throwable => false
+        }
+        if(canFirrtlConnect) {
+          consumer.firrtlConnect(producer)
+        } else {
+          // cannot call :<= and :>= directly because otherwise prefix is called twice
+          DirectionalConnectionFunctions.assign(consumer, producer, DirectionalConnectionFunctions.ProducerIsActive)
+          DirectionalConnectionFunctions.assign(consumer, producer, DirectionalConnectionFunctions.ConsumerIsActive)
+        }
+      }
+    }
+
+    /** The "mono-direction connection operator", aka the "coercion operator"
+      * 
+      * For `consumer :#= producer`, all leaf fields of consumer (regardless of relative flip) are driven by the corresponding leaf fields of producer (regardless of relative flip)
+      * 
+      * Identical to calling :<= and :>=, but swapping consumer/producer for :>=: (order is irrelevant), e.g.:
+      *   consumer :<= producer
+      *   producer :>= consumer
+      * 
+      * @note Connecting two [[Decoupled]]'s would connect `bits`, `valid`, AND `ready` from producer to consumer (despite `ready` being flipped)
+      * @note Functionally equivalent to chisel3.:=, but different than Chisel.:=
+      * @note If the widths differ between consumer/producer, the assignment will still occur and truncation, if necessary, is implicit
+      *
+      * @param consumer the left-hand-side of the connection, all fields will be driven-to
+      * @param producer the right-hand-side of the connection, all fields will be driving, none will be driven-to
+      * @param sourceInfo
+      */
+    final def :#=(producer: => T)(implicit sourceInfo: SourceInfo): Unit = {
+      consumer.:<=(producer)
+      producer.:>=(consumer)
+    }
+  }
+
+  /** ConnectableVec Typeclass defines the following operators on between a (consumer: Vec) and (producer: Seq): :<=, :>=, :<>=, :#=
+    *
+    * @param consumer the left-hand-side of the connection
+    */
+  implicit class ConnectableVec[T <: Data](consumer: Vec[T]) {
+
+    /** The "aligned connection operator" between a producer and consumer.
+      * 
+      * For `consumer :<= producer`, each of consumer's leaf fields WHO ARE ALIGNED WITH RESPECT TO CONSUMER are driven from the corresponding producer leaf field
+      * All producer's leaf/branch alignments (with respect to producer) do not influence the connection.
+      *
+      * The following restrictions apply:
+      *  - The Chisel type of consumer and producer must be the "same shape" recursively:
+      *    - All ground types are the same (UInt and UInt are same, SInt and UInt are not), but widths can be different
+      *    - All vector types are the same length
+      *    - All bundle types have the same field names, but the flips of fields can be different between producer and consumer
+      *  - The leaf fields that are ultimately assigned to, must be assignable. This means they cannot be module inputs or instance outputs.
+      * 
+      * @note Connecting two [[Decoupled]]'s would connect `bits` and `valid` from producer to consumer, but leave `ready` unconnected
+      * @note If the widths differ between consumer/producer, the assignment will still occur and truncation, if necessary, is implicit
+      * 
+      * @param consumer the left-hand-side of the connection; will always be driven by leaf connections, and never drive leaf connection ("aligned connection")
+      * @param producer the right-hand-side of the connection; will always drive leaf connections, and never get driven by leaf connections ("aligned connection")
+      * @param sourceInfo
+      */
+    def :<=(producer: Seq[T])(implicit sourceInfo: SourceInfo): Unit = {
+      if (consumer.length != producer.length) Builder.error(s"Vec (size ${consumer.length}) and Seq (size ${producer.length}) being connected have different lengths!")
+      for ((a, b) <- consumer.zip(producer)) { a :<= b }
+    }
+
+    /** The "flipped connection operator" between a producer and consumer.
+      * 
+      * For `consumer :>= producer`, each of producers's leaf fields WHO ARE FLIPPED WITH RESPECT TO PRODUCER are driven from the corresponding consumer leaf field
+      * All consumer's leaf/branch alignments (with respect to consumer) do not influence the connection.
+      *
+      * The following restrictions apply:
+      *  - The Chisel type of consumer and producer must be the "same shape":
+      *    - All ground types are the same (UInt and UInt are same, SInt and UInt are not), but widths can be different
+      *    - All vector types are the same length
+      *    - All bundle types have the same field names, but the flips of fields can be different
+      *  - The leaf fields that are ultimately assigned to, must be assignable. This means they cannot be module inputs or instance outputs.
+      * 
+      * @note Connecting two [[Decoupled]]'s would connect `ready` from consumer to producer, but leave `bits` and `valid` unconnected
+      * @note If the widths differ between consumer/producer, the assignment will still occur and truncation, if necessary, is implicit
+      * 
+      * @param consumer the left-hand-side of the connection; will always drive leaf connections, and never get driven by leaf connections ("flipped connection")
+      * @param producer the right-hand-side of the connection; will always be driven by leaf connections, and never drive leaf connections ("flipped connection")
+      * @param sourceInfo
+      */
+    def :>=(producer: Seq[T])(implicit sourceInfo: SourceInfo): Unit = {
+      if (consumer.length != producer.length) Builder.error(s"Vec (size ${consumer.length}) and Seq (size ${producer.length}) being connected have different lengths!")
+      for ((a, b) <- consumer.zip(producer)) { a :>= b }
+    }
+
+    /** The "bi-direction connection operator", aka the "tur-duck-en operator"
+      * 
+      * For `consumer :<>= producer`, both producer and consumer leafs could be driving or be driven-to:
+      *   - consumer's fields aligned w.r.t. consumer will be driven by corresponding fields of producer
+      *   - producer's fields flipped w.r.t. producer will be driven by corresponding fields of consumer
+      * 
+      * Identical to calling both :<= and :>= in sequence (order is irrelevant), e.g.:
+      *   consumer :<= producer
+      *   consumer :>= producer
+      * 
+      * @note Connecting two [[Decoupled]]'s would connect `bits` and `valid` from producer to consumer, and `ready` from consumer to producer.
+      * @note This may have surprising-to-new-users behavior if the flips of consumer and producer do not match. Save yourself the headache and internalize what
+      * :<= and :>= do, and then you'll be able to reason your way to understanding what's happening :)
+      * @note If the types of consumer and producer also have identical relative flips, then we can emit FIRRTL.<= as it is a stricter version of chisel3.:<>=
+      * @note If the widths differ between consumer/producer, the assignment will still occur and truncation, if necessary, is implicit
+      *
+      * @param consumer the left-hand-side of the connection (read above comment for more info)
+      * @param producer the right-hand-side of the connection (read above comment for more info)
+      * @param sourceInfo
+      */
+    def :<>=(producer: Seq[T])(implicit sourceInfo: SourceInfo): Unit = {
+      if (consumer.length != producer.length) Builder.error(s"Vec (size ${consumer.length}) and Seq (size ${producer.length}) being connected have different lengths!")
+      for ((a, b) <- consumer.zip(producer)) { a :<>= b }
+    }
+
+    /** The "mono-direction connection operator", aka the "coercion operator"
+      * 
+      * For `consumer :#= producer`, all leaf fields of consumer (regardless of relative flip) are driven by the corresponding leaf fields of producer (regardless of relative flip)
+      * 
+      * Identical to calling :<= and :>=, but swapping consumer/producer for :>=: (order is irrelevant), e.g.:
+      *   consumer :<= producer
+      *   producer :>= consumer
+      * 
+      * @note Connecting two [[Decoupled]]'s would connect `bits`, `valid`, AND `ready` from producer to consumer (despite `ready` being flipped)
+      * @note Functionally equivalent to chisel3.:=, but different than Chisel.:=
+      * @note If the widths differ between consumer/producer, the assignment will still occur and truncation, if necessary, is implicit
+      *
+      * @param consumer the left-hand-side of the connection, all fields will be driven-to
+      * @param producer the right-hand-side of the connection, all fields will be driving, none will be driven-to
+      * @param sourceInfo
+      */
+    def :#=(producer: Seq[T])(implicit sourceInfo: SourceInfo): Unit = {
+      if (consumer.length != producer.length) Builder.error(s"Vec (size ${consumer.length}) and Seq (size ${producer.length}) being connected have different lengths!")
+      for ((a, b) <- consumer.zip(producer)) { a :#= b }
+    }
+  }
+}
+
+private[chisel3] object DirectionalConnectionFunctions {
+  // Consumed by the := operator, set to what chisel3 will eventually become.
+  implicit val compileOptions = new CompileOptions {
+
+    val connectFieldsMustMatch: Boolean = true
+    val declaredTypeMustBeUnbound: Boolean = true
+    val dontTryConnectionsSwapped: Boolean = false
+    val dontAssumeDirectionality: Boolean = true
+    val checkSynthesizable: Boolean = true
+    val explicitInvalidate: Boolean = true
+    val inferModuleReset: Boolean = true
+    override def emitStrictConnects: Boolean = true
+  }
+
+  // Indicates whether the active side is aligned or flipped relative to the active side's root
+  sealed trait RelativeOrientation { def invert: RelativeOrientation }
+  case object AlignedWithRoot extends RelativeOrientation { def invert = FlippedWithRoot }
+  case object FlippedWithRoot extends RelativeOrientation { def invert = AlignedWithRoot }
+
+  // Indicates whether the consumer or producer is the active side
+  sealed trait ActiveSide
+  case object ProducerIsActive extends ActiveSide
+  case object ConsumerIsActive extends ActiveSide
+
+  /** Assignment function which implements both :<= and :>=
+    * 
+    * For example, given a connection like so:
+    *  c :<= p
+    * We can reason the following:
+    *  - c is the consumerRoot
+    *  - p is the producerRoot
+    *  - The '<' indicates that the consumer side (left hand side) is the active side
+    *
+    * @param consumerRoot the original expression on the left-hand-side of the connection operator
+    * @param producerRoot the original expression on the right-hand-side of the connection operator
+    * @param activeSide indicates if the connection was a :<= (consumer is active) or :>= (producer is active)
+    * @param sourceInfo source info for where the assignment occurred
+    */
+  def assign(consumerRoot: Data,
+             producerRoot: Data,
+             activeSide: ActiveSide)(implicit sourceInfo: SourceInfo): Unit = {
+
+    val activeRoot = if (activeSide == ProducerIsActive) producerRoot else consumerRoot
+    require(activeRoot != DontCare, s"Cannot have the active side be a DontCare! Use _ := DontCare or _ :<= DontCare or DontCare :>= _")
+
+    /** Determines the aligned/flipped of activeSubMember with respect to activeRoot
+      * 
+      * Due to Chisel/chisel3 differences, its a little complicated to calculate the RelativeOrientation, as the information
+      *   is captured with both ActualDirection and SpecifiedDirection. Fortunately, all this complexity is captured in this
+      *   one function.
+      * 
+      * References activeRoot, defined earlier in the function
+      *
+      * @param activeSubMember a subfield/subindex of activeRoot (or sub-sub, or sub-sub-sub etc) 
+      * @param orientation aligned/flipped of d's direct parent aggregate with respect to activeRoot
+      * @return orientation aligned/flipped of d with respect to activeRoot
+      */
+    def deriveOrientation(activeSubMember: Data, orientation: RelativeOrientation): RelativeOrientation = {
+      (activeRoot.direction, activeSubMember.direction, DataMirror.specifiedDirectionOf(activeSubMember)) match {
+        case (ActualDirection.Output,      ActualDirection.Output, _)                              => AlignedWithRoot
+        case (ActualDirection.Input,       ActualDirection.Input,  _)                              => AlignedWithRoot
+        case (ActualDirection.Output,      ActualDirection.Input,  _)                              => FlippedWithRoot
+        case (ActualDirection.Input,       ActualDirection.Output, _)                              => FlippedWithRoot
+        case (_,                           _,                      SpecifiedDirection.Unspecified) => orientation
+        case (_,                           _,                      SpecifiedDirection.Flip)        => orientation.invert
+        case (_,                           _,                      SpecifiedDirection.Output)      => orientation
+        case (_,                           _,                      SpecifiedDirection.Input)       => orientation.invert
+        case other => throw new Exception(s"Unexpected internal error! $other")
+      }
+    }
+
+    /** Recurses down our consumer and producer to connect leaf subfield/subindexes, depending on the final orientation
+      *
+      * @param consumer subfield/subindex of consumerRoot (or just is, for the first recursive case)
+      * @param producer subfield/subindex of producerRoot (or just is, for the first recursive case)
+      * @param orientation whether the active side's subfield/subindex (either consumer or producer) is flipped/aligned relative to activeRoot
+      */
+    def recursiveAssign(consumer: Data, producer: Data, orientation: RelativeOrientation): Unit = {
+      (consumer, producer) match {
+        case (vc: Vec[_], vp: Vec[_]) => {
+          if(vc.size != vp.size) {
+            Builder.error(s"Assignment between vectors of unequal length (${vc.size} != ${vp.size})")
+          } else {
+            (vc.zip(vp)).foreach { case (ec, ep) => recursiveAssign(ec, ep, orientation) }
+          }
+        }
+        case (rc: Record, rp: Record) => {
+          if(!rc.elements.keySet.sameElements(rp.elements.keySet)) {
+            Builder.error(s"Assignment between ${consumer} and ${producer} must have identical fields")
+          } else {
+            val active = if (activeSide == ProducerIsActive) producer else consumer
+            active.asInstanceOf[Record].elements.foreach {
+              case (key, ea) =>
+                val elementOrientation = deriveOrientation(ea, orientation)
+                val ec = rc.elements(key)
+                val ep = rp.elements(key)
+                recursiveAssign(ec, ep, elementOrientation)
+            }
+          }
+        }
+        // Active side must be vc due to earlier requirement
+        case (vc: Vec[_], DontCare) => vc.foreach { case ec => recursiveAssign(ec, DontCare, orientation) }
+        // Active side must be vp due to earlier requirement
+        case (DontCare, vp: Vec[_]) => vp.foreach { case ep => recursiveAssign(DontCare, ep, orientation) }
+        // Active side must be rc due to earlier requirement
+        case (rc: Record, DontCare) => rc.elements.foreach { case (_, ec) => recursiveAssign(ec, DontCare, deriveOrientation(ec, orientation)) }
+        // Active side must be rp due to earlier requirement
+        case (DontCare, rp: Record) => rp.elements.foreach { case (_, ep) => recursiveAssign(DontCare, ep, deriveOrientation(ep, orientation)) }
+
+        // Analog cases
+        case (ac: Analog, ap: Analog) => assignAnalog(ac, ap)
+        case (ac: Analog, DontCare)   => assignAnalog(ac, DontCare)
+        case (DontCare, ap: Analog)   => assignAnalog(ap, DontCare)
+
+        // Only non-Analog Ground types are left
+        case _ => (orientation, activeSide) match {
+          case (AlignedWithRoot, ConsumerIsActive) => consumer := producer // assign leaf fields (UInt/etc)
+          case (FlippedWithRoot, ProducerIsActive) => producer := consumer // assign leaf fields (UInt/etc)
+          case _ =>
+        }
+      }
+    }
+
+    // For the base recursive case, we start with the roots and they are aligned with themselves
+    recursiveAssign(consumerRoot, producerRoot, AlignedWithRoot)
+  }
+
+  def checkAnalog(as: Analog*)(implicit sourceInfo: SourceInfo): Unit = {
+    val currentModule = Builder.currentModule.get.asInstanceOf[RawModule]
+    try {
+      as.foreach { a => BiConnect.markAnalogConnected(sourceInfo, a, currentModule) }
+    } catch { // convert attach exceptions to BiConnectExceptions
+      case experimental.attach.AttachException(message) => Builder.error(message)
+    }
+  }
+
+  def assignAnalog(a: Analog, b: Data)(implicit sourceInfo: SourceInfo): Unit = b match {
+    case (ba: Analog) => {
+      checkAnalog(a, ba)
+      val currentModule = Builder.currentModule.get.asInstanceOf[RawModule]
+      experimental.attach.impl(Seq(a, ba), currentModule)(sourceInfo)
+    }
+    case (DontCare) => {
+      checkAnalog(a)
+      pushCommand(DefInvalid(sourceInfo, a.lref))
+    }
+  }
+}

--- a/core/src/main/scala/chisel3/Connectable.scala
+++ b/core/src/main/scala/chisel3/Connectable.scala
@@ -335,17 +335,18 @@ private[chisel3] object DirectionalConnectionFunctions {
             active(0) match {
               case d: experimental.Defaulting[_] =>
                 ((inactive.size until active.size).map { i => active(i) }, Nil)
-              case o => 
+              case o =>
                 (Nil, (inactive.size until active.size).map { i => active(i) })
             }
           } else (Nil, Nil)
-          if(unassignedSubIndexes.nonEmpty) {
+          if (unassignedSubIndexes.nonEmpty) {
             Builder.error(s"Connection has unassigned subindexes ${unassignedSubIndexes.mkString(", ")}")
           } else {
             (vc.zip(vp)).foreach { case (ec, ep) => recursiveAssign(ec, ep, orientation) }
-            defaultableSubIndexes.map { case d: experimental.Defaulting[Data] => 
-              if(activeSide == ProducerIsActive) recursiveAssign(d.default, d.underlying, orientation)
-              else recursiveAssign(d.underlying, d.default, orientation)
+            defaultableSubIndexes.map {
+              case d: experimental.Defaulting[Data] =>
+                if (activeSide == ProducerIsActive) recursiveAssign(d.default, d.underlying, orientation)
+                else recursiveAssign(d.underlying, d.default, orientation)
             }
           }
         }
@@ -355,21 +356,23 @@ private[chisel3] object DirectionalConnectionFunctions {
             val missingKeys = active.elements.keySet -- inactive.elements.keySet
             missingKeys.partition { k => active.elements(k).isInstanceOf[experimental.Defaulting[_]] }
           }
-          if(unassignableKeys.nonEmpty) {
+          if (unassignableKeys.nonEmpty) {
             val unassignableFields = unassignableKeys.map(k => active.elements(k))
-            Builder.error(s"Connection between $consumer and $producer has unassigned fields ${unassignableFields.mkString(", ")} in $active.")
+            Builder.error(
+              s"Connection between $consumer and $producer has unassigned fields ${unassignableFields.mkString(", ")} in $active."
+            )
           } else {
             active.asInstanceOf[Record].elements.foreach {
-                case (key, ea: experimental.Defaulting[Data]) if defaultableKeys.contains(key) =>
-                  val field = active.elements(key).asInstanceOf[experimental.Defaulting[Data]]
-                  val elementOrientation = deriveOrientation(ea, orientation)
-                  if(activeSide == ProducerIsActive) recursiveAssign(ea.default, ea.underlying, elementOrientation)
-                  else recursiveAssign(ea.underlying, ea.default, elementOrientation)
-                case (key, ea) =>
-                  val elementOrientation = deriveOrientation(ea, orientation)
-                  val ec = rc.elements(key)
-                  val ep = rp.elements(key)
-                  recursiveAssign(ec, ep, elementOrientation)
+              case (key, ea: experimental.Defaulting[Data]) if defaultableKeys.contains(key) =>
+                val field = active.elements(key).asInstanceOf[experimental.Defaulting[Data]]
+                val elementOrientation = deriveOrientation(ea, orientation)
+                if (activeSide == ProducerIsActive) recursiveAssign(ea.default, ea.underlying, elementOrientation)
+                else recursiveAssign(ea.underlying, ea.default, elementOrientation)
+              case (key, ea) =>
+                val elementOrientation = deriveOrientation(ea, orientation)
+                val ec = rc.elements(key)
+                val ep = rp.elements(key)
+                recursiveAssign(ec, ep, elementOrientation)
             }
           }
         }

--- a/core/src/main/scala/chisel3/Connectable.scala
+++ b/core/src/main/scala/chisel3/Connectable.scala
@@ -330,23 +330,46 @@ private[chisel3] object DirectionalConnectionFunctions {
     def recursiveAssign(consumer: Data, producer: Data, orientation: RelativeOrientation): Unit = {
       (consumer, producer) match {
         case (vc: Vec[_], vp: Vec[_]) => {
-          if (vc.size != vp.size) {
-            Builder.error(s"Assignment between vectors of unequal length (${vc.size} != ${vp.size})")
+          val (active, inactive) = if (activeSide == ProducerIsActive) (vp, vc) else (vc, vp)
+          val (defaultableSubIndexes, unassignedSubIndexes) = if (active.size > inactive.size) {
+            active(0) match {
+              case d: experimental.Defaulting[_] =>
+                ((inactive.size until active.size).map { i => active(i) }, Nil)
+              case o => 
+                (Nil, (inactive.size until active.size).map { i => active(i) })
+            }
+          } else (Nil, Nil)
+          if(unassignedSubIndexes.nonEmpty) {
+            Builder.error(s"Connection has unassigned subindexes ${unassignedSubIndexes.mkString(", ")}")
           } else {
             (vc.zip(vp)).foreach { case (ec, ep) => recursiveAssign(ec, ep, orientation) }
+            defaultableSubIndexes.map { case d: experimental.Defaulting[Data] => 
+              if(activeSide == ProducerIsActive) recursiveAssign(d.default, d.underlying, orientation)
+              else recursiveAssign(d.underlying, d.default, orientation)
+            }
           }
         }
         case (rc: Record, rp: Record) => {
-          if (!rc.elements.keySet.sameElements(rp.elements.keySet)) {
-            Builder.error(s"Assignment between ${consumer} and ${producer} must have identical fields")
+          val (active, inactive) = if (activeSide == ProducerIsActive) (rp, rc) else (rc, rp)
+          val (defaultableKeys, unassignableKeys) = {
+            val missingKeys = active.elements.keySet -- inactive.elements.keySet
+            missingKeys.partition { k => active.elements(k).isInstanceOf[experimental.Defaulting[_]] }
+          }
+          if(unassignableKeys.nonEmpty) {
+            val unassignableFields = unassignableKeys.map(k => active.elements(k))
+            Builder.error(s"Connection between $consumer and $producer has unassigned fields ${unassignableFields.mkString(", ")} in $active.")
           } else {
-            val active = if (activeSide == ProducerIsActive) producer else consumer
             active.asInstanceOf[Record].elements.foreach {
-              case (key, ea) =>
-                val elementOrientation = deriveOrientation(ea, orientation)
-                val ec = rc.elements(key)
-                val ep = rp.elements(key)
-                recursiveAssign(ec, ep, elementOrientation)
+                case (key, ea: experimental.Defaulting[Data]) if defaultableKeys.contains(key) =>
+                  val field = active.elements(key).asInstanceOf[experimental.Defaulting[Data]]
+                  val elementOrientation = deriveOrientation(ea, orientation)
+                  if(activeSide == ProducerIsActive) recursiveAssign(ea.default, ea.underlying, elementOrientation)
+                  else recursiveAssign(ea.underlying, ea.default, elementOrientation)
+                case (key, ea) =>
+                  val elementOrientation = deriveOrientation(ea, orientation)
+                  val ec = rc.elements(key)
+                  val ep = rp.elements(key)
+                  recursiveAssign(ec, ep, elementOrientation)
             }
           }
         }

--- a/core/src/main/scala/chisel3/Data.scala
+++ b/core/src/main/scala/chisel3/Data.scala
@@ -807,6 +807,7 @@ abstract class Data extends HasId with NamedComponent with SourceInfoDoc {
     *  - Equivalent to `this :<>= that` without the restrictions that bundle field names and vector sizes must match
     *
     * @param that the Data to connect from
+    * @group connection
     */
   final def <>(that: => Data)(implicit sourceInfo: SourceInfo, connectionCompileOptions: CompileOptions): Unit = {
     prefix(this) {

--- a/core/src/main/scala/chisel3/Data.scala
+++ b/core/src/main/scala/chisel3/Data.scala
@@ -791,6 +791,7 @@ abstract class Data extends HasId with NamedComponent with SourceInfoDoc {
     *  - Equivalent to `this :<>= that`, with the additional restriction that the relative bundle field flips must match
     *
     * @param that the Data to connect from
+    * @group connection
     */
   final def :=(that: => Data)(implicit sourceInfo: SourceInfo, connectionCompileOptions: CompileOptions): Unit = {
     prefix(this) {

--- a/core/src/main/scala/chisel3/Data.scala
+++ b/core/src/main/scala/chisel3/Data.scala
@@ -786,7 +786,7 @@ abstract class Data extends HasId with NamedComponent with SourceInfoDoc {
     *
     * For chisel3._, this operator is mono-directioned; all sub-elements of `this` will be driven by sub-elements of `that`.
     *  - Equivalent to `this :#= that`
-    * 
+    *
     * For Chisel._, this operator connections bi-directionally via emitting the FIRRTL.<=
     *  - Equivalent to `this :<>= that`, with the additional restriction that the relative bundle field flips must match
     *
@@ -802,7 +802,7 @@ abstract class Data extends HasId with NamedComponent with SourceInfoDoc {
     *
     * For chisel3._, uses the [[BiConnect]] algorithm; sub-elements of `that` may end up driving sub-elements of `this`
     *  - Complicated semantics, hard to write quickly, will likely be deprecated in the future
-    * 
+    *
     * For Chisel._, emits the FIRRTL.<- operator
     *  - Equivalent to `this :<>= that` without the restrictions that bundle field names and vector sizes must match
     *

--- a/core/src/main/scala/chisel3/Element.scala
+++ b/core/src/main/scala/chisel3/Element.scala
@@ -57,13 +57,18 @@ abstract class Element extends Data {
   override def litOption:                Option[BigInt] = litArgOption.map(_.num)
   private[chisel3] def litIsForcedWidth: Option[Boolean] = litArgOption.map(_.forcedWidth)
 
-  private[chisel3] def legacyConnect(that: Data)(implicit sourceInfo: SourceInfo): Unit = {
+  private[chisel3] def firrtlConnect(that: Data)(implicit sourceInfo: SourceInfo): Unit = {
     // If the source is a DontCare, generate a DefInvalid for the sink,
     //  otherwise, issue a Connect.
     if (that == DontCare) {
-      pushCommand(DefInvalid(sourceInfo, Node(this)))
+      pushCommand(DefInvalid(sourceInfo, lref))
     } else {
-      pushCommand(Connect(sourceInfo, Node(this), that.ref))
+      pushCommand(Connect(sourceInfo, lref, that.ref))
     }
+  }
+
+  // Since we are an element, we can just emit a Connect
+  private[chisel3] def firrtlPartialConnect(that: Data)(implicit sourceInfo: SourceInfo): Unit = {
+    firrtlConnect(that)
   }
 }

--- a/core/src/main/scala/chisel3/Trie.scala
+++ b/core/src/main/scala/chisel3/Trie.scala
@@ -1,0 +1,135 @@
+package chisel3
+
+
+import scala.annotation.tailrec
+import scala.collection.mutable
+
+/** A prefix tree. Prefixes represented by a list of `Token` values. For each
+  * valid path the tree will contain a value of type `Value`.
+  *
+  * To use this, do not extend this trait (it is sealed). Instead, create an empty trie with
+  * the helper method in the object. Then, add items with the insert method.
+  */
+sealed trait Trie[Token, Value] {
+  def value: Option[Value]
+  protected def setValue(value: Value): Unit
+  protected def clearValue(): Unit
+  protected def children:     mutable.LinkedHashMap[Token, Trie[Token, Value]]
+
+  /** Inserts a value into the trie */
+  @tailrec
+  final def insert(tokens: Seq[Token], value: Value): Unit = {
+    if (tokens.isEmpty) {
+      setValue(value)
+    } else {
+      val child = children.getOrElseUpdate(tokens.head, Trie.empty)
+      child.insert(tokens.tail, value)
+    }
+  }
+
+  /** Deletes a value in the trie */
+  final def delete(tokens: Seq[Token]): Unit = {
+    if (tokens.isEmpty) {
+      clearValue()
+    } else if (children.get(tokens.head).nonEmpty) {
+      val child = children(tokens.head)
+      child.delete(tokens.tail)
+      if (child.children.isEmpty && child.value.isEmpty) children.remove(tokens.head)
+    }
+  }
+
+  /** Returns the child located at the path */
+  @tailrec
+  final def getChild(path: Seq[Token]): Option[Trie[Token, Value]] = {
+    if (path.isEmpty) {
+      Some(this)
+    } else {
+      if (children.contains(path.head)) {
+        children(path.head).getChild(path.tail)
+      } else {
+        None
+      }
+    }
+  }
+
+  /** Returns the first value found, along the path */
+  @tailrec
+  final def getFirst(path: Seq[Token]): Option[Value] = {
+    value match {
+      case Some(v)                              => Some(v)
+      case None if path.isEmpty                 => None
+      case None if children.contains(path.head) => children(path.head).getFirst(path.tail)
+      case None                                 => None
+    }
+  }
+
+  /** Returns a new Trie, with each value being the result of applying f
+    * @param f Given the path and optional value, return a new optional value for the new trie
+    * @return
+    */
+  final def transform[NewValue](f: (Seq[Token], Option[Value]) => Option[NewValue]): Trie[Token, NewValue] = {
+    val newTrie = Trie.empty[Token, NewValue]
+
+    def recTransform(tokens: Seq[Token], subtrie: Trie[Token, Value]): Unit = {
+      val newValue = f(tokens, subtrie.value)
+      newValue.map(x => newTrie.insert(tokens, x))
+      subtrie.children.keys.foreach { case token => recTransform(tokens :+ token.asInstanceOf[Token], subtrie.children(token)) }
+    }
+
+    recTransform(Nil, this)
+    newTrie
+  }
+
+  /** Returns local children to this Trie */
+  final def getChildren(): List[(Token, Trie[Token, Value])] = children.toList
+
+  /** Returns children of the Trie located at this path */
+  final def getChildren(path: Seq[Token]): List[(Token, Trie[Token, Value])] = {
+    if (path.isEmpty) getChildren()
+    else {
+      children(path.head).getChildren(path.tail)
+    }
+  }
+
+  /** Returns the optional value at the path */
+  @tailrec
+  final def get(path: Seq[Token]): Option[Value] = {
+    if (path.isEmpty) value
+    else {
+      children.get(path.head) match {
+        case None       => None
+        case Some(trie) => trie.get(path.tail)
+      }
+    }
+  }
+
+  private final def collectDeepWithPath[T](path: Seq[Token])(collector: PartialFunction[(Seq[Token], Option[Value]), T]): Iterable[T] = {
+    val myItems           = collector.lift((path, value))
+    val deepChildrenItems = getChildren().flatMap { case (token, c) =>
+      c.collectDeepWithPath(path :+ token)(collector)
+    }
+    myItems ++ deepChildrenItems
+  }
+
+  /** For each matching path/value provided in the partial function, return an item */
+  final def collectDeep[T](collector: PartialFunction[(Seq[Token], Option[Value]), T]): Iterable[T] = {
+    collectDeepWithPath(Nil)(collector)
+  }
+
+}
+
+object Trie {
+
+  /** creates a new empty Trie
+    */
+  def empty[Token, Value]: Trie[Token, Value] = {
+    new Trie[Token, Value] {
+      var value: Option[Value] = None
+      def setValue(valuex: Value): Unit = {
+        value = Some(valuex)
+      }
+      def clearValue(): Unit   = value = None
+      val children             = mutable.LinkedHashMap.empty[Token, Trie[Token, Value]]
+    }
+  }
+}

--- a/core/src/main/scala/chisel3/Trie.scala
+++ b/core/src/main/scala/chisel3/Trie.scala
@@ -1,11 +1,14 @@
-package chisel3
+// SPDX-License-Identifier: Apache-2.0
 
+package chisel3
 
 import scala.annotation.tailrec
 import scala.collection.mutable
 
 /** A prefix tree. Prefixes represented by a list of `Token` values. For each
   * valid path the tree will contain a value of type `Value`.
+  * 
+  * For more information on Trie's, visit https://en.wikipedia.org/wiki/Trie
   *
   * To use this, do not extend this trait (it is sealed). Instead, create an empty trie with
   * the helper method in the object. Then, add items with the insert method.
@@ -120,8 +123,7 @@ sealed trait Trie[Token, Value] {
 
 object Trie {
 
-  /** creates a new empty Trie
-    */
+  /** Create a new empty Trie[Token, Value] */
   def empty[Token, Value]: Trie[Token, Value] = {
     new Trie[Token, Value] {
       var value: Option[Value] = None

--- a/core/src/main/scala/chisel3/experimental/Analog.scala
+++ b/core/src/main/scala/chisel3/experimental/Analog.scala
@@ -50,7 +50,7 @@ final class Analog private (private[chisel3] val width: Width) extends Element {
   // Used to enforce single bulk connect of Analog types, multi-attach is still okay
   // Note that this really means 1 bulk connect per Module because a port can
   //   be connected in the parent module as well
-  private[chisel3] val biConnectLocs = mutable.Map.empty[RawModule, SourceInfo]
+  private[chisel3] val biConnectLocs = mutable.Map.empty[RawModule, (SourceInfo, Data)]
 
   // Define setter/getter pairing
   // Analog can only be bound to Ports and Wires (and Unbound)

--- a/core/src/main/scala/chisel3/experimental/Defaulting.scala
+++ b/core/src/main/scala/chisel3/experimental/Defaulting.scala
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chisel3.experimental
+
+import chisel3.{chiselTypeOf, Record, Data, Element}
+
+import scala.collection.immutable.SeqMap
+
+/** Data type for representing any type who has a default value
+  *
+  * Uses the underlying opaque type support.
+  *
+  * @note This API is experimental and subject to change
+  */
+final class Defaulting[T <: Data] private (private[chisel3] val tpe: T, val defaultValue: T) extends Record {
+  requireIsChiselType(tpe, s"Chisel hardware type $tpe must be a pure type, not bound to hardware.")
+  requireIsHardware(defaultValue, s"Default value $defaultValue must be bound to a hardware component")
+
+  /** The underlying hardware component, is either the Chisel data type or hardware component */
+  val underlying: T = tpe
+
+  /** The default value for this Defaulting */
+  val default: T = defaultValue
+
+  val elements = SeqMap("" -> underlying)
+  override def opaqueType = elements.size == 1
+  override def cloneType: this.type = (new Defaulting[T](chiselTypeOf(tpe), defaultValue)).asInstanceOf[this.type]
+}
+
+
+/** Object that provides factory methods for [[Analog]] objects
+  *
+  * @note This API is experimental and subject to change
+  */
+object Defaulting {
+  /** Build a Defaulting[T <: Data]
+    *
+    * @param tpe the Chisel data type
+    * @param default the Chisel default value, must be bound to a hardware value
+    */
+  def apply[T <: Data](tpe: T, default: T): Defaulting[T] = new Defaulting(tpe, default)
+
+  /** Build a Defaulting[T <: Data]
+    *
+    * @param default the Chisel default value, must be bound to a hardware value. The underlying type is pulled from the default value.
+    */
+  def apply[T <: Data](default: T): Defaulting[T] = new Defaulting(chiselTypeOf(default), default)
+}

--- a/core/src/main/scala/chisel3/experimental/Defaulting.scala
+++ b/core/src/main/scala/chisel3/experimental/Defaulting.scala
@@ -7,21 +7,21 @@ import chisel3.internal.sourceinfo.SourceInfo
 
 import scala.collection.immutable.SeqMap
 
-/** Data type for representing any type who has a default value
+/** Data type for representing any type that has a defined default value
   *
   * Uses the underlying opaque type support.
   *
   * @note This API is experimental and subject to change
   */
-final class Defaulting[T <: Data] private (private[chisel3] val tpe: T, val defaultValue: T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions) extends Record {
+final class Defaulting[T <: Data] private (tpe: => T, defaultValue: => T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions) extends Record {
   requireIsChiselType(tpe, s"Chisel hardware type $tpe must be a pure type, not bound to hardware.")
   requireIsHardware(defaultValue, s"Default value $defaultValue must be bound to a hardware component")
 
-  /** The underlying hardware component, is either the Chisel data type or hardware component */
-  val underlying: T = tpe
+  /** The underlying hardware component, is either the Chisel data type (if `this` is unbound) or hardware component (if `this` is bound to hardware) */
+  lazy val underlying: T = tpe
 
   /** The default value for this Defaulting */
-  val default: T = defaultValue
+  lazy val default: T = defaultValue
 
   val elements = SeqMap("" -> underlying)
   override def opaqueType = elements.size == 1
@@ -32,7 +32,7 @@ final class Defaulting[T <: Data] private (private[chisel3] val tpe: T, val defa
 }
 
 
-/** Object that provides factory methods for [[Analog]] objects
+/** Object that provides factory methods for [[Defaulting]] objects
   *
   * @note This API is experimental and subject to change
   */

--- a/core/src/main/scala/chisel3/experimental/Defaulting.scala
+++ b/core/src/main/scala/chisel3/experimental/Defaulting.scala
@@ -13,7 +13,13 @@ import scala.collection.immutable.SeqMap
   *
   * @note This API is experimental and subject to change
   */
-final class Defaulting[T <: Data] private (tpe: => T, defaultValue: => T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions) extends Record {
+final class Defaulting[T <: Data] private (
+  tpe:          => T,
+  defaultValue: => T
+)(
+  implicit sourceInfo: SourceInfo,
+  compileOptions:      CompileOptions)
+    extends Record {
   requireIsChiselType(tpe, s"Chisel hardware type $tpe must be a pure type, not bound to hardware.")
   requireIsHardware(defaultValue, s"Default value $defaultValue must be bound to a hardware component")
 
@@ -26,27 +32,34 @@ final class Defaulting[T <: Data] private (tpe: => T, defaultValue: => T)(implic
   val elements = SeqMap("" -> underlying)
   override def opaqueType = elements.size == 1
   override def cloneType: this.type = {
-    val freshType = if(tpe.isSynthesizable) chiselTypeOf(tpe) else tpe.cloneType
+    val freshType = if (tpe.isSynthesizable) chiselTypeOf(tpe) else tpe.cloneType
     (new Defaulting[T](freshType, defaultValue)).asInstanceOf[this.type]
   }
 }
-
 
 /** Object that provides factory methods for [[Defaulting]] objects
   *
   * @note This API is experimental and subject to change
   */
 object Defaulting {
+
   /** Build a Defaulting[T <: Data]
     *
     * @param tpe the Chisel data type
     * @param default the Chisel default value, must be bound to a hardware value
     */
-  def apply[T <: Data](tpe: T, default: T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Defaulting[T] = new Defaulting(tpe, default)
+  def apply[T <: Data](
+    tpe:     T,
+    default: T
+  )(
+    implicit sourceInfo: SourceInfo,
+    compileOptions:      CompileOptions
+  ): Defaulting[T] = new Defaulting(tpe, default)
 
   /** Build a Defaulting[T <: Data]
     *
     * @param default the Chisel default value, must be bound to a hardware value. The underlying type is pulled from the default value.
     */
-  def apply[T <: Data](default: T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Defaulting[T] = new Defaulting(chiselTypeOf(default), default)
+  def apply[T <: Data](default: T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Defaulting[T] =
+    new Defaulting(chiselTypeOf(default), default)
 }

--- a/core/src/main/scala/chisel3/experimental/Waivable.scala
+++ b/core/src/main/scala/chisel3/experimental/Waivable.scala
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chisel3.experimental
+
+import chisel3._
+import chisel3.internal.sourceinfo.SourceInfo
+
+import scala.collection.immutable.SeqMap
+
+/** Data type for representing any type that is ok to either leave dangling or unassigned from :<>= (TODO: :<=? :>=? :#=?)
+  *
+  * Uses the underlying opaque type support.
+  *
+  * @note This API is experimental and subject to change
+  */
+class Waivable[T <: Data] private[chisel3] (
+  tpe: => T,
+  val okToDangle: Boolean,
+  val okToUnassign: Boolean,
+)(
+  implicit sourceInfo: SourceInfo,
+  compileOptions:      CompileOptions
+) extends Record {
+  requireIsChiselType(tpe, s"Chisel hardware type $tpe must be a pure type, not bound to hardware.")
+
+  /** The underlying hardware component, is either the Chisel data type (if `this` is unbound) or hardware component (if `this` is bound to hardware) */
+  lazy val underlying: T = tpe
+
+  val elements = SeqMap("" -> underlying)
+  override def opaqueType = elements.size == 1
+  override def cloneType: this.type = {
+    val freshType = if (tpe.isSynthesizable) chiselTypeOf(tpe) else tpe.cloneType
+    (new Waivable[T](freshType, okToDangle, okToUnassign)).asInstanceOf[this.type]
+  }
+}
+
+/** Object that provides factory methods for [[Waivable]] objects
+  *
+  * @note This API is experimental and subject to change
+  */
+object Waivable {
+
+  /** Build a Waivable[T <: Data]
+    *
+    * @param tpe the Chisel data type
+    * @param default the Chisel default value, must be bound to a hardware value
+    */
+  def apply[T <: Data](
+    tpe:     T,
+    okToDangle: Boolean,
+    okToUnassign: Boolean,
+  )(
+    implicit sourceInfo: SourceInfo,
+    compileOptions:      CompileOptions
+  ): Waivable[T] = new Waivable(tpe, okToDangle, okToUnassign)
+}

--- a/core/src/main/scala/chisel3/internal/BiConnect.scala
+++ b/core/src/main/scala/chisel3/internal/BiConnect.scala
@@ -299,10 +299,12 @@ private[chisel3] object BiConnect {
     def flowSourceCheck = MonoConnect.canBeSource(source, context_mod)
 
     // do not bulk connect source literals (results in infinite recursion from calling .ref)
-    def sourceNotLiteralCheck = source.topBinding match {
+    def sourceAndSinkNotLiteralOrViewCheck = List(source, sink).forall { _.topBinding match {
       case _: LitBinding => false
+      case _: ViewBinding => false
+      case _: AggregateViewBinding => false
       case _ => true
-    }
+    }}
 
     // do not bulk connect the 'io' pseudo-bundle of a BlackBox since it will be decomposed in FIRRTL
     def blackBoxCheck = Seq(source, sink).map(_._parent).forall {
@@ -310,7 +312,7 @@ private[chisel3] object BiConnect {
       case _ => true
     }
 
-    typeCheck && contextCheck && bindingCheck && flowSinkCheck && flowSourceCheck && sourceNotLiteralCheck && blackBoxCheck
+    typeCheck && contextCheck && bindingCheck && flowSinkCheck && flowSourceCheck && sourceAndSinkNotLiteralOrViewCheck && blackBoxCheck
   }
 
   // These functions (finally) issue the connection operation

--- a/core/src/main/scala/chisel3/internal/BiConnect.scala
+++ b/core/src/main/scala/chisel3/internal/BiConnect.scala
@@ -299,12 +299,14 @@ private[chisel3] object BiConnect {
     def flowSourceCheck = MonoConnect.canBeSource(source, context_mod)
 
     // do not bulk connect source literals (results in infinite recursion from calling .ref)
-    def sourceAndSinkNotLiteralOrViewCheck = List(source, sink).forall { _.topBinding match {
-      case _: LitBinding => false
-      case _: ViewBinding => false
-      case _: AggregateViewBinding => false
-      case _ => true
-    }}
+    def sourceAndSinkNotLiteralOrViewCheck = List(source, sink).forall {
+      _.topBinding match {
+        case _: LitBinding           => false
+        case _: ViewBinding          => false
+        case _: AggregateViewBinding => false
+        case _ => true
+      }
+    }
 
     // do not bulk connect the 'io' pseudo-bundle of a BlackBox since it will be decomposed in FIRRTL
     def blackBoxCheck = Seq(source, sink).map(_._parent).forall {

--- a/core/src/main/scala/chisel3/internal/BiConnect.scala
+++ b/core/src/main/scala/chisel3/internal/BiConnect.scala
@@ -255,12 +255,13 @@ private[chisel3] object BiConnect {
     * FIRRTL specification, the following must hold for FIRRTL connection:
     *
     *   1. The Chisel types of the left-hand and right-hand side expressions must be
-    *       equivalent.
+    *       equivalent (and thus will become the same FIRRTL type).
     *   2. The bit widths of the two expressions must allow for data to always
     *        flow from a smaller bit width to an equal size or larger bit width.
     *   3. The flow of the left-hand side expression must be sink or duplex
     *   4. Either the flow of the right-hand side expression is source or duplex,
     *      or the right-hand side expression has a passive type.
+    *   5. No analog connections
     *
     * @param raiseIfFalse raise a BiConnectException if the result would be false with information about why it's false.
     */

--- a/core/src/main/scala/chisel3/internal/MonoConnect.scala
+++ b/core/src/main/scala/chisel3/internal/MonoConnect.scala
@@ -136,7 +136,7 @@ private[chisel3] object MonoConnect {
         val sourceReified: Option[Aggregate] = if (isView(source_v)) reifyToAggregate(source_v) else Some(source_v)
 
         if (
-          sinkReified.nonEmpty && sourceReified.nonEmpty && canBulkConnectAggregates(
+          sinkReified.nonEmpty && sourceReified.nonEmpty && canFirrtlConnectData(
             sinkReified.get,
             sourceReified.get,
             sourceInfo,
@@ -172,7 +172,7 @@ private[chisel3] object MonoConnect {
         val sourceReified: Option[Aggregate] = if (isView(source_r)) reifyToAggregate(source_r) else Some(source_r)
 
         if (
-          sinkReified.nonEmpty && sourceReified.nonEmpty && canBulkConnectAggregates(
+          sinkReified.nonEmpty && sourceReified.nonEmpty && canFirrtlConnectData(
             sinkReified.get,
             sourceReified.get,
             sourceInfo,
@@ -225,16 +225,16 @@ private[chisel3] object MonoConnect {
       case (sink, source) => throw MismatchedException(sink, source)
     }
 
-  /** Determine if a valid connection can be made between a source [[Aggregate]] and sink
-    * [[Aggregate]] given their parent module and directionality context
+  /** Determine if a valid connection can be made between a source [[Data]] and sink
+    * [[Data]] given their parent module and directionality context
     *
     * @return whether the source and sink exist in an appropriate context to be connected
     */
-  private[chisel3] def aggregateConnectContextCheck(
+  private[chisel3] def dataConnectContextCheck(
     implicit sourceInfo:   SourceInfo,
     connectCompileOptions: CompileOptions,
-    sink:                  Aggregate,
-    source:                Aggregate,
+    sink:                  Data,
+    source:                Data,
     context_mod:           RawModule
   ): Boolean = {
     import ActualDirection.{Bidirectional, Input, Output}
@@ -338,24 +338,24 @@ private[chisel3] object MonoConnect {
   def canBeSink(data:   Data, context_mod: RawModule): Boolean = traceFlow(true, data, context_mod)
   def canBeSource(data: Data, context_mod: RawModule): Boolean = traceFlow(false, data, context_mod)
 
-  /** Check whether two aggregates can be bulk connected (<=) in FIRRTL. (MonoConnect case)
+  /** Check whether two Data can be bulk connected (<=) in FIRRTL. (MonoConnect case)
     *
     * Mono-directional bulk connects only work if all signals of the sink are unidirectional
     * In the case of a sink aggregate with bidirectional signals, e.g. `Decoupled`,
-    * a `BiConnect` is necessary.
+    * a `BiConnect` (`chisel3.<>` or `chisel.:<>=`) is necessary.
     */
-  private[chisel3] def canBulkConnectAggregates(
-    sink:                  Aggregate,
-    source:                Aggregate,
+  private[chisel3] def canFirrtlConnectData(
+    sink:                  Data,
+    source:                Data,
     sourceInfo:            SourceInfo,
     connectCompileOptions: CompileOptions,
     context_mod:           RawModule
   ): Boolean = {
-    // Assuming we're using a <>, check if a bulk connect is valid in that case
+    // Assuming we're using a <>, check if a FIRRTL.<= connection operator is valid in that case
     def biConnectCheck =
-      BiConnect.canBulkConnectAggregates(sink, source, sourceInfo, connectCompileOptions, context_mod)
+      BiConnect.canFirrtlConnectData(sink, source, sourceInfo, connectCompileOptions, context_mod)
 
-    // Check that the Aggregate can be driven (not bidirectional or an input) to match Chisel semantics
+    // Check that the sink Data can be driven (not bidirectional or an input) to match Chisel semantics
     def sinkCanBeDrivenCheck: Boolean =
       sink.direction == ActualDirection.Output || sink.direction == ActualDirection.Unspecified
 

--- a/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
@@ -302,7 +302,10 @@ private[chisel3] object Converter {
     case d: FixedPoint => fir.FixedType(convert(d.width), convert(d.binaryPoint))
     case d: Interval   => fir.IntervalType(d.range.lowerBound, d.range.upperBound, d.range.firrtlBinaryPoint)
     case d: Analog     => fir.AnalogType(convert(d.width))
-    case d: Vec[_] => fir.VectorType(extractType(d.sample_element, clearDir, info), d.length)
+    case d: Vec[_] =>
+      val childClearDir = clearDir ||
+        d.specifiedDirection == SpecifiedDirection.Input || d.specifiedDirection == SpecifiedDirection.Output
+      fir.VectorType(extractType(d.sample_element, childClearDir, info), d.length)
     case d: Record => {
       val childClearDir = clearDir ||
         d.specifiedDirection == SpecifiedDirection.Input || d.specifiedDirection == SpecifiedDirection.Output

--- a/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
@@ -162,7 +162,7 @@ private[chisel3] object Converter {
       )
     case Connect(info, loc, exp) =>
       Some(fir.Connect(convert(info), convert(loc, ctx, info), convert(exp, ctx, info)))
-    case BulkConnect(info, loc, exp) =>
+    case PartialConnect(info, loc, exp) =>
       Some(fir.PartialConnect(convert(info), convert(loc, ctx, info), convert(exp, ctx, info)))
     case Attach(info, locs) =>
       Some(fir.Attach(convert(info), locs.map(l => convert(l, ctx, info))))

--- a/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
@@ -319,7 +319,7 @@ private[chisel3] object Converter {
       if (!d.opaqueType)
         fir.BundleType(d.elements.toIndexedSeq.reverse.map { case (_, e) => eltField(e) })
       else
-        extractType(d.elements.head._2, true, info)
+        extractType(d.elements.head._2, childClearDir, info)
     }
   }
 

--- a/core/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -826,7 +826,7 @@ case class WhenEnd(sourceInfo: SourceInfo, firrtlDepth: Int, hasAlt: Boolean = f
 case class AltBegin(sourceInfo: SourceInfo) extends Command
 case class OtherwiseEnd(sourceInfo: SourceInfo, firrtlDepth: Int) extends Command
 case class Connect(sourceInfo: SourceInfo, loc: Node, exp: Arg) extends Command
-case class BulkConnect(sourceInfo: SourceInfo, loc1: Node, loc2: Node) extends Command
+case class PartialConnect(sourceInfo: SourceInfo, loc1: Node, loc2: Node) extends Command
 case class Attach(sourceInfo: SourceInfo, locs: Seq[Node]) extends Command
 case class ConnectInit(sourceInfo: SourceInfo, loc: Node, exp: Arg) extends Command
 case class Stop(id: stop.Stop, sourceInfo: SourceInfo, clock: Arg, ret: Int) extends Definition

--- a/src/main/scala/chisel3/aop/Select.scala
+++ b/src/main/scala/chisel3/aop/Select.scala
@@ -418,7 +418,7 @@ object Select {
                 .foreach(x => assert(x._1 == x._2, s"Prepredicates $x must match for signal $signal"))
               predicatedConnects += PredicatedConnect(preds.dropRight(prePredicates.size), d, expData, isBulk = false)
             }
-          case BulkConnect(_, loc @ Node(d: Data), exp) =>
+          case PartialConnect(_, loc @ Node(d: Data), exp) =>
             val effected = getEffected(loc).toSet
             if (sensitivitySignals.intersect(effected).nonEmpty) {
               val expData = getData(exp)

--- a/src/main/scala/chisel3/stage/ChiselStage.scala
+++ b/src/main/scala/chisel3/stage/ChiselStage.scala
@@ -214,7 +214,7 @@ object ChiselStage {
     )
 
     phase
-      .transform(Seq(ChiselGeneratorAnnotation(() => gen), RunFirrtlTransformAnnotation(new HighFirrtlEmitter)))
+      .transform(Seq(ChiselGeneratorAnnotation(() => gen), RunFirrtlTransformAnnotation(new HighFirrtlEmitter), PrintFullStackTraceAnnotation))
       .collectFirst {
         case EmittedFirrtlCircuitAnnotation(a) => a
       }

--- a/src/main/scala/chisel3/stage/ChiselStage.scala
+++ b/src/main/scala/chisel3/stage/ChiselStage.scala
@@ -135,13 +135,16 @@ object ChiselStage {
   /** Return a Chisel circuit for a Chisel module
     * @param gen a call-by-name Chisel module
     */
-  def elaborate(gen: => RawModule): cir.Circuit = {
+  def elaborate(gen: => RawModule, printFullStackTrace: Boolean = false, throwOnFirstError: Boolean = false): cir.Circuit = {
     val phase = new ChiselPhase {
       override val targets = Seq(Dependency[chisel3.stage.phases.Checks], Dependency[chisel3.stage.phases.Elaborate])
     }
 
+    val pfst = if(printFullStackTrace) Seq(PrintFullStackTraceAnnotation) else Nil
+    val tofe = if(throwOnFirstError) Seq(ThrowOnFirstErrorAnnotation) else Nil
+
     phase
-      .transform(Seq(ChiselGeneratorAnnotation(() => gen), NoRunFirrtlCompilerAnnotation))
+      .transform(Seq(ChiselGeneratorAnnotation(() => gen), NoRunFirrtlCompilerAnnotation) ++ pfst ++ tofe)
       .collectFirst {
         case ChiselCircuitAnnotation(a) => a
       }
@@ -151,7 +154,7 @@ object ChiselStage {
   /** Return a CHIRRTL circuit for a Chisel module
     * @param gen a call-by-name Chisel module
     */
-  def convert(gen: => RawModule): fir.Circuit = {
+  def convert(gen: => RawModule, printFullStackTrace: Boolean = false, throwOnFirstError: Boolean = false): fir.Circuit = {
     val phase = new ChiselPhase {
       override val targets = Seq(
         Dependency[chisel3.stage.phases.Checks],
@@ -163,8 +166,11 @@ object ChiselStage {
       )
     }
 
+    val pfst = if(printFullStackTrace) Seq(PrintFullStackTraceAnnotation) else Nil
+    val tofe = if(throwOnFirstError) Seq(ThrowOnFirstErrorAnnotation) else Nil
+
     phase
-      .transform(Seq(ChiselGeneratorAnnotation(() => gen)))
+      .transform(Seq(ChiselGeneratorAnnotation(() => gen)) ++ pfst ++ tofe)
       .collectFirst {
         case FirrtlCircuitAnnotation(a) => a
       }
@@ -195,12 +201,12 @@ object ChiselStage {
   /** Return a CHIRRTL string for a Chisel module
     * @param gen a call-by-name Chisel module
     */
-  def emitChirrtl(gen: => RawModule): String = convert(gen).serialize
+  def emitChirrtl(gen: => RawModule, printFullStackTrace: Boolean = false, throwOnFirstError: Boolean = false): String = convert(gen, printFullStackTrace, throwOnFirstError).serialize
 
   /** Return a FIRRTL string for a Chisel module
     * @param gen a call-by-name Chisel module
     */
-  def emitFirrtl(gen: => RawModule): String = {
+  def emitFirrtl(gen: => RawModule, printFullStackTrace: Boolean = false, throwOnFirstError: Boolean = false): String = {
     val phase = new PhaseManager(
       Seq(
         Dependency[chisel3.stage.phases.Checks],
@@ -213,13 +219,15 @@ object ChiselStage {
       )
     )
 
+    val pfst = if(printFullStackTrace) Seq(PrintFullStackTraceAnnotation) else Nil
+    val tofe = if(throwOnFirstError) Seq(ThrowOnFirstErrorAnnotation) else Nil
+
     phase
       .transform(
         Seq(
           ChiselGeneratorAnnotation(() => gen),
-          RunFirrtlTransformAnnotation(new HighFirrtlEmitter),
-          PrintFullStackTraceAnnotation
-        )
+          RunFirrtlTransformAnnotation(new HighFirrtlEmitter)
+        ) ++ pfst ++ tofe
       )
       .collectFirst {
         case EmittedFirrtlCircuitAnnotation(a) => a
@@ -232,7 +240,7 @@ object ChiselStage {
   /** Return a Verilog string for a Chisel module
     * @param gen a call-by-name Chisel module
     */
-  def emitVerilog(gen: => RawModule): String = {
+  def emitVerilog(gen: => RawModule, printFullStackTrace: Boolean = false, throwOnFirstError: Boolean = false): String = {
     val phase = new PhaseManager(
       Seq(
         Dependency[chisel3.stage.phases.Checks],
@@ -245,8 +253,11 @@ object ChiselStage {
       )
     )
 
+    val pfst = if(printFullStackTrace) Seq(PrintFullStackTraceAnnotation) else Nil
+    val tofe = if(throwOnFirstError) Seq(ThrowOnFirstErrorAnnotation) else Nil
+
     phase
-      .transform(Seq(ChiselGeneratorAnnotation(() => gen), RunFirrtlTransformAnnotation(new VerilogEmitter)))
+      .transform(Seq(ChiselGeneratorAnnotation(() => gen), RunFirrtlTransformAnnotation(new VerilogEmitter)) ++ pfst ++ tofe)
       .collectFirst {
         case EmittedVerilogCircuitAnnotation(a) => a
       }
@@ -257,7 +268,7 @@ object ChiselStage {
   /** Return a SystemVerilog string for a Chisel module
     * @param gen a call-by-name Chisel module
     */
-  def emitSystemVerilog(gen: => RawModule): String = {
+  def emitSystemVerilog(gen: => RawModule, printFullStackTrace: Boolean = false, throwOnFirstError: Boolean = false): String = {
     val phase = new PhaseManager(
       Seq(
         Dependency[chisel3.stage.phases.Checks],
@@ -270,8 +281,11 @@ object ChiselStage {
       )
     )
 
+    val pfst = if(printFullStackTrace) Seq(PrintFullStackTraceAnnotation) else Nil
+    val tofe = if(throwOnFirstError) Seq(ThrowOnFirstErrorAnnotation) else Nil
+
     phase
-      .transform(Seq(ChiselGeneratorAnnotation(() => gen), RunFirrtlTransformAnnotation(new SystemVerilogEmitter)))
+      .transform(Seq(ChiselGeneratorAnnotation(() => gen), RunFirrtlTransformAnnotation(new SystemVerilogEmitter)) ++ pfst ++ tofe)
       .collectFirst {
         case EmittedVerilogCircuitAnnotation(a) => a
       }

--- a/src/main/scala/chisel3/stage/ChiselStage.scala
+++ b/src/main/scala/chisel3/stage/ChiselStage.scala
@@ -214,7 +214,13 @@ object ChiselStage {
     )
 
     phase
-      .transform(Seq(ChiselGeneratorAnnotation(() => gen), RunFirrtlTransformAnnotation(new HighFirrtlEmitter), PrintFullStackTraceAnnotation))
+      .transform(
+        Seq(
+          ChiselGeneratorAnnotation(() => gen),
+          RunFirrtlTransformAnnotation(new HighFirrtlEmitter),
+          PrintFullStackTraceAnnotation
+        )
+      )
       .collectFirst {
         case EmittedFirrtlCircuitAnnotation(a) => a
       }

--- a/src/main/scala/chisel3/util/MixedVec.scala
+++ b/src/main/scala/chisel3/util/MixedVec.scala
@@ -110,6 +110,7 @@ final class MixedVec[T <: Data](private val eltsIn: Seq[T]) extends Record with 
   /** Strong bulk connect, assigning elements in this MixedVec from elements in a Seq.
     *
     * @note the lengths of this and that must match
+    * @group connection
     */
   def :=(that: Seq[T]): Unit = {
     require(this.length == that.length)

--- a/src/test/scala/chiselTests/Direction.scala
+++ b/src/test/scala/chiselTests/Direction.scala
@@ -379,4 +379,25 @@ class DirectionSpec extends ChiselPropSpec with Matchers with Utils {
     assert(emitted.contains("io.monitor.valid <= io.driver.valid"))
     assert(emitted.contains("io.monitor.ready <= io.driver.ready"))
   }
+  property("Bugfix: marking Vec fields with mixed directionality as Output clears inner directions") {
+    class Decoupled extends Bundle {
+      val bits = UInt(3.W)
+      val valid = Bool()
+      val ready = Flipped(Bool())
+    }
+    class DecoupledAndMonitor extends Bundle {
+      val driver = Output(Vec(1, new Decoupled()))
+    }
+    class MyModule extends RawModule {
+      val io = IO(new DecoupledAndMonitor())
+    }
+
+    val emitted: String = ChiselStage.emitChirrtl(new MyModule)
+
+    assert(
+      emitted.contains(
+        "output io : { driver : { bits : UInt<3>, valid : UInt<1>, ready : UInt<1>}[1]}"
+      )
+    )
+  }
 }

--- a/src/test/scala/chiselTests/Direction.scala
+++ b/src/test/scala/chiselTests/Direction.scala
@@ -6,6 +6,7 @@ import org.scalatest._
 import chisel3._
 import chisel3.stage.ChiselStage
 import org.scalatest.matchers.should.Matchers
+import chisel3.experimental.Waivable
 
 class DirectionedBundle extends Bundle {
   val in = Input(UInt(32.W))
@@ -397,6 +398,27 @@ class DirectionSpec extends ChiselPropSpec with Matchers with Utils {
     assert(
       emitted.contains(
         "output io : { driver : { bits : UInt<3>, valid : UInt<1>, ready : UInt<1>}[1]}"
+      )
+    )
+  }
+  property("Bugfix: clearing all flips inside an opaque type") {
+    class Decoupled extends Bundle {
+      val bits = UInt(3.W)
+      val valid = Bool()
+      val ready = Flipped(Bool())
+    }
+    class DecoupledAndMonitor extends Bundle {
+      val driver = new Decoupled()
+    }
+    class MyModule extends RawModule {
+      val w = Wire(Waivable(new Decoupled(), true, true))
+    }
+
+    val emitted: String = ChiselStage.emitChirrtl(new MyModule)
+
+    assert(
+      emitted.contains(
+        "wire w : { bits : UInt<3>, valid : UInt<1>, flip ready : UInt<1>}"
       )
     )
   }

--- a/src/test/scala/chiselTests/DirectionalBulkConnectSpec.scala
+++ b/src/test/scala/chiselTests/DirectionalBulkConnectSpec.scala
@@ -5,7 +5,7 @@ package chiselTests
 import org.scalatest._
 
 import chisel3._
-import chisel3.experimental.{Analog, FixedPoint, Defaulting}
+import chisel3.experimental.{Analog, Defaulting, FixedPoint}
 import chisel3.experimental.BundleLiterals._
 import chisel3.experimental.VecLiterals._
 import chisel3.stage.ChiselStage
@@ -315,7 +315,9 @@ class DirectionalBulkConnectSpec extends ChiselPropSpec with Utils {
     class InfoControl extends Info {
       val control = Defaulting(false.B)
     }
-    val firrtl = ChiselStage.emitChirrtl { new CrossDirectionalBulkConnectsWithWires(new InfoECC() : Info, new InfoControl() : Info, 1) }
+    val firrtl = ChiselStage.emitChirrtl {
+      new CrossDirectionalBulkConnectsWithWires(new InfoECC(): Info, new InfoControl(): Info, 1)
+    }
     println(firrtl)
     assert(firrtl.contains("wiresOut_0.control <= UInt<1>(\"h0\")"))
     assert(firrtl.contains("wiresOut_0.info <= wiresIn_0.info"))

--- a/src/test/scala/chiselTests/DirectionalBulkConnectSpec.scala
+++ b/src/test/scala/chiselTests/DirectionalBulkConnectSpec.scala
@@ -187,18 +187,18 @@ class DirectionalBulkConnectSpec extends ChiselFunSpec with Utils {
       // Vec sizes don't match
       testException(vec(alignedFooBundle(Bool())),    vec(alignedFooBundle(Bool()), 4), "dangling producer field")
       testException(vec(alignedFooBundle(Bool()), 4), vec(alignedFooBundle(Bool())), "unassigned consumer field")
-      testException(vec(flippedBarBundle(Bool())),    vec(flippedBarBundle(Bool()), 4), "unassigned producer field")
-      testException(vec(flippedBarBundle(Bool()), 4), vec(flippedBarBundle(Bool())), "dangling consumer field")
+      testException(vec(flippedBarBundle(Bool())),    vec(flippedBarBundle(Bool()), 4), "dangling producer field")
+      testException(vec(flippedBarBundle(Bool()), 4), vec(flippedBarBundle(Bool())), "unassigned consumer field")
 
       // Correct dangling/unassigned consumer/producer if vec has a bundle who has a flip field
-      testException(vec(alignedFooBundle(Bool())), vec(mixedBundle(Bool()), 4), "unassigned producer field")
+      testException(vec(alignedFooBundle(Bool())), vec(mixedBundle(Bool()), 4), "dangling producer field", "unassigned producer field")
       testException(vec(mixedBundle(Bool()), 4), vec(alignedFooBundle(Bool())), "dangling consumer field", "unassigned consumer field")
     }
     it("(0.i): Error if different root-relative flippedness on leaf fields between right-hand-side or left-hand-side") {
       testException(mixedBundle(Bool()), alignedBundle(Bool()), "inversely oriented fields")
       testException(alignedBundle(Bool()), mixedBundle(Bool()), "inversely oriented fields")
     }
-    it("(0.j): Emit defaultable assignments on type with default, instead of erroring with missing fields") {
+    ignore("(0.j): Emit defaultable assignments on type with default, instead of erroring with missing fields") {
       testDistinctTypes(
         alignedBundle(Bool().withConnectableDefault(true.B)),
         alignedFooBundle(Bool()),
@@ -378,7 +378,7 @@ class DirectionalBulkConnectSpec extends ChiselFunSpec with Utils {
       ))
       testException(vec(alignedFooBundle(Bool()), 4), vec(alignedFooBundle(Bool())), "unassigned consumer field")
       testDistinctTypes(vec(flippedBarBundle(Bool())), vec(flippedBarBundle(Bool()), 4), Seq("skip"))
-      testDistinctTypes(vec(flippedBarBundle(Bool()), 4), vec(flippedBarBundle(Bool())), Seq("skip"))
+      testException(vec(flippedBarBundle(Bool()), 4), vec(flippedBarBundle(Bool())), "unassigned consumer field")
 
       // Correct dangling/unassigned consumer/producer if vec has a bundle who has a flip field
       testDistinctTypes(vec(alignedFooBundle(Bool())), vec(mixedBundle(Bool()), 4), Seq(
@@ -395,7 +395,7 @@ class DirectionalBulkConnectSpec extends ChiselFunSpec with Utils {
         "io.out.bar <= io.in.bar"
       ))
     }
-    it("(1.j): Emit defaultable assignments on type with default, instead of erroring with missing fields") {
+    ignore("(1.j): Emit defaultable assignments on type with default, instead of erroring with missing fields") {
       testDistinctTypes(
         alignedBundle(Bool().withConnectableDefault(true.B)),
         alignedFooBundle(Bool()),
@@ -527,7 +527,7 @@ class DirectionalBulkConnectSpec extends ChiselFunSpec with Utils {
 
       // Missing foo
       testDistinctTypes(mixedBundle(Bool()), flippedBarBundle(Bool()), Seq("io.in.bar <= io.out.bar"))
-      testDistinctTypes(flippedBarBundle(Bool()), mixedBundle(Bool()), Seq("io.in.bar <= io.out.bar")) // No connection should be emitted
+      testDistinctTypes(flippedBarBundle(Bool()), mixedBundle(Bool()), Seq("io.in.bar <= io.out.bar"))
 
       // Vec sizes don't match
       testDistinctTypes(vec(alignedFooBundle(Bool())), vec(alignedFooBundle(Bool()), 4), Seq("skip"), Seq("<="))
@@ -701,7 +701,7 @@ class DirectionalBulkConnectSpec extends ChiselFunSpec with Utils {
       // Missing flip bar
       implicit val op: (Data, Data) => Unit = {_ :#= _}
       implicit val monitorOp: Option[(Data, Data) => Unit] = None
-      testException(mixedBundle(Bool()), alignedFooBundle(Bool()), "dangling consumer field")
+      testException(mixedBundle(Bool()), alignedFooBundle(Bool()), "unmatched consumer field")
       testException(alignedFooBundle(Bool()), mixedBundle(Bool()), "unmatched producer field")
 
       // Missing foo
@@ -715,8 +715,8 @@ class DirectionalBulkConnectSpec extends ChiselFunSpec with Utils {
       testException(vec(flippedBarBundle(Bool()), 4), vec(flippedBarBundle(Bool())), "cannot be written from module")
 
       // Correct dangling/unassigned consumer/producer if vec has a bundle who has a flip field
-      testException(vec(alignedFooBundle(Bool())), vec(mixedBundle(Bool()), 4), "unmatched producer field")
-      testException(vec(mixedBundle(Bool()), 4), vec(alignedFooBundle(Bool())), "unassigned consumer field")
+      testException(vec(alignedFooBundle(Bool())), vec(mixedBundle(Bool()), 4), "unmatched producer field", "dangling producer field")
+      testException(vec(mixedBundle(Bool()), 4), vec(alignedFooBundle(Bool())), "unmatched consumer field", "unassigned consumer field")
     }
     it("(3.i): Always assign to consumer regardless of orientation") {
       implicit val op: (Data, Data) => Unit = {_ :#= _}

--- a/src/test/scala/chiselTests/DirectionalBulkConnectSpec.scala
+++ b/src/test/scala/chiselTests/DirectionalBulkConnectSpec.scala
@@ -200,12 +200,12 @@ class DirectionalBulkConnectSpec extends ChiselFunSpec with Utils {
     }
     it("(0.j): Emit defaultable assignments on type with default, instead of erroring with missing fields") {
       testDistinctTypes(
-        alignedBundle(Bool().withDefault(true.B)),
+        alignedBundle(Bool().withConnectableDefault(true.B)),
         alignedFooBundle(Bool()),
         Seq("io.out.foo <= io.in.foo", "io.out.bar <= UInt<1>(\"h1\")")
       )
       testDistinctTypes(
-        alignedBundle(Bool()).withDefault{t => Seq(t.bar -> true.B)},
+        alignedBundle(Bool()).withConnectableDefault{(_.bar -> true.B)},
         alignedFooBundle(Bool()),
         Seq("io.out.foo <= io.in.foo", "io.out.bar <= UInt<1>(\"h1\")")
       )
@@ -397,12 +397,12 @@ class DirectionalBulkConnectSpec extends ChiselFunSpec with Utils {
     }
     it("(1.j): Emit defaultable assignments on type with default, instead of erroring with missing fields") {
       testDistinctTypes(
-        alignedBundle(Bool().withDefault(true.B)),
+        alignedBundle(Bool().withConnectableDefault(true.B)),
         alignedFooBundle(Bool()),
         Seq("io.out.foo <= io.in.foo", "io.out.bar <= UInt<1>(\"h1\")")
       )
       testDistinctTypes(
-        alignedBundle(Bool()).withDefault{t => Seq(t.bar -> true.B)},
+        alignedBundle(Bool()).withConnectableDefault{ (_.bar -> true.B)},
         alignedFooBundle(Bool()),
         Seq("io.out.foo <= io.in.foo", "io.out.bar <= UInt<1>(\"h1\")")
       )

--- a/src/test/scala/chiselTests/DirectionalBulkConnectSpec.scala
+++ b/src/test/scala/chiselTests/DirectionalBulkConnectSpec.scala
@@ -315,14 +315,14 @@ class DirectionalBulkConnectSpec extends ChiselPropSpec with Utils {
     class InfoControl extends Info {
       val control = Defaulting(false.B)
     }
-    val firrtl = ChiselStage.emitFirrtl { new CrossDirectionalBulkConnectsWithWires(new InfoECC() : Info, new InfoControl() : Info, 1) }
+    val firrtl = ChiselStage.emitChirrtl { new CrossDirectionalBulkConnectsWithWires(new InfoECC() : Info, new InfoControl() : Info, 1) }
     println(firrtl)
     assert(firrtl.contains("wiresOut_0.control <= UInt<1>(\"h0\")"))
     assert(firrtl.contains("wiresOut_0.info <= wiresIn_0.info"))
   }
   property("(D.s) :<>= works for different missing Defaulting subindexes") {
     def vecType(size: Int) = Vec(size, Defaulting(UInt(3.W), 0.U))
-    val firrtl = ChiselStage.emitFirrtl { new CrossDirectionalBulkConnectsWithWires(vecType(2), vecType(3), 1) }
+    val firrtl = ChiselStage.emitChirrtl { new CrossDirectionalBulkConnectsWithWires(vecType(2), vecType(3), 1) }
     println(firrtl)
     assert(firrtl.contains("wiresOut_0[2] <= UInt<1>(\"h0\")"))
     assert(firrtl.contains("wiresOut_0[1] <= wiresIn_0[1]"))

--- a/src/test/scala/chiselTests/DirectionalBulkConnectSpec.scala
+++ b/src/test/scala/chiselTests/DirectionalBulkConnectSpec.scala
@@ -1,0 +1,308 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiselTests
+
+import org.scalatest._
+
+import chisel3._
+import chisel3.experimental.{Analog, FixedPoint}
+import chisel3.stage.ChiselStage
+import chisel3.testers.BasicTester
+
+class CrossDirectionalBulkConnects(inType: Data, outType: Data) extends Module {
+  val io = IO(new Bundle {
+    val in = Flipped(inType)
+    val out = Flipped(Flipped(outType)) // no clonetype, no Aligned (yet)
+  })
+  io.out :<>= io.in
+}
+
+class NotCommutativeCrossDirectionalBulkConnects(inType: Data, outType: Data) extends Module {
+  val io = IO(new Bundle {
+    val in = Flipped(inType)
+    val out = Flipped(Flipped(outType)) // no clonetype, no Aligned (yet)
+  })
+  io.in :<>= io.out
+}
+
+class NotWritableCrossDirectionalBulkConnects(inType: Data) extends Module {
+  val io = IO(new Bundle {
+    val in = Flipped(inType)
+  })
+  val tmp = Wire(Flipped(inType))
+  io.in :<>= tmp
+}
+
+class CrossDirectionalBulkConnectsWithWires(inType: Data, outType: Data, nTmps: Int) extends Module {
+  val io = IO(new Bundle {
+    val in = Flipped(inType)
+    val out = Flipped(Flipped(outType)) // no clonetype, no Aligned (yet)
+  })
+  require(nTmps > 0)
+  val wiresIn = Seq.fill(nTmps)(Wire(inType))
+  val wiresOut = Seq.fill(nTmps)(Wire(outType))
+  (Seq(io.out) ++ wiresOut ++ wiresIn).zip(wiresOut ++ wiresIn :+ io.in).foreach {
+    case (l, r) =>
+      l :<>= r
+  }
+}
+
+class CrossDirectionalMonoConnectsWithWires(inType: Data, outType: Data, nTmps: Int) extends Module {
+  val io = IO(new Bundle {
+    val in = Flipped(inType)
+    val out = Output(outType) // no clonetype, no Aligned (yet)
+  })
+  require(nTmps > 0)
+  val wiresIn = Seq.fill(nTmps)(Wire(inType))
+  val wiresOut = Seq.fill(nTmps)(Wire(outType))
+  (Seq(io.out) ++ wiresOut ++ wiresIn).zip(wiresOut ++ wiresIn :+ io.in).foreach {
+    case (l, r) =>
+      l :#= r
+  }
+}
+
+class DirectionalBulkConnectSpec extends ChiselPropSpec with Utils {
+
+  // (D)irectional Bulk Connect tests
+  property("(D.a) SInt :<>= SInt should succeed") {
+    ChiselStage.elaborate { new CrossDirectionalBulkConnects(SInt(16.W), SInt(16.W)) }
+  }
+  property("(D.b) UInt :<>= UInt should succeed") {
+    ChiselStage.elaborate { new CrossDirectionalBulkConnects(UInt(16.W), UInt(16.W)) }
+  }
+  property("(D.c) SInt :<>= UInt should fail") {
+    intercept[ChiselException] { ChiselStage.elaborate { new CrossDirectionalBulkConnects(UInt(16.W), SInt(16.W)) } }
+  }
+  property("(D.d) Decoupled :<>= Decoupled should succeed") {
+    class Decoupled extends Bundle {
+      val bits = UInt(3.W)
+      val valid = Bool()
+      val ready = Flipped(Bool())
+    }
+    val out = ChiselStage.emitChirrtl { new CrossDirectionalBulkConnects(new Decoupled, new Decoupled) }
+    assert(out.contains("io.out <= io.in"))
+  }
+  property("(D.d) Aggregates with same-named fields should succeed") {
+    class Foo extends Bundle {
+      val foo = Bool()
+      val bar = Flipped(Bool())
+    }
+    class FooLike extends Bundle {
+      val foo = Bool()
+      val bar = Flipped(Bool())
+    }
+    val out = ChiselStage.emitChirrtl { new CrossDirectionalBulkConnects(new Foo, new FooLike) }
+    assert(out.contains("io.out <= io.in"))
+  }
+  property("(D.d) Decoupled[Foo] :<>= Decoupled[Foo-Like] should succeed") {
+    class Foo extends Bundle {
+      val foo = Bool()
+      val bar = Flipped(Bool())
+    }
+    class FooLike extends Bundle {
+      val foo = Bool()
+      val bar = Flipped(Bool())
+    }
+    class Decoupled[T <: Data](gen: => T) extends Bundle {
+      val bits = gen
+      val valid = Bool()
+      val ready = Flipped(Bool())
+    }
+    val out = ChiselStage.emitChirrtl {
+      new CrossDirectionalBulkConnects(new Decoupled(new Foo()), new Decoupled(new FooLike()))
+    }
+    assert(out.contains("io.out <= io.in"))
+  }
+  property("(D.e) different relative flips, but same absolute flippage is an error") {
+    class X(yflip: Boolean, zflip: Boolean) extends Bundle {
+      val y = if (yflip) Flipped(new Y(zflip)) else new Y(zflip)
+    }
+    class Y(flip: Boolean) extends Bundle {
+      val z = if (flip) Flipped(Bool()) else Bool()
+    }
+    intercept[ChiselException] {
+      ChiselStage.emitVerilog { new CrossDirectionalBulkConnects(new X(true, false), new X(false, true)) }
+    }
+  }
+  property("(D.f) :<>= is not commutative.") {
+    intercept[ChiselException] {
+      ChiselStage.elaborate { new NotCommutativeCrossDirectionalBulkConnects(UInt(16.W), UInt(16.W)) }
+    }
+  }
+  property("(D.g) UInt :<>= UInt should succeed with intermediate Wires") {
+    ChiselStage.elaborate { new CrossDirectionalBulkConnectsWithWires(UInt(16.W), UInt(16.W), 1) }
+  }
+  property("(D.h) Decoupled :<>= Decoupled should succeed with intermediate Wires") {
+    class Decoupled extends Bundle {
+      val bits = UInt(3.W)
+      val valid = Bool()
+      val ready = Flipped(Bool())
+    }
+    val out = ChiselStage.emitChirrtl { new CrossDirectionalBulkConnectsWithWires(new Decoupled, new Decoupled, 2) }
+    assert(out.contains("io.out <= wiresOut_0"))
+    assert(out.contains("wiresOut_1 <= wiresIn_0"))
+    assert(out.contains("wiresIn_1 <= io.in"))
+  }
+  property("(D.i) Aggregates :<>= with missing fields should not succeed, no matter the direction.") {
+    class Foo extends Bundle {
+      val foo = Bool()
+    }
+    class FooBar extends Bundle {
+      val foo = Bool()
+      val bar = Bool()
+    }
+    intercept[ChiselException] {
+      ChiselStage.emitChirrtl { new CrossDirectionalBulkConnects(new Foo(), new FooBar()) }
+    }
+    intercept[ChiselException] {
+      ChiselStage.emitChirrtl { new CrossDirectionalBulkConnects(new FooBar(), new Foo()) }
+    }
+  }
+  property("(D.j) Cannot :<>= to something that is not writable.") {
+
+    intercept[ChiselException] {
+      ChiselStage.emitChirrtl { new NotWritableCrossDirectionalBulkConnects(UInt(16.W)) }
+    }
+  }
+  property("(D.k) Can :<>= to Vecs of the same length") {
+    val out = (new ChiselStage).emitChirrtl { new CrossDirectionalBulkConnects(Vec(3, UInt(16.W)), Vec(3, UInt(16.W))) }
+    assert(out.contains("io.out <= io.in"))
+  }
+  property("(D.l) :<>= between Vecs of different length should not succeed, no matter the direction") {
+    intercept[ChiselException] {
+      ChiselStage.emitChirrtl { new CrossDirectionalBulkConnects(Vec(2, UInt(16.W)), Vec(3, UInt(16.W))) }
+    }
+    intercept[ChiselException] {
+      ChiselStage.emitChirrtl { new CrossDirectionalBulkConnects(Vec(3, UInt(16.W)), Vec(2, UInt(16.W))) }
+    }
+
+  }
+  property(
+    "(D.m) :<>= is NOT equivalent to Chisel.:= in that  `A Module with missing bundle fields when compiled with the Chisel compatibility package` *should* `throw an exception` "
+  ) {
+    // This is copied from CompatibilitySpec but the := is replaced with :<>=
+    class SmallBundle extends Bundle {
+      val f1 = UInt(4.W)
+      val f2 = UInt(5.W)
+    }
+    class BigBundle extends SmallBundle {
+      val f3 = UInt(6.W)
+    }
+
+    class ConnectFieldMismatchModule extends Module {
+      val io = IO(new Bundle {
+        val in = Input((new SmallBundle))
+        val out = Output((new BigBundle))
+      })
+      (io.out: Data) :<>= (io.in: Data)
+    }
+    intercept[ChiselException] {
+      ChiselStage.elaborate { new ConnectFieldMismatchModule() }
+    }
+  }
+
+  property(
+    "(D.n) :#= is the same as chisel3.:=, in that fields must match and all consumer fields are written to, regardless of flippedness"
+  ) {
+    // This is copied from CompatibilitySpec but the := is replaced with :<>=
+    class Decoupled extends Bundle {
+      val bits = UInt(3.W)
+      val valid = Bool()
+      val ready = Flipped(Bool())
+    }
+    val out = ChiselStage.emitChirrtl { new CrossDirectionalMonoConnectsWithWires(new Decoupled, new Decoupled, 1) }
+    assert(out.contains(
+      "wiresIn_0.bits <= io.in.bits",
+      "wiresIn_0.valid <= io.in.valid",
+      "wiresIn_0.ready <= io.in.ready",
+    ))
+  }
+
+  property("(D.o) :<>= works with DataView to connect a bundle that is a subtype") {
+    import chisel3.experimental.dataview._
+
+    class SmallBundle extends Bundle {
+      val f1 = UInt(4.W)
+      val f2 = UInt(5.W)
+    }
+    class BigBundle extends SmallBundle {
+      val f3 = UInt(6.W)
+    }
+
+    class ConnectSupertype extends Module {
+      val io = IO(new Bundle {
+        val in = Input((new SmallBundle))
+        val out = Output((new BigBundle))
+
+        val foo = Input((new BigBundle))
+        val bar = Output(new SmallBundle)
+      })
+      io.out := DontCare
+      io.out.viewAsSupertype(Output(new SmallBundle)) :<>= io.in
+
+      io.bar := DontCare
+      io.bar :<>= io.foo.viewAsSupertype(Input((new SmallBundle)))
+    }
+    val out = (new ChiselStage).emitChirrtl(gen = new ConnectSupertype(), args = Array("--full-stacktrace"))
+    assert(out.contains("io.out.f1 <= io.in.f1"))
+    assert(out.contains("io.out.f2 <= io.in.f2"))
+    assert(!out.contains("io.out.f3 <= io.in.f3"))
+    assert(!out.contains("io.out <= io.in"))
+    assert(!out.contains("io.out <- io.in"))
+
+    assert(out.contains("io.bar.f1 <= io.foo.f1"))
+    assert(out.contains("io.bar.f2 <= io.foo.f2"))
+    assert(!out.contains("io.bar.f3 <= io.foo.f3"))
+    assert(!out.contains("io.bar <= io.foo"))
+    assert(!out.contains("io.bar <- io.foo"))
+
+  }
+  property("(D.p) :<>= works with DataView to connect a two Bundles with a common trait") {
+    import chisel3.experimental.dataview._
+
+    class SmallBundle extends Bundle {
+      val common = Output(UInt(4.W))
+      val commonFlipped = Input(UInt(4.W))
+    }
+    class BigA extends SmallBundle {
+      val a = Input(UInt(6.W))
+    }
+    class BigB extends SmallBundle {
+      val b = Output(UInt(6.W))
+    }
+
+    class ConnectCommonTrait extends Module {
+      val io = IO(new Bundle {
+        val in = Flipped(new BigA)
+        val out = (new BigB)
+      })
+      io.in := DontCare
+      io.out := DontCare
+      io.out.viewAsSupertype(new SmallBundle) :<>= io.in.viewAsSupertype(Flipped(new SmallBundle))
+    }
+    val out = ChiselStage.emitChirrtl { new ConnectCommonTrait() }
+    assert(!out.contains("io.out <= io.in"))
+    assert(!out.contains("io.out <- io.in"))
+    assert(out.contains("io.out.common <= io.in.common"))
+    assert(out.contains("io.in.commonFlipped <= io.out.commonFlipped"))
+    assert(!out.contains("io.out.b <= io.in.b"))
+    assert(!out.contains("io.in.a  <= io.out.a"))
+  }
+
+  property("(D.q) :<>= works between Vec and Seq, as well as Vec and Vec") {
+    class ConnectVecSeqAndVecVec extends Module {
+      val a = IO(Vec(3, UInt(3.W)))
+      val b = IO(Vec(3, UInt(3.W)))
+      a :<>= Seq(0.U, 1.U, 2.U)
+      b :<>= VecInit(0.U, 1.U, 2.U)
+    }
+    val out = ChiselStage.emitChirrtl { new ConnectVecSeqAndVecVec() }
+    assert(out.contains("""a[0] <= UInt<1>("h0")"""))
+    assert(out.contains("""a[1] <= UInt<1>("h1")"""))
+    assert(out.contains("""a[2] <= UInt<2>("h2")"""))
+    assert(out.contains("""b[0] <= _WIRE[0]"""))
+    assert(out.contains("""b[1] <= _WIRE[1]"""))
+    assert(out.contains("""b[2] <= _WIRE[2]"""))
+  }
+
+}

--- a/src/test/scala/chiselTests/DirectionalBulkConnectSpec.scala
+++ b/src/test/scala/chiselTests/DirectionalBulkConnectSpec.scala
@@ -211,11 +211,9 @@ class DirectionalBulkConnectSpec extends ChiselPropSpec with Utils {
       val ready = Flipped(Bool())
     }
     val out = ChiselStage.emitChirrtl { new CrossDirectionalMonoConnectsWithWires(new Decoupled, new Decoupled, 1) }
-    assert(out.contains(
-      "wiresIn_0.bits <= io.in.bits",
-      "wiresIn_0.valid <= io.in.valid",
-      "wiresIn_0.ready <= io.in.ready",
-    ))
+    assert(out.contains("wiresIn_0.bits <= io.in.bits"))
+    assert(out.contains("wiresIn_0.valid <= io.in.valid"))
+    assert(out.contains("wiresIn_0.ready <= io.in.ready"))
   }
 
   property("(D.o) :<>= works with DataView to connect a bundle that is a subtype") {

--- a/src/test/scala/chiselTests/DirectionalBulkConnectSpec.scala
+++ b/src/test/scala/chiselTests/DirectionalBulkConnectSpec.scala
@@ -11,324 +11,411 @@ import chisel3.experimental.VecLiterals._
 import chisel3.stage.ChiselStage
 import chisel3.testers.BasicTester
 
-class CrossDirectionalBulkConnects(inType: Data, outType: Data) extends Module {
+class ConnectionTest[T <: Data, S <: Data](outType: S, inType: T, inDrivesOut: Boolean, op: (Data, Data) => Unit, nTmps: Int) extends Module {
   val io = IO(new Bundle {
     val in = Flipped(inType)
     val out = Flipped(Flipped(outType)) // no clonetype, no Aligned (yet)
   })
-  io.out :<>= io.in
-}
 
-class NotCommutativeCrossDirectionalBulkConnects(inType: Data, outType: Data) extends Module {
-  val io = IO(new Bundle {
-    val in = Flipped(inType)
-    val out = Flipped(Flipped(outType)) // no clonetype, no Aligned (yet)
-  })
-  io.in :<>= io.out
-}
-
-class NotWritableCrossDirectionalBulkConnects(inType: Data) extends Module {
-  val io = IO(new Bundle {
-    val in = Flipped(inType)
-  })
-  val tmp = Wire(Flipped(inType))
-  io.in :<>= tmp
-}
-
-class CrossDirectionalBulkConnectsWithWires(inType: Data, outType: Data, nTmps: Int) extends Module {
-  val io = IO(new Bundle {
-    val in = Flipped(inType)
-    val out = Flipped(Flipped(outType)) // no clonetype, no Aligned (yet)
-  })
-  require(nTmps > 0)
   val wiresIn = Seq.fill(nTmps)(Wire(inType))
   val wiresOut = Seq.fill(nTmps)(Wire(outType))
   (Seq(io.out) ++ wiresOut ++ wiresIn).zip(wiresOut ++ wiresIn :+ io.in).foreach {
-    case (l, r) =>
-      l :<>= r
+    case (l, r) => if (inDrivesOut) op(l, r) else op(r, l)
   }
 }
 
-class CrossDirectionalMonoConnectsWithWires(inType: Data, outType: Data, nTmps: Int) extends Module {
-  val io = IO(new Bundle {
-    val in = Flipped(inType)
-    val out = Output(outType) // no clonetype, no Aligned (yet)
-  })
-  require(nTmps > 0)
-  val wiresIn = Seq.fill(nTmps)(Wire(inType))
-  val wiresOut = Seq.fill(nTmps)(Wire(outType))
-  (Seq(io.out) ++ wiresOut ++ wiresIn).zip(wiresOut ++ wiresIn :+ io.in).foreach {
-    case (l, r) =>
-      l :#= r
-  }
-}
 
-class DirectionalBulkConnectSpec extends ChiselPropSpec with Utils {
+//class CrossDirectionalMonoConnectsWithWires(inType: Data, outType: Data, nTmps: Int) extends Module {
+//  val io = IO(new Bundle {
+//    val in = Flipped(inType)
+//    val out = Output(outType) // no clonetype, no Aligned (yet)
+//  })
+//  require(nTmps > 0)
+//  val wiresIn = Seq.fill(nTmps)(Wire(inType))
+//  val wiresOut = Seq.fill(nTmps)(Wire(outType))
+//  (Seq(io.out) ++ wiresOut ++ wiresIn).zip(wiresOut ++ wiresIn :+ io.in).foreach {
+//    case (l, r) =>
+//      l :#= r
+//  }
+//}
+
+class DirectionalBulkConnectSpec extends ChiselFunSpec with Utils {
+  def testCheck(firrtl: String, matches: String*): Unit = {
+    val unmatched = matches.collect { 
+      case m if !firrtl.contains(m) => m
+    }.toList
+    assert(unmatched.isEmpty, s"Unmatched in output:\n$firrtl")
+  }
+  def testBuild[T <: Data, S <: Data](outType: S, inType: T, inDrivesOut: Boolean, op: (Data, Data) => Unit, nTmps: Int): String = {
+    ChiselStage.emitFirrtl({ new ConnectionTest(outType, inType, inDrivesOut, op, nTmps) }, true, true)
+  }
+
+  def vec[T <: Data](tpe: T) = Vec(3, tpe)
+  def alignedBundle[T <: Data](fieldType: T) = new Bundle {
+    val foo = Flipped(Flipped(fieldType))
+    val bar = Flipped(Flipped(fieldType))
+  }
+  def mixedBundle[T <: Data](fieldType: T) = new Bundle {
+    val foo = Flipped(Flipped(fieldType))
+    val bar = Flipped(fieldType)
+  }
+  def alignedFooBundle[T <: Data](fieldType: T) = new Bundle {
+    val foo = Flipped(Flipped(fieldType))
+  }
 
   // (D)irectional Bulk Connect tests
-  property("(D.a) SInt :<>= SInt should succeed") {
-    ChiselStage.elaborate { new CrossDirectionalBulkConnects(SInt(16.W), SInt(16.W)) }
-  }
-  property("(D.b) UInt :<>= UInt should succeed") {
-    ChiselStage.elaborate { new CrossDirectionalBulkConnects(UInt(16.W), UInt(16.W)) }
-  }
-  property("(D.c) SInt :<>= UInt should fail") {
-    intercept[ChiselException] { ChiselStage.elaborate { new CrossDirectionalBulkConnects(UInt(16.W), SInt(16.W)) } }
-  }
-  property("(D.d) Decoupled :<>= Decoupled should succeed") {
-    class Decoupled extends Bundle {
-      val bits = UInt(3.W)
-      val valid = Bool()
-      val ready = Flipped(Bool())
-    }
-    val out = ChiselStage.emitChirrtl { new CrossDirectionalBulkConnects(new Decoupled, new Decoupled) }
-    assert(out.contains("io.out <= io.in"))
-  }
-  property("(D.d) Aggregates with same-named fields should succeed") {
-    class Foo extends Bundle {
-      val foo = Bool()
-      val bar = Flipped(Bool())
-    }
-    class FooLike extends Bundle {
-      val foo = Bool()
-      val bar = Flipped(Bool())
-    }
-    val out = ChiselStage.emitChirrtl { new CrossDirectionalBulkConnects(new Foo, new FooLike) }
-    assert(out.contains("io.out <= io.in"))
-  }
-  property("(D.d) Decoupled[Foo] :<>= Decoupled[Foo-Like] should succeed") {
-    class Foo extends Bundle {
-      val foo = Bool()
-      val bar = Flipped(Bool())
-    }
-    class FooLike extends Bundle {
-      val foo = Bool()
-      val bar = Flipped(Bool())
-    }
-    class Decoupled[T <: Data](gen: => T) extends Bundle {
-      val bits = gen
-      val valid = Bool()
-      val ready = Flipped(Bool())
-    }
-    val out = ChiselStage.emitChirrtl {
-      new CrossDirectionalBulkConnects(new Decoupled(new Foo()), new Decoupled(new FooLike()))
-    }
-    assert(out.contains("io.out <= io.in"))
-  }
-  property("(D.e) different relative flips, but same absolute flippage is an error") {
-    class X(yflip: Boolean, zflip: Boolean) extends Bundle {
-      val y = if (yflip) Flipped(new Y(zflip)) else new Y(zflip)
-    }
-    class Y(flip: Boolean) extends Bundle {
-      val z = if (flip) Flipped(Bool()) else Bool()
-    }
-    intercept[ChiselException] {
-      ChiselStage.emitVerilog { new CrossDirectionalBulkConnects(new X(true, false), new X(false, true)) }
-    }
-  }
-  property("(D.f) :<>= is not commutative.") {
-    intercept[ChiselException] {
-      ChiselStage.elaborate { new NotCommutativeCrossDirectionalBulkConnects(UInt(16.W), UInt(16.W)) }
-    }
-  }
-  property("(D.g) UInt :<>= UInt should succeed with intermediate Wires") {
-    ChiselStage.elaborate { new CrossDirectionalBulkConnectsWithWires(UInt(16.W), UInt(16.W), 1) }
-  }
-  property("(D.h) Decoupled :<>= Decoupled should succeed with intermediate Wires") {
-    class Decoupled extends Bundle {
-      val bits = UInt(3.W)
-      val valid = Bool()
-      val ready = Flipped(Bool())
-    }
-    val out = ChiselStage.emitChirrtl { new CrossDirectionalBulkConnectsWithWires(new Decoupled, new Decoupled, 2) }
-    assert(out.contains("io.out <= wiresOut_0"))
-    assert(out.contains("wiresOut_1 <= wiresIn_0"))
-    assert(out.contains("wiresIn_1 <= io.in"))
-  }
-  property("(D.i) Aggregates :<>= with missing fields should not succeed, no matter the direction.") {
-    class Foo extends Bundle {
-      val foo = Bool()
-    }
-    class FooBar extends Bundle {
-      val foo = Bool()
-      val bar = Bool()
-    }
-    intercept[ChiselException] {
-      ChiselStage.emitChirrtl { new CrossDirectionalBulkConnects(new Foo(), new FooBar()) }
-    }
-    intercept[ChiselException] {
-      ChiselStage.emitChirrtl { new CrossDirectionalBulkConnects(new FooBar(), new Foo()) }
-    }
-  }
-  property("(D.j) Cannot :<>= to something that is not writable.") {
-
-    intercept[ChiselException] {
-      ChiselStage.emitChirrtl { new NotWritableCrossDirectionalBulkConnects(UInt(16.W)) }
-    }
-  }
-  property("(D.k) Can :<>= to Vecs of the same length") {
-    val out = (new ChiselStage).emitChirrtl { new CrossDirectionalBulkConnects(Vec(3, UInt(16.W)), Vec(3, UInt(16.W))) }
-    assert(out.contains("io.out <= io.in"))
-  }
-  property("(D.l) :<>= between Vecs of different length should not succeed, no matter the direction") {
-    intercept[ChiselException] {
-      ChiselStage.emitChirrtl { new CrossDirectionalBulkConnects(Vec(2, UInt(16.W)), Vec(3, UInt(16.W))) }
-    }
-    intercept[ChiselException] {
-      ChiselStage.emitChirrtl { new CrossDirectionalBulkConnects(Vec(3, UInt(16.W)), Vec(2, UInt(16.W))) }
+  describe("(0) :<>=") {
+    def test(tpeIn: Data): Unit = testDistinctTypes(tpeIn, tpeIn)
+    def testDistinctTypes(tpeOut: Data, tpeIn: Data): Unit = testCheck(testBuild(tpeIn, tpeOut, true, {_ :<>= _}, 0), "io.out <= io.in")
+    def testException(tpeOut: Data, tpeIn: Data, messageMatch: String): Unit = {
+      val x = intercept[ChiselException] {
+        testBuild(tpeOut, tpeIn, true, {_ :<>= _}, 0)
+      }
+      assert(x.getMessage().contains(messageMatch), "Exception has wrong error message")
     }
 
+    it("(0.a): Emit '<=' between identical non-Analog ground types") {
+      test(Bool())
+      test(UInt(16.W))
+      test(SInt(16.W))
+      test(Clock())
+      testDistinctTypes(UInt(16.W), Bool()) // Bool inherits UInt, so this should work
+      testDistinctTypes(Bool(), UInt(16.W)) // Bool inherits UInt, so this should work
+    }
+    it("(0.b): Emit '<=' between identical aligned aggregate types") {
+      test(vec(Bool()))
+      test(vec(UInt(16.W)))
+      test(vec(SInt(16.W)))
+      test(vec(Clock()))
+
+      test(alignedBundle(Bool()))
+      test(alignedBundle(UInt(16.W)))
+      test(alignedBundle(SInt(16.W)))
+      test(alignedBundle(Clock()))
+    }
+    it("(0.c): Emit '<=' between identical aligned aggregate types, hierarchically") {
+      test(vec(vec(Bool())))
+      test(vec(vec(UInt(16.W))))
+      test(vec(vec(SInt(16.W))))
+      test(vec(vec(Clock())))
+
+      test(vec(alignedBundle(Bool())))
+      test(vec(alignedBundle(UInt(16.W))))
+      test(vec(alignedBundle(SInt(16.W))))
+      test(vec(alignedBundle(Clock())))
+
+      test(alignedBundle(vec(Bool())))
+      test(alignedBundle(vec(UInt(16.W))))
+      test(alignedBundle(vec(SInt(16.W))))
+      test(alignedBundle(vec(Clock())))
+
+      test(alignedBundle(alignedBundle(Bool())))
+      test(alignedBundle(alignedBundle(UInt(16.W))))
+      test(alignedBundle(alignedBundle(SInt(16.W))))
+      test(alignedBundle(alignedBundle(Clock())))
+    }
+    it("(0.d): Emit '<=' between identical aggregate types with mixed flipped/aligned fields") {
+      test(mixedBundle(Bool()))
+      test(mixedBundle(UInt(16.W)))
+      test(mixedBundle(SInt(16.W)))
+      test(mixedBundle(Clock()))
+    }
+    it("(0.e): Emit '<=' between identical aggregate types with mixed flipped/aligned fields, hierarchically") {
+      test(vec(mixedBundle(Bool())))
+      test(vec(mixedBundle(UInt(16.W))))
+      test(vec(mixedBundle(SInt(16.W))))
+      test(vec(mixedBundle(Clock())))
+
+      test(mixedBundle(vec(Bool())))
+      test(mixedBundle(vec(UInt(16.W))))
+      test(mixedBundle(vec(SInt(16.W))))
+      test(mixedBundle(vec(Clock())))
+
+      test(mixedBundle(mixedBundle(Bool())))
+      test(mixedBundle(mixedBundle(UInt(16.W))))
+      test(mixedBundle(mixedBundle(SInt(16.W))))
+      test(mixedBundle(mixedBundle(Clock())))
+    }
+    it("(0.f): Throw exception between differing ground types") {
+      testException(UInt(3.W), SInt(3.W), "have different types")
+      testException(UInt(3.W), Clock(), "have different types")
+      testException(SInt(3.W), Clock(), "have different types")
+    }
+    it("(0.g): Emit 'attach' between Analog types") {
+      testCheck(testBuild(Analog(3.W), Analog(3.W), true, {_ :<>= _}, 0), "attach (io.out, io.in)")
+    }
+    it("(0.h): Error on missing field names from either right-hand-side or left-hand-side") {
+      testException(mixedBundle(Bool()), alignedFooBundle(Bool()), "dangling consumer field")
+      testException(alignedFooBundle(Bool()), mixedBundle(Bool()), "unassigned producer field")
+    }
+    it("(0.i): Error if different absolute flippedness on leaf fields between right-hand-side or left-hand-side") {
+      testException(mixedBundle(Bool()), alignedBundle(Bool()), "inversely oriented fields")
+      testException(alignedBundle(Bool()), mixedBundle(Bool()), "inversely oriented fields")
+    }
   }
-  property(
-    "(D.m) :<>= is NOT equivalent to Chisel.:= in that  `A Module with missing bundle fields when compiled with the Chisel compatibility package` *should* `throw an exception` "
-  ) {
-    // This is copied from CompatibilitySpec but the := is replaced with :<>=
-    class SmallBundle extends Bundle {
-      val f1 = UInt(4.W)
-      val f2 = UInt(5.W)
-    }
-    class BigBundle extends SmallBundle {
-      val f3 = UInt(6.W)
-    }
+  //property("(D.a) SInt :<>= SInt should succeed") {
+  //  checkTest(buildTest(SInt(16.W), SInt(16.W), true, {_ :<>= _}, 0), "io.out <= io.in")
+  //}
+  //property("(D.b) UInt :<>= UInt should succeed") {
+  //  ChiselStage.elaborate { new CrossDirectionalBulkConnects(UInt(16.W), UInt(16.W)) }
+  //}
+  //property("(D.c) SInt :<>= UInt should fail") {
+  //  intercept[ChiselException] { ChiselStage.elaborate { new CrossDirectionalBulkConnects(UInt(16.W), SInt(16.W)) } }
+  //}
+  //property("(D.d) Decoupled :<>= Decoupled should succeed") {
+  //  class Decoupled extends Bundle {
+  //    val bits = UInt(3.W)
+  //    val valid = Bool()
+  //    val ready = Flipped(Bool())
+  //  }
+  //  val out = ChiselStage.emitChirrtl { new CrossDirectionalBulkConnects(new Decoupled, new Decoupled) }
+  //  assert(out.contains("io.out <= io.in"))
+  //}
+  //property("(D.d) Aggregates with same-named fields should succeed") {
+  //  class Foo extends Bundle {
+  //    val foo = Bool()
+  //    val bar = Flipped(Bool())
+  //  }
+  //  class FooLike extends Bundle {
+  //    val foo = Bool()
+  //    val bar = Flipped(Bool())
+  //  }
+  //  val out = ChiselStage.emitChirrtl { new CrossDirectionalBulkConnects(new Foo, new FooLike) }
+  //  assert(out.contains("io.out <= io.in"))
+  //}
+  //property("(D.d) Decoupled[Foo] :<>= Decoupled[Foo-Like] should succeed") {
+  //  class Foo extends Bundle {
+  //    val foo = Bool()
+  //    val bar = Flipped(Bool())
+  //  }
+  //  class FooLike extends Bundle {
+  //    val foo = Bool()
+  //    val bar = Flipped(Bool())
+  //  }
+  //  class Decoupled[T <: Data](gen: => T) extends Bundle {
+  //    val bits = gen
+  //    val valid = Bool()
+  //    val ready = Flipped(Bool())
+  //  }
+  //  val out = ChiselStage.emitChirrtl {
+  //    new CrossDirectionalBulkConnects(new Decoupled(new Foo()), new Decoupled(new FooLike()))
+  //  }
+  //  assert(out.contains("io.out <= io.in"))
+  //}
+  //property("(D.e) different relative flips, but same absolute flippage is an error") {
+  //  class X(yflip: Boolean, zflip: Boolean) extends Bundle {
+  //    val y = if (yflip) Flipped(new Y(zflip)) else new Y(zflip)
+  //  }
+  //  class Y(flip: Boolean) extends Bundle {
+  //    val z = if (flip) Flipped(Bool()) else Bool()
+  //  }
+  //  intercept[ChiselException] {
+  //    ChiselStage.emitVerilog { new CrossDirectionalBulkConnects(new X(true, false), new X(false, true)) }
+  //  }
+  //}
+  //property("(D.f) :<>= is not commutative.") {
+  //  intercept[ChiselException] {
+  //    ChiselStage.elaborate { new NotCommutativeCrossDirectionalBulkConnects(UInt(16.W), UInt(16.W)) }
+  //  }
+  //}
+  //property("(D.g) UInt :<>= UInt should succeed with intermediate Wires") {
+  //  ChiselStage.elaborate { new CrossDirectionalBulkConnectsWithWires(UInt(16.W), UInt(16.W), 1) }
+  //}
+  //property("(D.h) Decoupled :<>= Decoupled should succeed with intermediate Wires") {
+  //  class Decoupled extends Bundle {
+  //    val bits = UInt(3.W)
+  //    val valid = Bool()
+  //    val ready = Flipped(Bool())
+  //  }
+  //  val out = ChiselStage.emitChirrtl { new CrossDirectionalBulkConnectsWithWires(new Decoupled, new Decoupled, 2) }
+  //  assert(out.contains("io.out <= wiresOut_0"))
+  //  assert(out.contains("wiresOut_1 <= wiresIn_0"))
+  //  assert(out.contains("wiresIn_1 <= io.in"))
+  //}
+  //property("(D.i) Aggregates :<>= with missing fields should not succeed, no matter the direction.") {
+  //  class Foo extends Bundle {
+  //    val foo = Bool()
+  //  }
+  //  class FooBar extends Bundle {
+  //    val foo = Bool()
+  //    val bar = Bool()
+  //  }
+  //  intercept[ChiselException] {
+  //    ChiselStage.emitChirrtl { new CrossDirectionalBulkConnects(new Foo(), new FooBar()) }
+  //  }
+  //  intercept[ChiselException] {
+  //    ChiselStage.emitChirrtl { new CrossDirectionalBulkConnects(new FooBar(), new Foo()) }
+  //  }
+  //}
+  //property("(D.j) Cannot :<>= to something that is not writable.") {
 
-    class ConnectFieldMismatchModule extends Module {
-      val io = IO(new Bundle {
-        val in = Input((new SmallBundle))
-        val out = Output((new BigBundle))
-      })
-      (io.out: Data) :<>= (io.in: Data)
-    }
-    intercept[ChiselException] {
-      ChiselStage.elaborate { new ConnectFieldMismatchModule() }
-    }
-  }
+  //  intercept[ChiselException] {
+  //    ChiselStage.emitChirrtl { new NotWritableCrossDirectionalBulkConnects(UInt(16.W)) }
+  //  }
+  //}
+  //property("(D.k) Can :<>= to Vecs of the same length") {
+  //  val out = (new ChiselStage).emitChirrtl { new CrossDirectionalBulkConnects(Vec(3, UInt(16.W)), Vec(3, UInt(16.W))) }
+  //  assert(out.contains("io.out <= io.in"))
+  //}
+  //property("(D.l) :<>= between Vecs of different length should not succeed, no matter the direction") {
+  //  intercept[ChiselException] {
+  //    ChiselStage.emitChirrtl { new CrossDirectionalBulkConnects(Vec(2, UInt(16.W)), Vec(3, UInt(16.W))) }
+  //  }
+  //  intercept[ChiselException] {
+  //    ChiselStage.emitChirrtl { new CrossDirectionalBulkConnects(Vec(3, UInt(16.W)), Vec(2, UInt(16.W))) }
+  //  }
 
-  property(
-    "(D.n) :#= is the same as chisel3.:=, in that fields must match and all consumer fields are written to, regardless of flippedness"
-  ) {
-    // This is copied from CompatibilitySpec but the := is replaced with :<>=
-    class Decoupled extends Bundle {
-      val bits = UInt(3.W)
-      val valid = Bool()
-      val ready = Flipped(Bool())
-    }
-    val out = ChiselStage.emitChirrtl { new CrossDirectionalMonoConnectsWithWires(new Decoupled, new Decoupled, 1) }
-    assert(out.contains("wiresIn_0.bits <= io.in.bits"))
-    assert(out.contains("wiresIn_0.valid <= io.in.valid"))
-    assert(out.contains("wiresIn_0.ready <= io.in.ready"))
-  }
+  //}
+  //property(
+  //  "(D.m) :<>= is NOT equivalent to Chisel.:= in that  `A Module with missing bundle fields when compiled with the Chisel compatibility package` *should* `throw an exception` "
+  //) {
+  //  // This is copied from CompatibilitySpec but the := is replaced with :<>=
+  //  class SmallBundle extends Bundle {
+  //    val f1 = UInt(4.W)
+  //    val f2 = UInt(5.W)
+  //  }
+  //  class BigBundle extends SmallBundle {
+  //    val f3 = UInt(6.W)
+  //  }
 
-  property("(D.o) :<>= works with DataView to connect a bundle that is a subtype") {
-    import chisel3.experimental.dataview._
+  //  class ConnectFieldMismatchModule extends Module {
+  //    val io = IO(new Bundle {
+  //      val in = Input((new SmallBundle))
+  //      val out = Output((new BigBundle))
+  //    })
+  //    (io.out: Data) :<>= (io.in: Data)
+  //  }
+  //  intercept[ChiselException] {
+  //    ChiselStage.elaborate { new ConnectFieldMismatchModule() }
+  //  }
+  //}
 
-    class SmallBundle extends Bundle {
-      val f1 = UInt(4.W)
-      val f2 = UInt(5.W)
-    }
-    class BigBundle extends SmallBundle {
-      val f3 = UInt(6.W)
-    }
+  //property(
+  //  "(D.n) :#= is the same as chisel3.:=, in that fields must match and all consumer fields are written to, regardless of flippedness"
+  //) {
+  //  // This is copied from CompatibilitySpec but the := is replaced with :<>=
+  //  class Decoupled extends Bundle {
+  //    val bits = UInt(3.W)
+  //    val valid = Bool()
+  //    val ready = Flipped(Bool())
+  //  }
+  //  val out = ChiselStage.emitChirrtl { new CrossDirectionalMonoConnectsWithWires(new Decoupled, new Decoupled, 1) }
+  //  assert(out.contains("wiresIn_0.bits <= io.in.bits"))
+  //  assert(out.contains("wiresIn_0.valid <= io.in.valid"))
+  //  assert(out.contains("wiresIn_0.ready <= io.in.ready"))
+  //}
 
-    class ConnectSupertype extends Module {
-      val io = IO(new Bundle {
-        val in = Input((new SmallBundle))
-        val out = Output((new BigBundle))
+  //property("(D.o) :<>= works with DataView to connect a bundle that is a subtype") {
+  //  import chisel3.experimental.dataview._
 
-        val foo = Input((new BigBundle))
-        val bar = Output(new SmallBundle)
-      })
-      io.out := DontCare
-      io.out.viewAsSupertype(Output(new SmallBundle)) :<>= io.in
+  //  class SmallBundle extends Bundle {
+  //    val f1 = UInt(4.W)
+  //    val f2 = UInt(5.W)
+  //  }
+  //  class BigBundle extends SmallBundle {
+  //    val f3 = UInt(6.W)
+  //  }
 
-      io.bar := DontCare
-      io.bar :<>= io.foo.viewAsSupertype(Input((new SmallBundle)))
-    }
-    val out = (new ChiselStage).emitChirrtl(gen = new ConnectSupertype(), args = Array("--full-stacktrace"))
-    assert(out.contains("io.out.f1 <= io.in.f1"))
-    assert(out.contains("io.out.f2 <= io.in.f2"))
-    assert(!out.contains("io.out.f3 <= io.in.f3"))
-    assert(!out.contains("io.out <= io.in"))
-    assert(!out.contains("io.out <- io.in"))
+  //  class ConnectSupertype extends Module {
+  //    val io = IO(new Bundle {
+  //      val in = Input((new SmallBundle))
+  //      val out = Output((new BigBundle))
 
-    assert(out.contains("io.bar.f1 <= io.foo.f1"))
-    assert(out.contains("io.bar.f2 <= io.foo.f2"))
-    assert(!out.contains("io.bar.f3 <= io.foo.f3"))
-    assert(!out.contains("io.bar <= io.foo"))
-    assert(!out.contains("io.bar <- io.foo"))
+  //      val foo = Input((new BigBundle))
+  //      val bar = Output(new SmallBundle)
+  //    })
+  //    io.out := DontCare
+  //    io.out.viewAsSupertype(Output(new SmallBundle)) :<>= io.in
 
-  }
-  property("(D.p) :<>= works with DataView to connect a two Bundles with a common trait") {
-    import chisel3.experimental.dataview._
+  //    io.bar := DontCare
+  //    io.bar :<>= io.foo.viewAsSupertype(Input((new SmallBundle)))
+  //  }
+  //  val out = (new ChiselStage).emitChirrtl(gen = new ConnectSupertype(), args = Array("--full-stacktrace"))
+  //  assert(out.contains("io.out.f1 <= io.in.f1"))
+  //  assert(out.contains("io.out.f2 <= io.in.f2"))
+  //  assert(!out.contains("io.out.f3 <= io.in.f3"))
+  //  assert(!out.contains("io.out <= io.in"))
+  //  assert(!out.contains("io.out <- io.in"))
 
-    class SmallBundle extends Bundle {
-      val common = Output(UInt(4.W))
-      val commonFlipped = Input(UInt(4.W))
-    }
-    class BigA extends SmallBundle {
-      val a = Input(UInt(6.W))
-    }
-    class BigB extends SmallBundle {
-      val b = Output(UInt(6.W))
-    }
+  //  assert(out.contains("io.bar.f1 <= io.foo.f1"))
+  //  assert(out.contains("io.bar.f2 <= io.foo.f2"))
+  //  assert(!out.contains("io.bar.f3 <= io.foo.f3"))
+  //  assert(!out.contains("io.bar <= io.foo"))
+  //  assert(!out.contains("io.bar <- io.foo"))
 
-    class ConnectCommonTrait extends Module {
-      val io = IO(new Bundle {
-        val in = Flipped(new BigA)
-        val out = (new BigB)
-      })
-      io.in := DontCare
-      io.out := DontCare
-      io.out.viewAsSupertype(new SmallBundle) :<>= io.in.viewAsSupertype(Flipped(new SmallBundle))
-    }
-    val out = ChiselStage.emitChirrtl { new ConnectCommonTrait() }
-    assert(!out.contains("io.out <= io.in"))
-    assert(!out.contains("io.out <- io.in"))
-    assert(out.contains("io.out.common <= io.in.common"))
-    assert(out.contains("io.in.commonFlipped <= io.out.commonFlipped"))
-    assert(!out.contains("io.out.b <= io.in.b"))
-    assert(!out.contains("io.in.a  <= io.out.a"))
-  }
+  //}
+  //property("(D.p) :<>= works with DataView to connect a two Bundles with a common trait") {
+  //  import chisel3.experimental.dataview._
 
-  property("(D.q) :<>= works between Vec and Seq, as well as Vec and Vec") {
-    class ConnectVecSeqAndVecVec extends Module {
-      val a = IO(Vec(3, UInt(3.W)))
-      val b = IO(Vec(3, UInt(3.W)))
-      a :<>= Seq(0.U, 1.U, 2.U)
-      b :<>= VecInit(0.U, 1.U, 2.U)
-    }
-    val out = ChiselStage.emitChirrtl { new ConnectVecSeqAndVecVec() }
-    assert(out.contains("""a[0] <= UInt<1>("h0")"""))
-    assert(out.contains("""a[1] <= UInt<1>("h1")"""))
-    assert(out.contains("""a[2] <= UInt<2>("h2")"""))
-    assert(out.contains("""b[0] <= _WIRE[0]"""))
-    assert(out.contains("""b[1] <= _WIRE[1]"""))
-    assert(out.contains("""b[2] <= _WIRE[2]"""))
-  }
+  //  class SmallBundle extends Bundle {
+  //    val common = Output(UInt(4.W))
+  //    val commonFlipped = Input(UInt(4.W))
+  //  }
+  //  class BigA extends SmallBundle {
+  //    val a = Input(UInt(6.W))
+  //  }
+  //  class BigB extends SmallBundle {
+  //    val b = Output(UInt(6.W))
+  //  }
 
-  property("(D.r) :<>= works for different missing Defaulting subfields") {
-    trait Info extends Bundle {
-      val info = UInt(32.W)
-    }
-    class InfoECC extends Info {
-      val ecc = Defaulting(false.B)
-    }
-    class InfoControl extends Info {
-      val control = Defaulting(false.B)
-    }
-    val firrtl = ChiselStage.emitChirrtl {
-      new CrossDirectionalBulkConnectsWithWires(new InfoECC(): Info, new InfoControl(): Info, 1)
-    }
-    println(firrtl)
-    assert(firrtl.contains("wiresOut_0.control <= UInt<1>(\"h0\")"))
-    assert(firrtl.contains("wiresOut_0.info <= wiresIn_0.info"))
-  }
-  property("(D.s) :<>= works for different missing Defaulting subindexes") {
-    def vecType(size: Int) = Vec(size, Defaulting(UInt(3.W), 0.U))
-    val firrtl = ChiselStage.emitChirrtl { new CrossDirectionalBulkConnectsWithWires(vecType(2), vecType(3), 1) }
-    println(firrtl)
-    assert(firrtl.contains("wiresOut_0[2] <= UInt<1>(\"h0\")"))
-    assert(firrtl.contains("wiresOut_0[1] <= wiresIn_0[1]"))
-    assert(firrtl.contains("wiresOut_0[0] <= wiresIn_0[0]"))
+  //  class ConnectCommonTrait extends Module {
+  //    val io = IO(new Bundle {
+  //      val in = Flipped(new BigA)
+  //      val out = (new BigB)
+  //    })
+  //    io.in := DontCare
+  //    io.out := DontCare
+  //    io.out.viewAsSupertype(new SmallBundle) :<>= io.in.viewAsSupertype(Flipped(new SmallBundle))
+  //  }
+  //  val out = ChiselStage.emitChirrtl { new ConnectCommonTrait() }
+  //  assert(!out.contains("io.out <= io.in"))
+  //  assert(!out.contains("io.out <- io.in"))
+  //  assert(out.contains("io.out.common <= io.in.common"))
+  //  assert(out.contains("io.in.commonFlipped <= io.out.commonFlipped"))
+  //  assert(!out.contains("io.out.b <= io.in.b"))
+  //  assert(!out.contains("io.in.a  <= io.out.a"))
+  //}
 
-  }
+  //property("(D.q) :<>= works between Vec and Seq, as well as Vec and Vec") {
+  //  class ConnectVecSeqAndVecVec extends Module {
+  //    val a = IO(Vec(3, UInt(3.W)))
+  //    val b = IO(Vec(3, UInt(3.W)))
+  //    a :<>= Seq(0.U, 1.U, 2.U)
+  //    b :<>= VecInit(0.U, 1.U, 2.U)
+  //  }
+  //  val out = ChiselStage.emitChirrtl { new ConnectVecSeqAndVecVec() }
+  //  assert(out.contains("""a[0] <= UInt<1>("h0")"""))
+  //  assert(out.contains("""a[1] <= UInt<1>("h1")"""))
+  //  assert(out.contains("""a[2] <= UInt<2>("h2")"""))
+  //  assert(out.contains("""b[0] <= _WIRE[0]"""))
+  //  assert(out.contains("""b[1] <= _WIRE[1]"""))
+  //  assert(out.contains("""b[2] <= _WIRE[2]"""))
+  //}
+
+  //property("(D.r) :<>= works for different missing Defaulting subfields") {
+  //  trait Info extends Bundle {
+  //    val info = UInt(32.W)
+  //  }
+  //  class InfoECC extends Info {
+  //    val ecc = Defaulting(false.B)
+  //  }
+  //  class InfoControl extends Info {
+  //    val control = Defaulting(false.B)
+  //  }
+  //  val firrtl = ChiselStage.emitChirrtl {
+  //    new CrossDirectionalBulkConnectsWithWires(new InfoECC(): Info, new InfoControl(): Info, 1)
+  //  }
+  //  println(firrtl)
+  //  assert(firrtl.contains("wiresOut_0.control <= UInt<1>(\"h0\")"))
+  //  assert(firrtl.contains("wiresOut_0.info <= wiresIn_0.info"))
+  //}
+  //property("(D.s) :<>= works for different missing Defaulting subindexes") {
+  //  def vecType(size: Int) = Vec(size, Defaulting(UInt(3.W), 0.U))
+  //  val firrtl = ChiselStage.emitChirrtl { new CrossDirectionalBulkConnectsWithWires(vecType(2), vecType(3), 1) }
+  //  println(firrtl)
+  //  assert(firrtl.contains("wiresOut_0[2] <= UInt<1>(\"h0\")"))
+  //  assert(firrtl.contains("wiresOut_0[1] <= wiresIn_0[1]"))
+  //  assert(firrtl.contains("wiresOut_0[0] <= wiresIn_0[0]"))
+
+  //}
 }

--- a/src/test/scala/chiselTests/experimental/DefaultingSpec.scala
+++ b/src/test/scala/chiselTests/experimental/DefaultingSpec.scala
@@ -62,5 +62,11 @@ class DefaultingSpec extends ChiselFunSpec with Utils {
       assert(firrtl.contains("io.in <= UInt<1>(\"h1\")"))
       assert(firrtl.contains("io.out <= UInt<1>(\"h0\")"))
     }
+    //TODO: Is it legal for a leaf field to dangle in :<>=, if it defines a default value?
+    // This is weird, because you'd normally not rely on that behavior.
+    // Maybe we make a trait like OkToDangle, and you mix it in?
+    // It probably can't be a trait because you want it to be a value
+    // Its effectively the inverse of the connectableValue. Perhaps it should be UnassignedValue ?
+    // And the inverse of withUnassignedValue() is withDanglingOk() ?
   }
 }

--- a/src/test/scala/chiselTests/experimental/DefaultingSpec.scala
+++ b/src/test/scala/chiselTests/experimental/DefaultingSpec.scala
@@ -14,10 +14,12 @@ import scala.collection.immutable.ListMap
 class DefaultingSpec extends ChiselFunSpec with Utils {
   describe("(0): Defaulting type creation") {
     it("(0.a): Creating a default type of UInt, and then accessing the value") {
-      val firrtl = ChiselStage.emitFirrtl { new Module {
-        val io = IO(Output(Defaulting(UInt(32.W), 1.U)))
-        io.underlying := io.default
-      }}
+      val firrtl = ChiselStage.emitFirrtl {
+        new Module {
+          val io = IO(Output(Defaulting(UInt(32.W), 1.U)))
+          io.underlying := io.default
+        }
+      }
       assert(firrtl.contains("io <= UInt<1>(\"h1\")"))
     }
     it("(0.b): Creating a defaulting type of Bundle") {
@@ -25,18 +27,22 @@ class DefaultingSpec extends ChiselFunSpec with Utils {
         val a = UInt(width.W)
         val b = UInt(width.W)
       }
-      val firrtl = ChiselStage.emitFirrtl { new Module {
-        val io = IO(Output(Defaulting(new MyBundle(32).Lit(_.a -> 1.U, _.b -> 2.U))))
-        io.underlying := io.default
-      }}
+      val firrtl = ChiselStage.emitFirrtl {
+        new Module {
+          val io = IO(Output(Defaulting(new MyBundle(32).Lit(_.a -> 1.U, _.b -> 2.U))))
+          io.underlying := io.default
+        }
+      }
       assert(firrtl.contains("io.a <= UInt<1>(\"h1\")"))
       assert(firrtl.contains("io.b <= UInt<2>(\"h2\")"))
     }
     it("(0.c): Creating a defaulting type of Vec") {
-      val firrtl = ChiselStage.emitFirrtl { new Module {
-        val io = IO(Output(Defaulting(Vec(2, UInt(32.W)).Lit(0 -> 1.U, 1 -> 2.U))))
-        io.underlying := io.default
-      }}
+      val firrtl = ChiselStage.emitFirrtl {
+        new Module {
+          val io = IO(Output(Defaulting(Vec(2, UInt(32.W)).Lit(0 -> 1.U, 1 -> 2.U))))
+          io.underlying := io.default
+        }
+      }
       assert(firrtl.contains("io[0] <= UInt<32>(\"h1\")"))
       assert(firrtl.contains("io[1] <= UInt<32>(\"h2\")"))
     }
@@ -47,10 +53,12 @@ class DefaultingSpec extends ChiselFunSpec with Utils {
         val elements = ListMap("in" -> foo, "out" -> bar)
         def cloneType = (new MyRecord).asInstanceOf[this.type]
       }
-      val firrtl = ChiselStage.emitFirrtl { new Module {
-        val io = IO(Output(Defaulting(new MyRecord().Lit(_.elements("in") -> true.B, _.elements("out") -> false.B))))
-        io.underlying := io.default
-      }}
+      val firrtl = ChiselStage.emitFirrtl {
+        new Module {
+          val io = IO(Output(Defaulting(new MyRecord().Lit(_.elements("in") -> true.B, _.elements("out") -> false.B))))
+          io.underlying := io.default
+        }
+      }
       assert(firrtl.contains("io.in <= UInt<1>(\"h1\")"))
       assert(firrtl.contains("io.out <= UInt<1>(\"h0\")"))
     }

--- a/src/test/scala/chiselTests/experimental/DefaultingSpec.scala
+++ b/src/test/scala/chiselTests/experimental/DefaultingSpec.scala
@@ -9,6 +9,7 @@ import chisel3.experimental.Defaulting
 import chisel3.experimental.BundleLiterals._
 import chisel3.experimental.VecLiterals._
 
+import scala.collection.immutable.ListMap
 
 class DefaultingSpec extends ChiselFunSpec with Utils {
   describe("(0): Defaulting type creation") {
@@ -31,13 +32,27 @@ class DefaultingSpec extends ChiselFunSpec with Utils {
       assert(firrtl.contains("io.a <= UInt<1>(\"h1\")"))
       assert(firrtl.contains("io.b <= UInt<2>(\"h2\")"))
     }
-    it("(0.b): Creating a defaulting type of Vec") {
+    it("(0.c): Creating a defaulting type of Vec") {
       val firrtl = ChiselStage.emitFirrtl { new Module {
         val io = IO(Output(Defaulting(Vec(2, UInt(32.W)).Lit(0 -> 1.U, 1 -> 2.U))))
         io.underlying := io.default
       }}
       assert(firrtl.contains("io[0] <= UInt<32>(\"h1\")"))
       assert(firrtl.contains("io[1] <= UInt<32>(\"h2\")"))
+    }
+    it("(0.d): Creating a defaulting type of Record") {
+      class MyRecord extends Record {
+        val foo = Bool()
+        val bar = Bool()
+        val elements = ListMap("in" -> foo, "out" -> bar)
+        def cloneType = (new MyRecord).asInstanceOf[this.type]
+      }
+      val firrtl = ChiselStage.emitFirrtl { new Module {
+        val io = IO(Output(Defaulting(new MyRecord().Lit(_.elements("in") -> true.B, _.elements("out") -> false.B))))
+        io.underlying := io.default
+      }}
+      assert(firrtl.contains("io.in <= UInt<1>(\"h1\")"))
+      assert(firrtl.contains("io.out <= UInt<1>(\"h0\")"))
     }
   }
 }


### PR DESCRIPTION
### Background

In general, Chisel's connection operators are very broken; their semantics change depending on `import Chisel._` vs `import chisel3._`. Even `chisel3._`'s semantics are not clean; you cannot reason about what will be connected to what unless you know whether the things you are connecting are Wires or IOs. Part of this stems from the fact that we got rid of relative-flippedness for declaring things, instead relying on using Input/Output.

This PR defines four new operators which have very clean semantics which depend solely on the hardware type of the things you are connecting. Using them, we plan to migrate all existing operators semantics to compositions of them, but for now we define them independently of Chisel/chisel3, and thus they have more verbose syntax to make them compatible with both imports.

As we continue, we may rename them etc., but their semantics are composable which is an important property. In fact, there are only actually two operators which, when composed in different ways, can implement the semantics of other kinds of operators: `:<=` and `:>=`. While these operators may not be the most common ones to use, understanding them will help users reason about how all the connection operators work.

I've written a lot of ScalaDoc to describe their semantics. Future work can write more explanative material (mdoc etc.) to flesh out them in more detail.

Update: I've adding the `Defaulting` type, and it the operators will assign default values to unassigned fields, rather than erroring.

### TODO:

- Update docs to clarify strictness guarantees
- Write mdoc
- Brainstorm names for `Defaulting`
- Improve the tests, I'm not happy with their structure, and they aren't testing `:<=` and `:>=`

### Current requested reviewer feedback

- ScalaDoc explanations are clear (and mdoc once written)

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
 - new feature/API 

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

No impact on current code. Adds new operators and documentation.

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
 - Squash: The PR will be squashed and merged (choose this if you have no preference.
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

- Added new operators :<>=, :<=, :>=, :#=
- Added new Scaladoc to :=, <>

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
