### PR TITLE
Improve CI sentinel job for better branch protection

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -143,14 +143,8 @@ jobs:
       # Pass only if check-tests set its output value
     steps:
       - run: |
-        PASSED="${{ needs.check-tests.outputs.success }}"
-        if [[ $PASSED == "true" ]]; then
-          echo "All tests passed!"
-          exit 0
-        else
-          echo "One or more tests FAILED!"
-          exit 1
-        fi
+        echo "hi"
+        echo "bye"
 
   # sbt ci-release publishes all cross versions so this job needs to be
   # separate from a Scala versions build matrix to avoid duplicate publishing

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -144,7 +144,7 @@ jobs:
       # Pass only if check-tests set its output value
       - run: |
         # Maybe a comment will help
-        PASSED=$(echo "false")
+        export PASSED=$(echo "false")
         if [[ $PASSED == "true" ]]; then
           echo "All tests passed!"
           exit 0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -139,9 +139,18 @@ jobs:
     name: "all tests passed"
     runs-on: ubuntu-20.04
     if: always() # Always run so that we never skip this check
-    needs: [check-tests]
+    needs: check-tests
+      # Pass only if check-tests set its output value
     steps:
-      - run: echo "hi"
+      - run: |
+        PASSED="${{ needs.check-tests.outputs.success }}"
+        if [[ $PASSED == "true" ]]; then
+          echo "All tests passed!"
+          exit 0
+        else
+          echo "One or more tests FAILED!"
+          exit 1
+        fi
 
   # sbt ci-release publishes all cross versions so this job needs to be
   # separate from a Scala versions build matrix to avoid duplicate publishing

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -141,9 +141,7 @@ jobs:
     if: always() # Always run so that we never skip this check
     needs: [check-tests]
     steps:
-      - run: |
-          echo "hi"
-          echo "bye"
+      - run: echo "hi"
 
   # sbt ci-release publishes all cross versions so this job needs to be
   # separate from a Scala versions build matrix to avoid duplicate publishing

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -141,15 +141,16 @@ jobs:
     if: always() # Always run so that we never skip this check
     needs: check-tests
       # Pass only if check-tests set its output value
-    run: |
-      PASSED="${{ needs.check-tests.outputs.success }}"
-      if [[ $PASSED == "true" ]]; then
-        echo "All tests passed!"
-        exit 0
-      else
-        echo "One or more tests FAILED!"
-        exit 1
-      fi
+    steps:
+      run: |
+        PASSED="${{ needs.check-tests.outputs.success }}"
+        if [[ $PASSED == "true" ]]; then
+          echo "All tests passed!"
+          exit 0
+        else
+          echo "One or more tests FAILED!"
+          exit 1
+        fi
 
   # sbt ci-release publishes all cross versions so this job needs to be
   # separate from a Scala versions build matrix to avoid duplicate publishing

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -144,7 +144,6 @@ jobs:
       # Pass only if check-tests set its output value
       - run: |
         # Maybe a comment will help
-        export PASSED=$(echo "false")
         if [[ $PASSED == "true" ]]; then
           echo "All tests passed!"
           exit 0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -140,17 +140,16 @@ jobs:
     runs-on: ubuntu-20.04
     if: always() # Always run so that we never skip this check
     needs: check-tests
-    steps:
       # Pass only if check-tests set its output value
-      - run: |
-        # Maybe a comment will help
-        if [[ $PASSED == "true" ]]; then
-          echo "All tests passed!"
-          exit 0
-        else
-          echo "One or more tests FAILED!"
-          exit 1
-        fi
+    steps:
+      - run: echo "hello world!"
+        #if [[ $PASSED == "true" ]]; then
+        #  echo "All tests passed!"
+        #  exit 0
+        #else
+        #  echo "One or more tests FAILED!"
+        #  exit 1
+        #fi
 
   # sbt ci-release publishes all cross versions so this job needs to be
   # separate from a Scala versions build matrix to avoid duplicate publishing

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -140,8 +140,8 @@ jobs:
     runs-on: ubuntu-20.04
     if: always() # Always run so that we never skip this check
     needs: check-tests
-      # Pass only if check-tests set its output value
     steps:
