### PR TITLE
Error on S-interpolator usage for assert, assume and printf

### DIFF
--- a/core/src/main/scala/chisel3/Printf.scala
+++ b/core/src/main/scala/chisel3/Printf.scala
@@ -92,8 +92,8 @@ object printf {
         c.error(
           c.enclosingPosition,
           "The s-interpolator prints the Scala .toString of Data objects rather than the value " +
-          "of the hardware wire during simulation. Use the cf-interpolator instead. If you want " +
-          "an elaboration time print, use println."
+            "of the hardware wire during simulation. Use the cf-interpolator instead. If you want " +
+            "an elaboration time print, use println."
         )
       case _ =>
     }

--- a/core/src/main/scala/chisel3/Printf.scala
+++ b/core/src/main/scala/chisel3/Printf.scala
@@ -91,7 +91,9 @@ object printf {
       case q"scala.StringContext.apply(..$_).s(..$_)" =>
         c.error(
           c.enclosingPosition,
-          "The s-interpolator for Chisel assert, assume and printf statements are deprecated (since 3.5); use the cf interpolator instead"
+          "The s-interpolator prints the Scala .toString of Data objects rather than the value " +
+          "of the hardware wire during simulation. Use the cf-interpolator instead. If you want " +
+          "an elaboration time print, use println."
         )
       case _ =>
     }

--- a/core/src/main/scala/chisel3/Printf.scala
+++ b/core/src/main/scala/chisel3/Printf.scala
@@ -91,7 +91,7 @@ object printf {
       case q"scala.StringContext.apply(..$_).s(..$_)" =>
         c.error(
           c.enclosingPosition,
-          "s-interpolators for Chisel assert, assume and printf statements are deprecated (since 3.5); use p or cf interpolators instead"
+          "The s-interpolator for Chisel assert, assume and printf statements are deprecated (since 3.5); use the cf interpolator instead"
         )
       case _ =>
     }

--- a/core/src/main/scala/chisel3/VerificationStatement.scala
+++ b/core/src/main/scala/chisel3/VerificationStatement.scala
@@ -95,7 +95,7 @@ object assert extends VerifPrintMacrosDoc {
       case q"scala.StringContext.apply(..$_).s(..$_)" =>
         c.error(
           c.enclosingPosition,
-          "s-interpolators for Chisel assert, assume and printf statements are deprecated (since 3.5); use p or cf interpolators instead"
+          "The s-interpolator for Chisel assert, assume and printf statements are deprecated (since 3.5); use the cf interpolator instead"
         )
       case _ =>
     }
@@ -292,7 +292,7 @@ object assume extends VerifPrintMacrosDoc {
       case q"scala.StringContext.apply(..$_).s(..$_)" =>
         c.error(
           c.enclosingPosition,
-          "s-interpolators for Chisel assert, assume and printf statements are deprecated (since 3.5); use p or cf interpolators instead"
+          "The s-interpolator for Chisel assert, assume and printf statements are deprecated (since 3.5); use the cf interpolator instead"
         )
       case _ =>
     }

--- a/core/src/main/scala/chisel3/VerificationStatement.scala
+++ b/core/src/main/scala/chisel3/VerificationStatement.scala
@@ -96,8 +96,8 @@ object assert extends VerifPrintMacrosDoc {
         c.error(
           c.enclosingPosition,
           "The s-interpolator prints the Scala .toString of Data objects rather than the value " +
-          "of the hardware wire during simulation. Use the cf-interpolator instead. If you want " +
-          "an elaboration time check, call assert with a Boolean condition."
+            "of the hardware wire during simulation. Use the cf-interpolator instead. If you want " +
+            "an elaboration time check, call assert with a Boolean condition."
         )
       case _ =>
     }
@@ -295,8 +295,8 @@ object assume extends VerifPrintMacrosDoc {
         c.error(
           c.enclosingPosition,
           "The s-interpolator prints the Scala .toString of Data objects rather than the value " +
-          "of the hardware wire during simulation. Use the cf-interpolator instead. If you want " +
-          "an elaboration time check, call assert with a Boolean condition."
+            "of the hardware wire during simulation. Use the cf-interpolator instead. If you want " +
+            "an elaboration time check, call assert with a Boolean condition."
         )
       case _ =>
     }

