### PR TITLE
Wires should have source location information in firrtl

### DIFF
--- a/core/src/main/scala/chisel3/Data.scala
+++ b/core/src/main/scala/chisel3/Data.scala
@@ -9,7 +9,7 @@ import chisel3.experimental.{Analog, BaseModule, DataMirror, EnumType, FixedPoin
 import chisel3.internal.Builder.pushCommand
 import chisel3.internal._
 import chisel3.internal.firrtl._
-import chisel3.internal.sourceinfo.{DeprecatedSourceInfo, SourceInfo, SourceInfoTransform, UnlocatableSourceInfo}
+import chisel3.internal.sourceinfo.{SourceInfo, SourceInfoTransform, UnlocatableSourceInfo}
 
 import scala.collection.immutable.LazyList // Needed for 2.12 alias
 import scala.reflect.ClassTag
@@ -1087,7 +1087,6 @@ object WireDefault {
     implicit sourceInfo: SourceInfo,
     compileOptions:      CompileOptions
   ): T = {
-    implicit val noSourceInfo = UnlocatableSourceInfo
     val x = Wire(t)
     requireIsHardware(init, "wire initializer")
     x := init

--- a/core/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -5,7 +5,7 @@ package chisel3.internal.firrtl
 import firrtl.{ir => fir}
 import chisel3._
 import chisel3.internal._
-import chisel3.internal.sourceinfo.SourceInfo
+import chisel3.internal.sourceinfo.{SourceInfo, UnlocatableSourceInfo}
 import chisel3.experimental._
 import _root_.firrtl.{ir => firrtlir}
 import _root_.firrtl.{PrimOps, RenameMap}

--- a/core/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -5,7 +5,7 @@ package chisel3.internal.firrtl
 import firrtl.{ir => fir}
 import chisel3._
 import chisel3.internal._
-import chisel3.internal.sourceinfo.{SourceInfo, UnlocatableSourceInfo}
+import chisel3.internal.sourceinfo.SourceInfo
 import chisel3.experimental._
 import _root_.firrtl.{ir => firrtlir}
 import _root_.firrtl.{PrimOps, RenameMap}

--- a/src/test/scala/chiselTests/WireSpec.scala
+++ b/src/test/scala/chiselTests/WireSpec.scala
@@ -3,7 +3,7 @@
 package chiselTests
 
 import chisel3._
-import circt.stage.ChiselStage
+import chisel3.stage.ChiselStage
 
 class WireSpec extends ChiselFlatSpec {
   "WireDefault.apply" should "work" in {
@@ -29,8 +29,8 @@ class WireSpec extends ChiselFlatSpec {
       out := in & wire & wire2
     }
 
-    val chirrtl = ChiselStage.emitCHIRRTL(new Dummy)
-    chirrtl should include("wire wire : UInt<1> @[WireSpec.scala 26:26]")
-    chirrtl should include("wire wire2 : UInt<1> @[WireSpec.scala 27:23]")
+    val chirrtl = ChiselStage.emitChirrtl(new Dummy)
+    chirrtl should include("wire wire : UInt<1> @[WireSpec.scala")
+    chirrtl should include("wire wire2 : UInt<1> @[WireSpec.scala")
   }
 }

--- a/src/test/scala/chiselTests/WireSpec.scala
+++ b/src/test/scala/chiselTests/WireSpec.scala
@@ -3,6 +3,7 @@
 package chiselTests
 
 import chisel3._
+import circt.stage.ChiselStage
 
 class WireSpec extends ChiselFlatSpec {
   "WireDefault.apply" should "work" in {
@@ -16,5 +17,20 @@ class WireSpec extends ChiselFlatSpec {
   }
   it should "not allow init argument to affect type inference" in {
     assertDoesNotCompile("val x: UInt = WireDefault(UInt(4.W), 2.S)")
+  }
+  it should "have source locator information on wires" in {
+    class Dummy extends chisel3.Module {
+      val in = IO(Input(Bool()))
+      val out = IO(Output(Bool()))
+
+      val wire = WireInit(Bool(), true.B)
+      val wire2 = Wire(Bool())
+      wire2 := in
+      out := in & wire & wire2
+    }
+
+    val chirrtl = ChiselStage.emitCHIRRTL(new Dummy)
+    chirrtl should include("wire wire : UInt<1> @[WireSpec.scala 26:26]")
+    chirrtl should include("wire wire2 : UInt<1> @[WireSpec.scala 27:23]")
   }
 }


### PR DESCRIPTION
  `implicit val noSourceInfo = UnlocatableSourceInfo` from `WireDefault#apply`
- Add test to show locators

### Contributor Checklist

- [-] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [-] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

- code cleanup
 
#### API Impact
- wires in firrtl will now have source location information making it easier to find where they were declared
- Slightly changes the appearance of firrtl, adds some more characters to `Wire` 

#### Backend Code Generation Impact

- Should have no change in code functionality
- 
#### Desired Merge Strategy

- Squash: The PR will be squashed and merged (choose this if you have no preference. -->

#### Release Notes
Source location information for `Wire`, `WireInit`, and `WireDefault` is now included in generated firrtl.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