+      # Pass only if check-tests set its output value
       - name: okay
         run: |
           echo "hi"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -139,7 +139,7 @@ jobs:
     name: "all tests passed"
     runs-on: ubuntu-20.04
     if: always() # Always run so that we never skip this check
-    needs: check-tests
+    needs: [check-tests]
     steps:
       - run: |
           echo "hi"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,15 +115,42 @@ jobs:
         run: sbt ++${{ matrix.scala }} standardLibrary/test
 
   # Sentinel job to simplify how we specify which checks need to pass in branch
-  # protection and in Mergify
+  # protection and in Mergify. This job checks that all jobs were successful.
   #
   # When adding new jobs, please add them to `needs` below
-  all_tests_passed:
-    name: "all tests passed"
+  check-tests:
+    name: "check tests"
     needs: [ci, integration, std]
     runs-on: ubuntu-20.04
+    if: success() # only run if all tests have passed
+    outputs:
+      success: ${{ steps.setoutput.outputs.success }}
     steps:
-      - run: echo Success!
+      id: setoutput
+      run: echo "::set-output name=success::true"
+
+  # Related to check-tests above, this job _always_ runs (even if tests fail
+  # and thus check-steps is skipped). This two sentinel job approach avoids an
+  # issue where failing tests causes a single sentinel job to be skipped which
+  # counts as passing for purposes of branch protection.
+  #
+  # See: https://brunoscheufler.com/blog/2022-04-09-the-required-github-status-check-that-wasnt
+  all_tests_passed:
+    name: "all tests passed"
+    runs-on: ubuntu-20.04
+    if: always() # Always run so that we never skip this check
+    needs: check-tests
+    steps:
+      # Pass only if check-tests set its output value
+      - run: |
+        PASSED="${{ needs.check-tests.outputs.success }}"
+        if [[ $PASSED == "true" ]]; then
+          echo "All tests passed!"
+          exit 0
+        else
+          echo "One or more tests FAILED!"
+          exit 1
+        fi
 
   # sbt ci-release publishes all cross versions so this job needs to be
   # separate from a Scala versions build matrix to avoid duplicate publishing

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -141,15 +141,15 @@ jobs:
     if: always() # Always run so that we never skip this check
     needs: check-tests
       # Pass only if check-tests set its output value
-    steps:
-      - run: echo "hello world!"
-        #if [[ $PASSED == "true" ]]; then
-        #  echo "All tests passed!"
-        #  exit 0
-        #else
-        #  echo "One or more tests FAILED!"
-        #  exit 1
-        #fi
+    run: |
+      PASSED="${{ needs.check-tests.outputs.success }}"
+      if [[ $PASSED == "true" ]]; then
+        echo "All tests passed!"
+        exit 0
+      else
+        echo "One or more tests FAILED!"
+        exit 1
+      fi
 
   # sbt ci-release publishes all cross versions so this job needs to be
   # separate from a Scala versions build matrix to avoid duplicate publishing

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -143,7 +143,7 @@ jobs:
     steps:
       # Pass only if check-tests set its output value
       - run: |
-        PASSED=${{ needs.check-tests.outputs.success }}
+        PASSED=$(echo "${{ needs.check-tests.outputs.success }}")
         if [[ $PASSED == "true" ]]; then
           echo "All tests passed!"
           exit 0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -143,8 +143,8 @@ jobs:
       # Pass only if check-tests set its output value
     steps:
       - run: |
-        echo "hi"
-        echo "bye"
+          echo "hi"
+          echo "bye"
 
   # sbt ci-release publishes all cross versions so this job needs to be
   # separate from a Scala versions build matrix to avoid duplicate publishing

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -143,14 +143,14 @@ jobs:
       # Pass only if check-tests set its output value
     steps:
       - run: |
-        PASSED="${{ needs.check-tests.outputs.success }}"
-        if [[ $PASSED == "true" ]]; then
-          echo "All tests passed!"
-          exit 0
-        else
-          echo "One or more tests FAILED!"
-          exit 1
-        fi
+          PASSED="${{ needs.check-tests.outputs.success }}"
+          if [[ $PASSED == "true" ]]; then
+            echo "All tests passed!"
+            exit 0
+          else
+            echo "One or more tests FAILED!"
+            exit 1
+          fi
 
   # sbt ci-release publishes all cross versions so this job needs to be
   # separate from a Scala versions build matrix to avoid duplicate publishing

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -143,6 +143,7 @@ jobs:
     steps:
       # Pass only if check-tests set its output value
       - run: |