--- a/core/src/main/scala/chisel3/VerificationStatement.scala
+++ b/core/src/main/scala/chisel3/VerificationStatement.scala
@@ -95,7 +95,9 @@ object assert extends VerifPrintMacrosDoc {
       case q"scala.StringContext.apply(..$_).s(..$_)" =>
         c.error(
           c.enclosingPosition,
-          "The s-interpolator for Chisel assert, assume and printf statements are deprecated (since 3.5); use the cf interpolator instead"
+          "The s-interpolator prints the Scala .toString of Data objects rather than the value " +
+          "of the hardware wire during simulation. Use the cf-interpolator instead. If you want " +
+          "an elaboration time check, call assert with a Boolean condition."
         )
       case _ =>
     }
@@ -292,7 +294,9 @@ object assume extends VerifPrintMacrosDoc {
       case q"scala.StringContext.apply(..$_).s(..$_)" =>
         c.error(
           c.enclosingPosition,
-          "The s-interpolator for Chisel assert, assume and printf statements are deprecated (since 3.5); use the cf interpolator instead"
+          "The s-interpolator prints the Scala .toString of Data objects rather than the value " +
+          "of the hardware wire during simulation. Use the cf-interpolator instead. If you want " +
+          "an elaboration time check, call assert with a Boolean condition."
         )
       case _ =>
     }

