### PR TITLE
Remove incorrect clock warning on Mem.read

### DIFF
--- a/core/src/main/scala/chisel3/Mem.scala
+++ b/core/src/main/scala/chisel3/Mem.scala
@@ -60,7 +60,7 @@ sealed abstract class MemBase[T <: Data](val t: T, val length: BigInt)
   // ensure memory ports are created with the same clock unless explicitly specified to use a different clock
   private val clockInst: Option[Clock] = Builder.currentClock
 
-  protected def clockWarning(sourceInfo: Option[SourceInfo]): Unit = {
+  protected def clockWarning(sourceInfo: Option[SourceInfo], dir: MemPortDirection): Unit = {
     // Turn into pretty String if possible, if not, Builder.deprecated will find one via stack trace
     val infoStr = sourceInfo.collect { case SourceLine(file, line, col) => s"$file:$line:$col" }
     Builder.deprecated(
@@ -135,7 +135,7 @@ sealed abstract class MemBase[T <: Data](val t: T, val length: BigInt)
     compileOptions:      CompileOptions
   ): T = {
     if (warn && clockInst.isDefined && clock != clockInst.get) {
-      clockWarning(Some(sourceInfo))
+      clockWarning(Some(sourceInfo), dir)
     }
     makePort(sourceInfo, idx, dir, clock)
   }
@@ -167,7 +167,7 @@ sealed abstract class MemBase[T <: Data](val t: T, val length: BigInt)
     implicit compileOptions: CompileOptions
   ): Unit = {
     if (warn && clockInst.isDefined && clock != clockInst.get) {
-      clockWarning(None)
+      clockWarning(None, MemPortDirection.WRITE)
     }
     implicit val sourceInfo = UnlocatableSourceInfo
     makePort(UnlocatableSourceInfo, idx, MemPortDirection.WRITE, clock) := data
@@ -226,7 +226,7 @@ sealed abstract class MemBase[T <: Data](val t: T, val length: BigInt)
   ): Unit = {
     implicit val sourceInfo = UnlocatableSourceInfo
     if (warn && clockInst.isDefined && clock != clockInst.get) {
-      clockWarning(None)
+      clockWarning(None, MemPortDirection.WRITE)
     }
     val accessor = makePort(sourceInfo, idx, MemPortDirection.WRITE, clock).asInstanceOf[Vec[Data]]
     val dataVec = data.asInstanceOf[Vec[Data]]
@@ -274,7 +274,13 @@ sealed abstract class MemBase[T <: Data](val t: T, val length: BigInt)
   * @note when multiple conflicting writes are performed on a Mem element, the
   * result is undefined (unlike Vec, where the last assignment wins)
   */
-sealed class Mem[T <: Data] private[chisel3] (t: T, length: BigInt) extends MemBase(t, length)
+sealed class Mem[T <: Data] private[chisel3] (t: T, length: BigInt) extends MemBase(t, length) {
+  override protected def clockWarning(sourceInfo: Option[SourceInfo], dir: MemPortDirection): Unit = {
+    // Do not issue clock warnings on reads, since they are not clocked
+    if (dir != MemPortDirection.READ)
+      super.clockWarning(sourceInfo, dir)
+  }
+}
 
 object SyncReadMem {
 

--- a/src/test/scala/chiselTests/MultiClockSpec.scala
+++ b/src/test/scala/chiselTests/MultiClockSpec.scala
@@ -166,14 +166,6 @@ class MultiClockSpec extends ChiselFlatSpec with Utils {
   }
 
   "Differing clocks at memory and read accessor instantiation" should "warn" in {
-    class modMemReadDifferingClock extends Module {
-      val myClock = IO(Input(Clock()))
-      val mem = withClock(myClock) { Mem(4, UInt(8.W)) }
-      val readVal = mem.read(0.U)
-    }
-    val (logMemReadDifferingClock, _) = grabLog(ChiselStage.elaborate(new modMemReadDifferingClock))
-    logMemReadDifferingClock should include("memory is different")
-
     class modSyncReadMemReadDifferingClock extends Module {
       val myClock = IO(Input(Clock()))
       val mem = withClock(myClock) { SyncReadMem(4, UInt(8.W)) }


### PR DESCRIPTION
Mem.read is combinational and thus unaffected by the clock, and so it does not make sense to issue warnings about the current clock in this context.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you ~add~ delete at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
- bug fix
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

None.

#### Backend Code Generation Impact

None.

#### Desired Merge Strategy

- Squash: The PR will be squashed and merged (choose this if you have no preference.
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes

Removed deprecation warning when reading a Mem when the current implicit clock differs from the implicit clock at time of definition.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