+        # Maybe a comment will help
         PASSED=$(echo "${{ needs.check-tests.outputs.success }}")
         if [[ $PASSED == "true" ]]; then
           echo "All tests passed!"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -142,7 +142,8 @@ jobs:
     needs: check-tests
       # Pass only if check-tests set its output value
     steps:
-      - run: |
+      - name: okay
+        run: |
           echo "hi"
           echo "bye"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -141,9 +141,7 @@ jobs:
     if: always() # Always run so that we never skip this check
     needs: check-tests
     steps:
-      # Pass only if check-tests set its output value
-      - name: okay
-        run: |
+      - run: |
           echo "hi"
           echo "bye"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -144,7 +144,7 @@ jobs:
       # Pass only if check-tests set its output value
       - run: |
         # Maybe a comment will help
-        PASSED=$(echo "${{ needs.check-tests.outputs.success }}")
+        PASSED=$(echo "false")
         if [[ $PASSED == "true" ]]; then
           echo "All tests passed!"
           exit 0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -143,7 +143,7 @@ jobs:
     steps:
       # Pass only if check-tests set its output value
       - run: |
-        PASSED="${{ needs.check-tests.outputs.success }}"
+        PASSED=${{ needs.check-tests.outputs.success }}
         if [[ $PASSED == "true" ]]; then
           echo "All tests passed!"
           exit 0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -142,7 +142,7 @@ jobs:
     needs: check-tests
       # Pass only if check-tests set its output value
     steps:
-      run: |
+      - run: |
         PASSED="${{ needs.check-tests.outputs.success }}"
         if [[ $PASSED == "true" ]]; then
           echo "All tests passed!"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,8 +126,8 @@ jobs:
     outputs:
       success: ${{ steps.setoutput.outputs.success }}
     steps:
-      id: setoutput
-      run: echo "::set-output name=success::true"
+      - id: setoutput
+        run: echo "::set-output name=success::true"
 
   # Related to check-tests above, this job _always_ runs (even if tests fail
   # and thus check-steps is skipped). This two sentinel job approach avoids an

--- a/src/test/scala/chiselTests/DecoupledSpec.scala
+++ b/src/test/scala/chiselTests/DecoupledSpec.scala
@@ -101,7 +101,7 @@ class DecoupledSpec extends ChiselFlatSpec {
     chirrtl should include("""wire _deq_map : { flip ready : UInt<1>, valid : UInt<1>, bits : UInt<8>}""")
 
     // Check for data assignment
-    chirrtl should include("""node _deq_map_bits = and(enq.bits.foo, enq.bits.bar)""")
+    chirrtl should include("""node _deq_map_bits = and(enq.bits.foowefoiwefoij, enq.bits.bar)""")
     chirrtl should include("""_deq_map.bits <= _deq_map_bits""")
     chirrtl should include("""deq <= _deq_map""")
 

--- a/src/test/scala/chiselTests/DecoupledSpec.scala
+++ b/src/test/scala/chiselTests/DecoupledSpec.scala
@@ -101,7 +101,7 @@ class DecoupledSpec extends ChiselFlatSpec {
     chirrtl should include("""wire _deq_map : { flip ready : UInt<1>, valid : UInt<1>, bits : UInt<8>}""")
 
     // Check for data assignment
-    chirrtl should include("""node _deq_map_bits = and(enq.bits.foowefoiwefoij, enq.bits.bar)""")
+    chirrtl should include("""node _deq_map_bits = and(enq.bits.foo, enq.bits.bar)""")
     chirrtl should include("""_deq_map.bits <= _deq_map_bits""")
     chirrtl should include("""deq <= _deq_map""")
 


### PR DESCRIPTION
Previously, failed jobs in the CI matrix would cause the sentinel job (all-tests-passed) to be skipped, which for purposes of Github Actions branch protection would count as "success". This allowed PRs with failing CI to be merged. This new approach which uses two sentinel jobs should not suffer from this same issue.

This approach was borrowed with love from https://brunoscheufler.com/blog/2022-04-09-the-required-github-status-check-that-wasnt

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [NA] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [NA] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

   - CI

#### API Impact

No impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

  - Squash

#### Release Notes


### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