--- a/core/src/main/scala/chisel3/VerificationStatement.scala
+++ b/core/src/main/scala/chisel3/VerificationStatement.scala
@@ -43,7 +43,7 @@ object assert extends VerifPrintMacrosDoc {
   // Macros currently can't take default arguments, so we need two functions to emulate defaults.
   def apply(
     cond:    Bool,
-    message: => String,
+    message: String,
     data:    Bits*
   )(
     implicit sourceInfo: SourceInfo,
@@ -93,9 +93,9 @@ object assert extends VerifPrintMacrosDoc {
     import c.universe._
     message match {
       case q"scala.StringContext.apply(..$_).s(..$_)" =>
-        c.warning(
+        c.error(
           c.enclosingPosition,
-          "s-interpolators for Chisel assert, assume and printf statements will be deprecated in 3.5; use p or cf interpolators instead"
+          "s-interpolators for Chisel assert, assume and printf statements are deprecated (since 3.5); use p or cf interpolators instead"
         )
       case _ =>
     }
@@ -290,9 +290,9 @@ object assume extends VerifPrintMacrosDoc {
     import c.universe._
     message match {
       case q"scala.StringContext.apply(..$_).s(..$_)" =>
-        c.warning(
+        c.error(
           c.enclosingPosition,
-          "s-interpolators for Chisel assert, assume and printf statements will be deprecated in 3.5; use p or cf interpolators instead"
+          "s-interpolators for Chisel assert, assume and printf statements are deprecated (since 3.5); use p or cf interpolators instead"
         )
       case _ =>
     }

--- a/docs/src/explanations/printing.md
+++ b/docs/src/explanations/printing.md
@@ -103,6 +103,8 @@ Message:
 
 Notice the use of `+` between `cf` interpolated "strings". The results of `cf` interpolation can be concatenated by using the `+` operator.
 
+> :warning: The Scala s-interpolator is deprecated since 3.5 and will output the warning: "s-interpolators for Chisel assert, assume and printf statements are deprecated (since 3.5); use p or cf interpolators instead"
+
 ### C-Style
 
 Chisel provides `printf` in a similar style to its C namesake. It accepts a double-quoted format string and a variable number of arguments which will then be printed on rising clock edges. Chisel supports the following format specifiers:

--- a/docs/src/explanations/printing.md
+++ b/docs/src/explanations/printing.md
@@ -13,11 +13,21 @@ Chisel provides the `printf` function for debugging purposes. It comes in two fl
 
 ### Scala-style
 
-Chisel also supports printf in a style similar to [Scala's String Interpolation](http://docs.scala-lang.org/overviews/core/string-interpolation.html). Chisel provides a custom string interpolator `cf` which follows C-style format specifiers (see section [C-style](#c-style) below). Here's a few examples of using the `cf` interpolator:
+Chisel also supports printf in a style similar to [Scala's String Interpolation](http://docs.scala-lang.org/overviews/core/string-interpolation.html). Chisel provides a custom string interpolator `cf` which follows C-style format specifiers (see section [C-style](#c-style) below). Note that the Scala s-interpolator is not supported and will throw an error:
 
 ```scala mdoc:invisible
 import chisel3._
 ```
+
+```scala mdoc:fail
+class MyModule extends Module {
+  val in = IO(Input(UInt(8.W)))
+  printf(s"in = $in\n")
+}
+```
+
+Here's a few examples of using the `cf` interpolator:
+
 ```scala mdoc:compile-only
 val myUInt = 33.U
 printf(cf"myUInt = $myUInt") // myUInt = 33
@@ -102,8 +112,6 @@ Message:
 ```
 
 Notice the use of `+` between `cf` interpolated "strings". The results of `cf` interpolation can be concatenated by using the `+` operator.
-
-> :warning: The Scala s-interpolator is deprecated since 3.5 and will output the warning: "s-interpolators for Chisel assert, assume and printf statements are deprecated (since 3.5); use p or cf interpolators instead"
 
 ### C-Style
 

--- a/docs/src/explanations/printing.md
+++ b/docs/src/explanations/printing.md
@@ -13,7 +13,9 @@ Chisel provides the `printf` function for debugging purposes. It comes in two fl
 
 ### Scala-style
 
-Chisel also supports printf in a style similar to [Scala's String Interpolation](http://docs.scala-lang.org/overviews/core/string-interpolation.html). Chisel provides a custom string interpolator `cf` which follows C-style format specifiers (see section [C-style](#c-style) below). Note that the Scala s-interpolator is not supported and will throw an error:
+Chisel also supports printf in a style similar to [Scala's String Interpolation](http://docs.scala-lang.org/overviews/core/string-interpolation.html). Chisel provides a custom string interpolator `cf` which follows C-style format specifiers (see section [C-style](#c-style) below).
+
+Note that the Scala s-interpolator is not supported in Chisel constructs and will throw an error:
 
 ```scala mdoc:invisible
 import chisel3._
@@ -26,7 +28,7 @@ class MyModule extends Module {
 }
 ```
 
-Here's a few examples of using the `cf` interpolator:
+Instead, use Chisel's `cf` interpolator as in the following examples:
 
 ```scala mdoc:compile-only
 val myUInt = 33.U

--- a/src/test/scala/chiselTests/IntervalSpec.scala
+++ b/src/test/scala/chiselTests/IntervalSpec.scala
@@ -245,7 +245,7 @@ class SqueezeFunctionalityTester(range: IntervalRange, startNum: BigDecimal, end
   squeezeTemplate := toSqueeze.squeeze(squeezeInterval)
 
   printf(
-    cf"SqueezeTest %d${counter}    %d${toSqueeze.asSInt()}.squeeze($range) => %d${squeezeTemplate.asSInt()}\n"
+    cf"SqueezeTest $counter%d ${toSqueeze.asSInt()}%d.squeeze($range) => ${squeezeTemplate.asSInt()}%d\n"
   )
 }
 

--- a/src/test/scala/chiselTests/IntervalSpec.scala
+++ b/src/test/scala/chiselTests/IntervalSpec.scala
@@ -211,7 +211,7 @@ class ClipSqueezeWrapDemo(
   val wrapped = counter.wrap(0.U.asInterval(targetRange))
 
   when(counter === startValue) {
-    printf(s"Target range is $range\n")
+    printf(cf"Target range is $range\n")
     printf("value     clip      squeeze      wrap\n")
   }
 
@@ -245,10 +245,7 @@ class SqueezeFunctionalityTester(range: IntervalRange, startNum: BigDecimal, end
   squeezeTemplate := toSqueeze.squeeze(squeezeInterval)
 
   printf(
-    s"SqueezeTest %d    %d.squeeze($range) => %d\n",
-    counter,
-    toSqueeze.asSInt(),
-    squeezeTemplate.asSInt()
+    cf"SqueezeTest %d${counter}    %d${toSqueeze.asSInt()}.squeeze($range) => %d${squeezeTemplate.asSInt()}\n"
   )
 }
 

--- a/src/test/scala/chiselTests/Vec.scala
+++ b/src/test/scala/chiselTests/Vec.scala
@@ -235,7 +235,7 @@ class IterateTester(start: Int, len: Int)(f: UInt => UInt) extends BasicTester {
   val testVec = VecInit.iterate(start.U, len)(f)
   assert(
     controlVec.asUInt() === testVec.asUInt(),
-    cf"Expected Vec to be filled like $controlVec, instead creaeted $testVec\n"
+    cf"Expected Vec to be filled like $controlVec, instead created $testVec\n"
   )
   stop()
 }

--- a/src/test/scala/chiselTests/Vec.scala
+++ b/src/test/scala/chiselTests/Vec.scala
@@ -111,7 +111,7 @@ class FillTester(n: Int, value: Int) extends BasicTester {
   val x = VecInit(Array.fill(n)(value.U))
   val u = VecInit.fill(n)(value.U)
 
-  assert(x.asUInt() === u.asUInt(), s"Expected Vec to be filled like $x, instead VecInit.fill created $u")
+  assert(x.asUInt() === u.asUInt(), cf"Expected Vec to be filled like $x, instead VecInit.fill created $u")
   stop()
 }
 
@@ -235,7 +235,7 @@ class IterateTester(start: Int, len: Int)(f: UInt => UInt) extends BasicTester {
   val testVec = VecInit.iterate(start.U, len)(f)
   assert(
     controlVec.asUInt() === testVec.asUInt(),
-    s"Expected Vec to be filled like $controlVec, instead creaeted $testVec\n"
+    cf"Expected Vec to be filled like $controlVec, instead creaeted $testVec\n"
   )
   stop()
 }

--- a/src/test/scala/chiselTests/VecLiteralSpec.scala
+++ b/src/test/scala/chiselTests/VecLiteralSpec.scala
@@ -205,7 +205,7 @@ class VecLiteralSpec extends ChiselFreeSpec with Utils {
 
     assertTesterPasses {
       new BasicTester {
-        chisel3.assert(outsideVecLit(0) === 0xdd.U, s"v(0)")
+        chisel3.assert(outsideVecLit(0) === 0xdd.U, cf"v(0)")
         stop()
       }
     }
@@ -216,7 +216,7 @@ class VecLiteralSpec extends ChiselFreeSpec with Utils {
 
     assertTesterPasses {
       new BasicTester {
-        chisel3.assert(outsideVecLit(0) === 0xdd.U, s"v(0)")
+        chisel3.assert(outsideVecLit(0) === 0xdd.U, cf"v(0)")
         chisel3.assert(outsideVecLit(1) === 0xcc.U)
         chisel3.assert(outsideVecLit(2) === 0xbb.U)
         chisel3.assert(outsideVecLit(3) === 0xaa.U)

--- a/src/test/scala/chiselTests/VecLiteralSpec.scala
+++ b/src/test/scala/chiselTests/VecLiteralSpec.scala
@@ -205,7 +205,7 @@ class VecLiteralSpec extends ChiselFreeSpec with Utils {
 
     assertTesterPasses {
       new BasicTester {
-        chisel3.assert(outsideVecLit(0) === 0xdd.U, cf"v(0)")
+        chisel3.assert(outsideVecLit(0) === 0xdd.U, "v(0)")
         stop()
       }
     }
@@ -216,7 +216,7 @@ class VecLiteralSpec extends ChiselFreeSpec with Utils {
 
     assertTesterPasses {
       new BasicTester {
-        chisel3.assert(outsideVecLit(0) === 0xdd.U, cf"v(0)")
+        chisel3.assert(outsideVecLit(0) === 0xdd.U, "v(0)")
         chisel3.assert(outsideVecLit(1) === 0xcc.U)
         chisel3.assert(outsideVecLit(2) === 0xbb.U)
         chisel3.assert(outsideVecLit(3) === 0xaa.U)


### PR DESCRIPTION
This is to be backported to 3.5.x as a warning instead of an error

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
 - updated feature/API      

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->
Current `assert`, `assume` and `printf` APIs allow the Scala s-interpolator for formatting messages. This often leads to user errors where the Scala object is printed instead of the Chisel object, which leads to the messages being generally unhelpful.

After this update, using s-interpolators will throw an error about deprecation.

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->
N/A
#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
  - Squash: The PR will be squashed and merged (choose this if you have no preference.
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
Using Scala s-interpolators now throws an error recommending a shift to the cf interpolator.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
