### PR TITLE
Added Defaulting type to experimental

### DIFF
--- a/core/src/main/scala/chisel3/experimental/Defaulting.scala
+++ b/core/src/main/scala/chisel3/experimental/Defaulting.scala
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chisel3.experimental
+
+import chisel3.{chiselTypeOf, Record, Data, Element}
+
+import scala.collection.immutable.SeqMap
+
+/** Data type for representing any type who has a default value
+  *
+  * Uses the underlying opaque type support.
+  *
+  * @note This API is experimental and subject to change
+  */
+final class Defaulting[T <: Data] private (private[chisel3] val tpe: T, val defaultValue: T) extends Record {
+  requireIsChiselType(tpe, s"Chisel hardware type $tpe must be a pure type, not bound to hardware.")
+  requireIsHardware(defaultValue, s"Default value $defaultValue must be bound to a hardware component")
+
+  /** The underlying hardware component, is either the Chisel data type or hardware component */
+  val underlying: T = tpe
+
+  /** The default value for this Defaulting */
+  val default: T = defaultValue
+
+  val elements = SeqMap("" -> underlying)
+  override def opaqueType = elements.size == 1
+  override def cloneType: this.type = (new Defaulting[T](chiselTypeOf(tpe), defaultValue)).asInstanceOf[this.type]
+}
+
+
+/** Object that provides factory methods for [[Analog]] objects
+  *
+  * @note This API is experimental and subject to change
+  */
+object Defaulting {
+  /** Build a Defaulting[T <: Data]
+    *
+    * @param tpe the Chisel data type
+    * @param default the Chisel default value, must be bound to a hardware value
+    */
+  def apply[T <: Data](tpe: T, default: T): Defaulting[T] = new Defaulting(tpe, default)
+
+  /** Build a Defaulting[T <: Data]
+    *
+    * @param default the Chisel default value, must be bound to a hardware value. The underlying type is pulled from the default value.
+    */
+  def apply[T <: Data](default: T): Defaulting[T] = new Defaulting(chiselTypeOf(default), default)
+}


### PR DESCRIPTION
## Background

In order to remove `Chisel._`, we need to somehow tackle the difference in semantics between `chisel3.<>` and `Chisel.<>`. Our approach has been to revisit connections from first principles, and arrived at the conclusion that the `FixChisel3` operators from RocketChip are an excellent starting place, where we can likely describe the behaviors of `chisel3.<>` and `Chisel.<>` as different combinations of those operators with erroring in cases which were buggy or unintuitive behavior.

The PR https://github.com/chipsalliance/chisel3/pull/2713 adds these operators with the following changes:
- Any field being assigned to must have a corresponding field to assign from
- No support for `CustomBulkAssignable`
- The datatype used for recursing (left-of-connect or right-of-connect) is clarified

## The final blocking issue: `CustomBulkAssignable`

We believe we can handle `Chisel.<>` and `chisel3.<>` now, but the `FixChisel3` operators have one additional behavior which we have not figured out how to support in chisel3: `BundleMap`'s `CustomBulkAssignable`.

When at first glance this appears to be a catch-all loophole to support weird connection behavior, it is only ever used for the single use-case of assigning default values to unassigned BundleMapFields (which is always associated with the field definition).

## Proposals

We considered two major proposals:

Proposal 1: Relies on last-connect-semantics to give the default value, removes the strictness of the previously referenced chisel3 PR, and relies on initialization errors to give back the strictness.

Proposal 2: Enable letting Chisel types define default values, and these are used rather than erroring for the bulk operators (similar to BundleMap behavior).

After some playing around, we realized that BundleMaps would often be nested within other type hierarchies, making last-connect-semantics more painful to rely on for the default behavior, as you would need to only assign defaults to the subfields of bundlemap-kind of things. In addition, the new support for opaque types provided an excellent mechanism to create a special defaulting wrapping type. Hence, we selected Proposal 2.

## Specific Reviewer Requests

1. Whether mdoc should be written
2. Whether you have any ideas for the name besides `Defaulting`

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

 - new feature/API 

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

Adds a new experimental datatype, `Defaulting` which enables associating a default value with a type. In a future PR, the new connection operators will assign this default value for missing fields of `Defaulting` type, rather than erroring.


#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

Adds a new experimental datatype, `Defaulting` which enables associating a default value with a type.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
