### PR TITLE
Add source locators to ports

### DIFF
--- a/core/src/main/scala/chisel3/BlackBox.scala
+++ b/core/src/main/scala/chisel3/BlackBox.scala
@@ -72,7 +72,7 @@ package experimental {
       // Ports are named in the same way as regular Modules
       namePorts()
 
-      val firrtlPorts = getModulePorts.map { case (port, _) => Port(port, port.specifiedDirection) }
+      val firrtlPorts = getModulePorts.map { case (port, _) => Port(port, port.specifiedDirection, UnlocatableSourceInfo) }
       val component = DefBlackBox(this, name, firrtlPorts, SpecifiedDirection.Unspecified, params)
       _component = Some(component)
       _component
@@ -166,7 +166,7 @@ abstract class BlackBox(
       port.setRef(ModuleIO(this, _namespace.name(name)), force = true)
     }
 
-    val firrtlPorts = namedPorts.map { namedPort => Port(namedPort._2, namedPort._2.specifiedDirection) }
+    val firrtlPorts = namedPorts.map { namedPort => Port(namedPort._2, namedPort._2.specifiedDirection, UnlocatableSourceInfo) }
     val component = DefBlackBox(this, name, firrtlPorts, io.specifiedDirection, params)
     _component = Some(component)
     _component

--- a/core/src/main/scala/chisel3/BlackBox.scala
+++ b/core/src/main/scala/chisel3/BlackBox.scala
@@ -72,7 +72,7 @@ package experimental {
       // Ports are named in the same way as regular Modules
       namePorts()
 
-      val firrtlPorts = getModulePorts.map { port => Port(port, port.specifiedDirection) }
+      val firrtlPorts = getModulePorts.map { case (port, _) => Port(port, port.specifiedDirection) }
       val component = DefBlackBox(this, name, firrtlPorts, SpecifiedDirection.Unspecified, params)
       _component = Some(component)
       _component
@@ -81,8 +81,8 @@ package experimental {
     private[chisel3] def initializeInParent(parentCompileOptions: CompileOptions): Unit = {
       implicit val sourceInfo = UnlocatableSourceInfo
 
-      for (x <- getModulePorts) {
-        pushCommand(DefInvalid(sourceInfo, x.ref))
+      for ((port, _) <- getModulePorts) {
+        pushCommand(DefInvalid(sourceInfo, port.ref))
       }
     }
   }

--- a/core/src/main/scala/chisel3/BlackBox.scala
+++ b/core/src/main/scala/chisel3/BlackBox.scala
@@ -72,7 +72,9 @@ package experimental {
       // Ports are named in the same way as regular Modules
       namePorts()
 
-      val firrtlPorts = getModulePorts.map { case (port, _) => Port(port, port.specifiedDirection, UnlocatableSourceInfo) }
+      val firrtlPorts = getModulePorts.map {
+        case (port, _) => Port(port, port.specifiedDirection, UnlocatableSourceInfo)
+      }
       val component = DefBlackBox(this, name, firrtlPorts, SpecifiedDirection.Unspecified, params)
       _component = Some(component)
       _component
@@ -166,7 +168,9 @@ abstract class BlackBox(
       port.setRef(ModuleIO(this, _namespace.name(name)), force = true)
     }
 
-    val firrtlPorts = namedPorts.map { namedPort => Port(namedPort._2, namedPort._2.specifiedDirection, UnlocatableSourceInfo) }
+    val firrtlPorts = namedPorts.map { namedPort =>
+      Port(namedPort._2, namedPort._2.specifiedDirection, UnlocatableSourceInfo)
+    }
     val component = DefBlackBox(this, name, firrtlPorts, io.specifiedDirection, params)
     _component = Some(component)
     _component

--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -357,7 +357,7 @@ package experimental {
     private[chisel3] def findPort(name: String): Option[Data] = {
       _ports.find(_._1.seedOpt.contains(name)) match {
         case Some((data, _)) => Some(data)
-        case _ => None
+        case _               => None
       }
     }
 

--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -187,7 +187,7 @@ package experimental {
       * requested (so that all calls to ports will return the same information).
       * Internal API.
       */
-    def apply[T <: Data](iodef: => T): T = {
+    def apply[T <: Data](iodef: => T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T = {
       val module = Module.currentModule.get // Impossible to fail
       require(!module.isClosed, "Can't add more ports after module close")
       val prevId = Builder.idGen.value
@@ -337,7 +337,7 @@ package experimental {
       _ids.toSeq
     }
 
-    private val _ports = new ArrayBuffer[Data]()
+    private val _ports = new ArrayBuffer[(Data, SourceInfo)]()
 
     // getPorts unfortunately already used for tester compatibility
     protected[chisel3] def getModulePorts = {
@@ -352,7 +352,9 @@ package experimental {
     // This is dangerous because it can be called before the module is closed and thus there could
     // be more ports and names have not yet been finalized.
     // This should only to be used during the process of closing when it is safe to do so.
-    private[chisel3] def findPort(name: String): Option[Data] = _ports.find(_.seedOpt.contains(name))
+    private[chisel3] def findPort(name: String): Option[Data] = {
+      _ports.map(_._1).find { _.seedOpt.contains(name) }
+    }
 
     protected def portsSize: Int = _ports.size
 
@@ -366,7 +368,7 @@ package experimental {
     private[chisel3] def initializeInParent(parentCompileOptions: CompileOptions): Unit
 
     private[chisel3] def namePorts(): Unit = {
-      for (port <- getModulePorts) {
+      for ((port, _) <- getModulePorts) {
         port._computeName(None) match {
           case Some(name) =>
             if (_namespace.contains(name)) {
@@ -520,7 +522,7 @@ package experimental {
     /** Chisel2 code didn't require the IO(...) wrapper and would assign a Chisel type directly to
       * io, then do operations on it. This binds a Chisel type in-place (mutably) as an IO.
       */
-    protected def _bindIoInPlace(iodef: Data): Unit = {
+    protected def _bindIoInPlace(iodef: Data)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Unit = {
       // Compatibility code: Chisel2 did not require explicit direction on nodes
       //   (unspecified treated as output, and flip on nothing was input).
       // However, we are going to go back to Chisel2 semantics, so we need to make it work
@@ -552,11 +554,16 @@ package experimental {
       assignCompatDir(iodef)
 
       iodef.bind(PortBinding(this))
-      _ports += iodef
+      _ports += iodef -> sourceInfo
     }
 
     /** Private accessor for _bindIoInPlace */
-    private[chisel3] def bindIoInPlace(iodef: Data): Unit = _bindIoInPlace(iodef)
+    private[chisel3] def bindIoInPlace(
+      iodef: Data
+    )(
+      implicit sourceInfo: SourceInfo,
+      compileOptions:      CompileOptions
+    ): Unit = _bindIoInPlace(iodef)
 
     /**
       * This must wrap the datatype used to set the io field of any Module.
@@ -574,7 +581,9 @@ package experimental {
       * TODO(twigg): Specifically walk the Data definition to call out which nodes
       * are problematic.
       */
-    protected def IO[T <: Data](iodef: => T): T = chisel3.experimental.IO.apply(iodef)
+    protected def IO[T <: Data](iodef: => T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T = {
+      chisel3.experimental.IO.apply(iodef)
+    }
 
     //
     // Internal Functions

--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -354,12 +354,8 @@ package experimental {
     // This is dangerous because it can be called before the module is closed and thus there could
     // be more ports and names have not yet been finalized.
     // This should only to be used during the process of closing when it is safe to do so.
-    private[chisel3] def findPort(name: String): Option[Data] = {
-      _ports.find(_._1.seedOpt.contains(name)) match {
-        case Some((data, _)) => Some(data)
-        case _               => None
-      }
-    }
+    private[chisel3] def findPort(name: String): Option[Data] =
+      _ports.collectFirst { case (data, _) if data.seedOpt.contains(name) => data }
 
     protected def portsSize: Int = _ports.size
 

--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -355,7 +355,10 @@ package experimental {
     // be more ports and names have not yet been finalized.
     // This should only to be used during the process of closing when it is safe to do so.
     private[chisel3] def findPort(name: String): Option[Data] = {
-      _ports.map(_._1).find { _.seedOpt.contains(name) }
+      _ports.find(_._1.seedOpt.contains(name)) match {
+        case Some((data, _)) => Some(data)
+        case _ => None
+      }
     }
 
     protected def portsSize: Int = _ports.size

--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -117,8 +117,8 @@ object Module extends SourceInfoDoc {
   */
 abstract class Module(implicit moduleCompileOptions: CompileOptions) extends RawModule {
   // Implicit clock and reset pins
-  final val clock: Clock = IO(Input(Clock())).suggestName("clock")
-  final val reset: Reset = IO(Input(mkReset)).suggestName("reset")
+  final val clock: Clock = IO(Input(Clock()))(UnlocatableSourceInfo, moduleCompileOptions).suggestName("clock")
+  final val reset: Reset = IO(Input(mkReset))(UnlocatableSourceInfo, moduleCompileOptions).suggestName("reset")
 
   // TODO It's hard to remove these deprecated override methods because they're used by
   //   Chisel.QueueCompatibility which extends chisel3.Queue which extends chisel3.Module
@@ -347,7 +347,9 @@ package experimental {
 
     // These methods allow checking some properties of ports before the module is closed,
     // mainly for compatibility purposes.
-    protected def portsContains(elem: Data): Boolean = _ports contains elem
+    protected def portsContains(elem: Data): Boolean = {
+      _ports.exists { port => port._1 == elem }
+    }
 
     // This is dangerous because it can be called before the module is closed and thus there could
     // be more ports and names have not yet been finalized.

--- a/core/src/main/scala/chisel3/RawModule.scala
+++ b/core/src/main/scala/chisel3/RawModule.scala
@@ -290,7 +290,7 @@ package object internal {
 
     override def _compatAutoWrapPorts(): Unit = {
       if (!_compatIoPortBound()) {
-        _io.foreach(_bindIoInPlace(_))
+        _io.foreach(_bindIoInPlace(_)(UnlocatableSourceInfo, moduleCompileOptions))
       }
     }
   }
@@ -314,7 +314,7 @@ package object internal {
     // required) to build.
     override def _compatAutoWrapPorts(): Unit = {
       if (!_compatIoPortBound()) {
-        _io.foreach(_bindIoInPlace(_))
+        _io.foreach(_bindIoInPlace(_)(UnlocatableSourceInfo, moduleCompileOptions))
       }
     }
   }

--- a/core/src/main/scala/chisel3/RawModule.scala
+++ b/core/src/main/scala/chisel3/RawModule.scala
@@ -92,24 +92,25 @@ abstract class RawModule(implicit moduleCompileOptions: CompileOptions) extends 
       }
     }
 
-    val firrtlPorts = getModulePorts.map { case (port, sourceInfo) =>
-      // Special case Vec to make FIRRTL emit the direction of its
-      // element.
-      // Just taking the Vec's specifiedDirection is a bug in cases like
-      // Vec(Flipped()), since the Vec's specifiedDirection is
-      // Unspecified.
-      val direction = port match {
-        case v: Vec[_] =>
-          v.specifiedDirection match {
-            case SpecifiedDirection.Input       => SpecifiedDirection.Input
-            case SpecifiedDirection.Output      => SpecifiedDirection.Output
-            case SpecifiedDirection.Flip        => SpecifiedDirection.flip(v.sample_element.specifiedDirection)
-            case SpecifiedDirection.Unspecified => v.sample_element.specifiedDirection
-          }
-        case _ => port.specifiedDirection
-      }
+    val firrtlPorts = getModulePorts.map {
+      case (port, sourceInfo) =>
+        // Special case Vec to make FIRRTL emit the direction of its
+        // element.
+        // Just taking the Vec's specifiedDirection is a bug in cases like
+        // Vec(Flipped()), since the Vec's specifiedDirection is
+        // Unspecified.
+        val direction = port match {
+          case v: Vec[_] =>
+            v.specifiedDirection match {
+              case SpecifiedDirection.Input       => SpecifiedDirection.Input
+              case SpecifiedDirection.Output      => SpecifiedDirection.Output
+              case SpecifiedDirection.Flip        => SpecifiedDirection.flip(v.sample_element.specifiedDirection)
+              case SpecifiedDirection.Unspecified => v.sample_element.specifiedDirection
+            }
+          case _ => port.specifiedDirection
+        }
 
-      Port(port, direction, sourceInfo)
+        Port(port, direction, sourceInfo)
     }
     _firrtlPorts = Some(firrtlPorts)
 

--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/Instance.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/Instance.scala
@@ -130,7 +130,9 @@ object Instance extends SourceInfoDoc {
         override def generateComponent(): Option[Component] = {
           require(!_closed, s"Can't generate $desiredName module more than once")
           _closed = true
-          val firrtlPorts = definition.proto.getModulePorts.map { port => Port(port, port.specifiedDirection) }
+          val firrtlPorts = definition.proto.getModulePorts.map { case (port, sourceInfo) =>
+            Port(port, port.specifiedDirection, sourceInfo)
+          }
           val component = DefBlackBox(this, definition.proto.name, firrtlPorts, SpecifiedDirection.Unspecified, params)
           Some(component)
         }

--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/Instance.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/Instance.scala
@@ -130,8 +130,9 @@ object Instance extends SourceInfoDoc {
         override def generateComponent(): Option[Component] = {
           require(!_closed, s"Can't generate $desiredName module more than once")
           _closed = true
-          val firrtlPorts = definition.proto.getModulePorts.map { case (port, sourceInfo) =>
-            Port(port, port.specifiedDirection, sourceInfo)
+          val firrtlPorts = definition.proto.getModulePorts.map {
+            case (port, sourceInfo) =>
+              Port(port, port.specifiedDirection, sourceInfo)
           }
           val component = DefBlackBox(this, definition.proto.name, firrtlPorts, SpecifiedDirection.Unspecified, params)
           Some(component)

--- a/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
@@ -337,9 +337,8 @@ private[chisel3] object Converter {
       case SpecifiedDirection.Input | SpecifiedDirection.Output     => true
       case SpecifiedDirection.Unspecified | SpecifiedDirection.Flip => false
     }
-    val info = UnlocatableSourceInfo // Unfortunately there is no source locator for ports ATM
-    val tpe = extractType(port.id, clearDir, info)
-    fir.Port(fir.NoInfo, getRef(port.id, info).name, dir, tpe)
+    val tpe = extractType(port.id, clearDir, port.sourceInfo)
+    fir.Port(convert(port.sourceInfo), getRef(port.id, port.sourceInfo).name, dir, tpe)
   }
 
   def convert(component: Component): fir.DefModule = component match {

--- a/core/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -835,7 +835,7 @@ case class Stop(id: stop.Stop, sourceInfo: SourceInfo, clock: Arg, ret: Int) ext
   "This API should never have been public, for Module port reflection, use DataMirror.modulePorts",
   "Chisel 3.5"
 )
-case class Port(id: Data, dir: SpecifiedDirection, sourceInfo: SourceInfo = UnlocatableSourceInfo)
+case class Port(id: Data, dir: SpecifiedDirection, sourceInfo: SourceInfo)
 case class Printf(id: printf.Printf, sourceInfo: SourceInfo, clock: Arg, pable: Printable) extends Definition
 object Formal extends Enumeration {
   val Assert = Value("assert")

--- a/core/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -5,7 +5,7 @@ package chisel3.internal.firrtl
 import firrtl.{ir => fir}
 import chisel3._
 import chisel3.internal._
-import chisel3.internal.sourceinfo.SourceInfo
+import chisel3.internal.sourceinfo.{SourceInfo, UnlocatableSourceInfo}
 import chisel3.experimental._
 import _root_.firrtl.{ir => firrtlir}
 import _root_.firrtl.{PrimOps, RenameMap}
@@ -835,7 +835,7 @@ case class Stop(id: stop.Stop, sourceInfo: SourceInfo, clock: Arg, ret: Int) ext
   "This API should never have been public, for Module port reflection, use DataMirror.modulePorts",
   "Chisel 3.5"
 )
-case class Port(id: Data, dir: SpecifiedDirection)
+case class Port(id: Data, dir: SpecifiedDirection, sourceInfo: SourceInfo = UnlocatableSourceInfo)
 case class Printf(id: printf.Printf, sourceInfo: SourceInfo, clock: Arg, pable: Printable) extends Definition
 object Formal extends Enumeration {
   val Assert = Value("assert")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.8
+sbt.version=1.6.2

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.2
+sbt.version=1.5.8

--- a/src/test/scala/chiselTests/Module.scala
+++ b/src/test/scala/chiselTests/Module.scala
@@ -204,14 +204,15 @@ class ModuleSpec extends ChiselPropSpec with Utils {
     // Note this also uses deprecated Port
     import chisel3.internal.firrtl.Port
     import SpecifiedDirection.{Input => IN, Unspecified}
-    (mod.getPorts.map { port => port.copy(sourceInfo = UnlocatableSourceInfo)} should contain).theSameElementsInOrderAs(
-      Seq(
-        Port(mod.clock, IN),
-        Port(mod.reset, IN),
-        Port(mod.io, Unspecified),
-        Port(mod.extra, IN)
-      )
-    ): @nowarn // delete when Port and getPorts become private
+    (mod.getPorts.map { port => port.copy(sourceInfo = UnlocatableSourceInfo) } should contain)
+      .theSameElementsInOrderAs(
+        Seq(
+          Port(mod.clock, IN),
+          Port(mod.reset, IN),
+          Port(mod.io, Unspecified),
+          Port(mod.extra, IN)
+        )
+      ): @nowarn // delete when Port and getPorts become private
   }
 
   property("DataMirror.fullModulePorts should return all ports including children of Aggregates") {

--- a/src/test/scala/chiselTests/Module.scala
+++ b/src/test/scala/chiselTests/Module.scala
@@ -4,6 +4,7 @@ package chiselTests
 
 import chisel3._
 import chisel3.experimental.DataMirror
+import chisel3.internal.sourceinfo.UnlocatableSourceInfo
 import chisel3.stage.{ChiselGeneratorAnnotation, ChiselStage, NoRunFirrtlCompilerAnnotation}
 import firrtl.annotations.NoTargetAnnotation
 import firrtl.options.Unserializable
@@ -203,7 +204,7 @@ class ModuleSpec extends ChiselPropSpec with Utils {
     // Note this also uses deprecated Port
     import chisel3.internal.firrtl.Port
     import SpecifiedDirection.{Input => IN, Unspecified}
-    (mod.getPorts should contain).theSameElementsInOrderAs(
+    (mod.getPorts.map { port => port.copy(sourceInfo = UnlocatableSourceInfo)} should contain).theSameElementsInOrderAs(
       Seq(
         Port(mod.clock, IN),
         Port(mod.reset, IN),

--- a/src/test/scala/chiselTests/Module.scala
+++ b/src/test/scala/chiselTests/Module.scala
@@ -207,10 +207,10 @@ class ModuleSpec extends ChiselPropSpec with Utils {
     (mod.getPorts.map { port => port.copy(sourceInfo = UnlocatableSourceInfo) } should contain)
       .theSameElementsInOrderAs(
         Seq(
-          Port(mod.clock, IN),
-          Port(mod.reset, IN),
-          Port(mod.io, Unspecified),
-          Port(mod.extra, IN)
+          Port(mod.clock, IN, UnlocatableSourceInfo),
+          Port(mod.reset, IN, UnlocatableSourceInfo),
+          Port(mod.io, Unspecified, UnlocatableSourceInfo),
+          Port(mod.extra, IN, UnlocatableSourceInfo)
         )
       ): @nowarn // delete when Port and getPorts become private
   }

--- a/src/test/scala/chiselTests/PortSpec.scala
+++ b/src/test/scala/chiselTests/PortSpec.scala
@@ -18,11 +18,11 @@ class PortSpec extends ChiselFreeSpec {
 
   "Ports now have source locators" in {
     val chirrtl = ChiselStage.emitCHIRRTL(new Dummy)
-    println(chirrtl)
-
-    chirrtl should include ("input clock : Clock @[Module.scala 120:30]")
-    chirrtl should include ("input reset : UInt<1> @[Module.scala 121:30]")
-    chirrtl should include ("output in : { flip foo : UInt<1>, flip bar : UInt<8>} @[PortSpec.scala 14:16]")
-    chirrtl should include ("output out : UInt<1> @[PortSpec.scala 15:17]")
+    // Automatic clock and reset coming from Module do not get source locators
+    chirrtl should include ("input clock : Clock")
+    chirrtl should include ("input reset : UInt<1>")
+    // other ports get source locators
+    chirrtl should include ("output in : { flip foo : UInt<1>, flip bar : UInt<8>} @[PortSpec.scala")
+    chirrtl should include ("output out : UInt<1> @[PortSpec.scala")
   }
 }

--- a/src/test/scala/chiselTests/PortSpec.scala
+++ b/src/test/scala/chiselTests/PortSpec.scala
@@ -19,10 +19,10 @@ class PortSpec extends ChiselFreeSpec {
   "Ports now have source locators" in {
     val chirrtl = ChiselStage.emitCHIRRTL(new Dummy)
     // Automatic clock and reset coming from Module do not get source locators
-    chirrtl should include ("input clock : Clock")
-    chirrtl should include ("input reset : UInt<1>")
+    chirrtl should include("input clock : Clock")
+    chirrtl should include("input reset : UInt<1>")
     // other ports get source locators
-    chirrtl should include ("output in : { flip foo : UInt<1>, flip bar : UInt<8>} @[PortSpec.scala")
-    chirrtl should include ("output out : UInt<1> @[PortSpec.scala")
+    chirrtl should include("output in : { flip foo : UInt<1>, flip bar : UInt<8>} @[PortSpec.scala")
+    chirrtl should include("output out : UInt<1> @[PortSpec.scala")
   }
 }

--- a/src/test/scala/chiselTests/PortSpec.scala
+++ b/src/test/scala/chiselTests/PortSpec.scala
@@ -1,0 +1,28 @@
+package chiselTests
+
+import chisel3._
+import circt.stage.ChiselStage
+
+class PortSpec extends ChiselFreeSpec {
+
+  class DummyIO extends Bundle {
+    val foo = Input(Bool())
+    val bar = Input(UInt(8.W))
+  }
+
+  class Dummy extends Module {
+    val in = IO(new DummyIO)
+    val out = IO(Output(Bool()))
+    out := in.foo.asUInt + in.bar
+  }
+
+  "Ports now have source locators" in {
+    val chirrtl = ChiselStage.emitCHIRRTL(new Dummy)
+    println(chirrtl)
+
+    chirrtl should include ("input clock : Clock @[Module.scala 120:30]")
+    chirrtl should include ("input reset : UInt<1> @[Module.scala 121:30]")
+    chirrtl should include ("output in : { flip foo : UInt<1>, flip bar : UInt<8>} @[PortSpec.scala 14:16]")
+    chirrtl should include ("output out : UInt<1> @[PortSpec.scala 15:17]")
+  }
+}


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

- backend code generation
- 
#### API Impact

Source locators are now on regularly define ports (not on automatically generated clock and reset).
This should not affect anything downstream

#### Backend Code Generation Impact

Source locators for ports will be included in generated verilog, but should have change any behavior

#### Desired Merge Strategy

- Squash: The PR will be squashed and merged

#### Release Notes
With this change firrtl and verilog will contain source locators for ports. This can be very helpful on figuring out where the ports were declared in deeply nested generated `IO`s

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
