### PR TITLE
Bump to Scala 2.13.9 and 2.12.17

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         system: ["ubuntu-20.04"]
         jvm: ["adopt@1.8"]
-        scala: ["2.13.6", "2.12.16"]
+        scala: ["2.13.9", "2.12.17"]
         espresso: ["2.4"]
         circt: ["sifive/1/14/0"]
     runs-on: ${{ matrix.system }}
@@ -94,7 +94,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        scala: [ "2.13.6", "2.12.16" ]
+        scala: [ "2.13.9", "2.12.17" ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/build.sbt
+++ b/build.sbt
@@ -19,8 +19,8 @@ lazy val commonSettings = Seq(
   organization := "edu.berkeley.cs",
   version := "3.6-SNAPSHOT",
   autoAPIMappings := true,
-  scalaVersion := "2.12.16",
-  crossScalaVersions := Seq("2.13.6", "2.12.16"),
+  scalaVersion := "2.12.17",
+  crossScalaVersions := Seq("2.13.9", "2.12.17"),
   scalacOptions := Seq("-deprecation", "-feature"),
   libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value,
   // Macros paradise is integrated into 2.13 but requires a scalacOption
@@ -107,6 +107,7 @@ lazy val pluginScalaVersions = Seq(
   "2.12.14",
   "2.12.15",
   "2.12.16",
+  "2.12.17",
   "2.13.0",
   "2.13.1",
   "2.13.2",
@@ -115,7 +116,8 @@ lazy val pluginScalaVersions = Seq(
   "2.13.5",
   "2.13.6",
   "2.13.7",
-  "2.13.8"
+  "2.13.8",
+  "2.13.9"
 )
 
 lazy val plugin = (project in file("plugin"))

--- a/build.sc
+++ b/build.sc
@@ -6,7 +6,7 @@ import coursier.maven.MavenRepository
 import $ivy.`com.lihaoyi::mill-contrib-buildinfo:$MILL_VERSION`
 import mill.contrib.buildinfo.BuildInfo
 
-object chisel3 extends mill.Cross[chisel3CrossModule]("2.13.6", "2.12.14")
+object chisel3 extends mill.Cross[chisel3CrossModule]("2.13.9", "2.12.17")
 
 object v {
   val firrtl = ivy"edu.berkeley.cs::firrtl:1.6-SNAPSHOT"


### PR DESCRIPTION
We should get this into 3.5.5.

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [NA] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

- dependency bump

#### API Impact

Enables Chisel users to use Scala versions 2.13.9 and 2.12.17

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

  - Squash

#### Release Notes

Bump to Scala 2.13.9 and 2.12.17

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
