### PR TITLE
Revert "Privatize trait VerifPrintMacros"

### DIFF
--- a/core/src/main/scala/chisel3/VerificationStatement.scala
+++ b/core/src/main/scala/chisel3/VerificationStatement.scala
@@ -23,7 +23,7 @@ import scala.reflect.macros.blackbox
   *
   * @groupprio VerifPrintMacros 1001
   */
-private[chisel3] trait VerifPrintMacrosDoc
+trait VerifPrintMacrosDoc
 
 object assert extends VerifPrintMacrosDoc {
 


### PR DESCRIPTION
Reverts chipsalliance/chisel3#2683

So it seems that in order for ScalaDoc grouping and prioritization to work, the `trait` has to be public. We could make the trait `sealed`, but then it would be a source incompatible change to ever change which objects extend it, so I think just leaving it public is fine.

I even tried putting the trait in package `chisel3.internal`, but because that package is excluded from ScalaDoc, that also broke the method grouping. Alas.