### PR TITLE
Use new lazy serialization in FIRRTL

### DIFF
--- a/src/main/scala/chisel3/internal/firrtl/Emitter.scala
+++ b/src/main/scala/chisel3/internal/firrtl/Emitter.scala
@@ -11,12 +11,14 @@ private[chisel3] object Emitter {
     Serializer.serialize(fcircuit)
   }
 
-  def emitLazily(circuit: Circuit): Iterable[String] = {
-    val result = LazyList(s"circuit ${circuit.name} :\n")
-    val modules = circuit.components.view.map(Converter.convert)
-    val moduleStrings = modules.flatMap { m =>
-      Array(Serializer.serialize(m, 1), "\n\n")
+  def emitLazily(circuit: Circuit): Iterable[String] = new Iterable[String] {
+    def iterator = {
+      val prelude = Iterator(s"circuit ${circuit.name} :\n")
+      val modules = circuit.components.iterator.map(Converter.convert)
+      val moduleStrings = modules.flatMap { m =>
+        Serializer.lazily(m, 1) ++ Seq("\n\n")
+      }
+      prelude ++ moduleStrings
     }
-    result ++ moduleStrings
   }
 }


### PR DESCRIPTION
This enables emission of modules that serialize to >2 GiB of .fir text.

See https://github.com/chipsalliance/firrtl/pull/2554.

This has no impact on performance for most designs, it slightly improves serialization performance for designs with very large modules (due to the cost of allocating large Strings--but the JVM is very good at this so the impact is small).

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

  - bug fix 
  - performance improvement  

#### API Impact

No change

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

 - Squash

#### Release Notes

Support serialization of Modules that require over 2 GiB of `.fir` text.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
