### PR TITLE
Remove all deprecations from Bool.scala and Clock.scala

### DIFF
--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -115,7 +115,7 @@ sealed abstract class Aggregate extends Data {
   }
 
   override def do_asUInt(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): UInt = {
-    SeqUtils.do_asUInt(flatten.map(_.asUInt()))
+    SeqUtils.do_asUInt(flatten.map(_.asUInt))
   }
 
   private[chisel3] override def connectFromBits(

--- a/core/src/main/scala/chisel3/Bits.scala
+++ b/core/src/main/scala/chisel3/Bits.scala
@@ -31,12 +31,6 @@ private[chisel3] sealed trait ToBoolable extends Element {
     */
   final def asBool: Bool = macro SourceInfoWhiteboxTransform.noArg
 
-  @deprecated(
-    "Calling this function with an empty argument list is invalid in Scala 3. Use the form without parentheses instead",
-    "Chisel 3.5"
-  )
-  final def asBool(dummy: Int*): Bool = macro SourceInfoWhiteboxTransform.noArgDummy
-
   /** @group SourceInfoTransformMacro */
   def do_asBool(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool
 }
@@ -269,12 +263,6 @@ sealed abstract class Bits(private[chisel3] val width: Width) extends Element wi
     */
   final def unary_~ : Bits = macro SourceInfoWhiteboxTransform.noArg
 
-  @deprecated(
-    "Calling this function with an empty argument list is invalid in Scala 3. Use the form without parentheses instead",
-    "Chisel 3.5"
-  )
-  final def unary_~(dummy: Int*): Bits = macro SourceInfoWhiteboxTransform.noArgDummy
-
   /** @group SourceInfoTransformMacro */
   def do_unary_~(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bits
 
@@ -357,12 +345,6 @@ sealed abstract class Bits(private[chisel3] val width: Width) extends Element wi
   /** Returns the contents of this wire as a [[scala.collection.Seq]] of [[Bool]]. */
   final def asBools: Seq[Bool] = macro SourceInfoTransform.noArg
 
-  @deprecated(
-    "Calling this function with an empty argument list is invalid in Scala 3. Use the form without parentheses instead",
-    "Chisel 3.5"
-  )
-  final def asBools(dummy: Int*): Seq[Bool] = macro SourceInfoWhiteboxTransform.noArgDummy
-
   /** @group SourceInfoTransformMacro */
   def do_asBools(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Seq[Bool] =
     Seq.tabulate(this.getWidth)(i => this(i))
@@ -373,12 +355,6 @@ sealed abstract class Bits(private[chisel3] val width: Width) extends Element wi
     * width 3 and value 7 (0b111) would become an [[SInt]] of width 3 and value -1.
     */
   final def asSInt: SInt = macro SourceInfoTransform.noArg
-
-  @deprecated(
-    "Calling this function with an empty argument list is invalid in Scala 3. Use the form without parentheses instead",
-    "Chisel 3.5"
-  )
-  final def asSInt(dummy: Int*): SInt = macro SourceInfoWhiteboxTransform.noArgDummy
 
   /** @group SourceInfoTransformMacro */
   def do_asSInt(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): SInt
@@ -476,12 +452,6 @@ sealed class UInt private[chisel3] (width: Width) extends Bits(width) with Num[U
     */
   final def unary_- : UInt = macro SourceInfoTransform.noArg
 
-  @deprecated(
-    "Calling this function with an empty argument list is invalid in Scala 3. Use the form without parentheses instead",
-    "Chisel 3.5"
-  )
-  final def unary_-(dummy: Int*): UInt = macro SourceInfoTransform.noArgDummy
-
   /** Unary negation (constant width)
     *
     * @return a $coll equal to zero minus this $coll shifted right by one.
@@ -489,12 +459,6 @@ sealed class UInt private[chisel3] (width: Width) extends Bits(width) with Num[U
     * @group Arithmetic
     */
   final def unary_-% : UInt = macro SourceInfoTransform.noArg
-
-  @deprecated(
-    "Calling this function with an empty argument list is invalid in Scala 3. Use the form without parentheses instead",
-    "Chisel 3.5"
-  )
-  final def unary_%(dummy: Int*): UInt = macro SourceInfoTransform.noArgDummy
 
   /** @group SourceInfoTransformMacro */
   def do_unary_-(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): UInt = 0.U - this
@@ -630,12 +594,6 @@ sealed class UInt private[chisel3] (width: Width) extends Bits(width) with Num[U
     */
   final def orR: Bool = macro SourceInfoTransform.noArg
 
-  @deprecated(
-    "Calling this function with an empty argument list is invalid in Scala 3. Use the form without parentheses instead",
-    "Chisel 3.5"
-  )
-  final def orR(dummy: Int*): Bool = macro SourceInfoTransform.noArgDummy
-
   /** And reduction operator
     *
     * @return a hardware [[Bool]] resulting from every bit of this $coll and'd together
@@ -643,24 +601,12 @@ sealed class UInt private[chisel3] (width: Width) extends Bits(width) with Num[U
     */
   final def andR: Bool = macro SourceInfoTransform.noArg
 
-  @deprecated(
-    "Calling this function with an empty argument list is invalid in Scala 3. Use the form without parentheses instead",
-    "Chisel 3.5"
-  )
-  final def andR(dummy: Int*): Bool = macro SourceInfoTransform.noArgDummy
-
   /** Exclusive or (xor) reduction operator
     *
     * @return a hardware [[Bool]] resulting from every bit of this $coll xor'd together
     * @group Bitwise
     */
   final def xorR: Bool = macro SourceInfoTransform.noArg
-
-  @deprecated(
-    "Calling this function with an empty argument list is invalid in Scala 3. Use the form without parentheses instead",
-    "Chisel 3.5"
-  )
-  final def xorR(dummy: Int*): Bool = macro SourceInfoTransform.noArgDummy
 
   /** @group SourceInfoTransformMacro */
   def do_orR(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool = redop(sourceInfo, OrReduceOp)
@@ -710,12 +656,6 @@ sealed class UInt private[chisel3] (width: Width) extends Bits(width) with Num[U
     * @group Bitwise
     */
   final def unary_! : Bool = macro SourceInfoTransform.noArg
-
-  @deprecated(
-    "Calling this function with an empty argument list is invalid in Scala 3. Use the form without parentheses instead",
-    "Chisel 3.5"
-  )
-  final def unary_!(dummy: Int*): Bool = macro SourceInfoTransform.noArgDummy
 
   /** @group SourceInfoTransformMacro */
   def do_unary_!(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool = this === 0.U(1.W)
@@ -771,7 +711,7 @@ sealed class UInt private[chisel3] (width: Width) extends Bits(width) with Num[U
     implicit sourceInfo: SourceInfo,
     compileOptions:      CompileOptions
   ): UInt =
-    n.asBools().zipWithIndex.foldLeft(this) {
+    n.asBools.zipWithIndex.foldLeft(this) {
       case (in, (en, sh)) => Mux(en, staticShift(in, 1 << sh), in)
     }
 
@@ -806,12 +746,6 @@ sealed class UInt private[chisel3] (width: Width) extends Bits(width) with Num[U
     * @note The width of the returned [[SInt]] is `width of this` + `1`.
     */
   final def zext: SInt = macro SourceInfoTransform.noArg
-
-  @deprecated(
-    "Calling this function with an empty argument list is invalid in Scala 3. Use the form without parentheses instead",
-    "Chisel 3.5"
-  )
-  final def zext(dummy: Int*): SInt = macro SourceInfoTransform.noArgDummy
 
   /** @group SourceInfoTransformMacro */
   def do_zext(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): SInt =
@@ -904,12 +838,6 @@ sealed class SInt private[chisel3] (width: Width) extends Bits(width) with Num[S
     */
   final def unary_- : SInt = macro SourceInfoTransform.noArg
 
-  @deprecated(
-    "Calling this function with an empty argument list is invalid in Scala 3. Use the form without parentheses instead",
-    "Chisel 3.5"
-  )
-  final def unary_-(dummy: Int*): SInt = macro SourceInfoTransform.noArgDummy
-
   /** Unary negation (constant width)
     *
     * @return a hardware $coll equal to zero minus `this` shifted right by one
@@ -917,12 +845,6 @@ sealed class SInt private[chisel3] (width: Width) extends Bits(width) with Num[S
     * @group Arithmetic
     */
   final def unary_-% : SInt = macro SourceInfoTransform.noArg
-
-  @deprecated(
-    "Calling this function with an empty argument list is invalid in Scala 3. Use the form without parentheses instead",
-    "Chisel 3.5"
-  )
-  final def unary_-%(dummy: Int*): SInt = macro SourceInfoTransform.noArgDummy
 
   /** @group SourceInfoTransformMacro */
   def do_unary_-(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): SInt = 0.S - this
@@ -1171,12 +1093,6 @@ sealed trait Reset extends Element with ToBoolable {
   /** Casts this $coll to an [[AsyncReset]] */
   final def asAsyncReset: AsyncReset = macro SourceInfoWhiteboxTransform.noArg
 
-  @deprecated(
-    "Calling this function with an empty argument list is invalid in Scala 3. Use the form without parentheses instead",
-    "Chisel 3.5"
-  )
-  final def asAsyncReset(dummy: Int*): AsyncReset = macro SourceInfoTransform.noArgDummy
-
   /** @group SourceInfoTransformMacro */
   def do_asAsyncReset(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): AsyncReset
 }
@@ -1376,12 +1292,6 @@ sealed class Bool() extends UInt(1.W) with Reset {
   /** Reinterprets this $coll as a clock */
   def asClock: Clock = macro SourceInfoTransform.noArg
 
-  @deprecated(
-    "Calling this function with an empty argument list is invalid in Scala 3. Use the form without parentheses instead",
-    "Chisel 3.5"
-  )
-  def asClock(dummy: Int*): Clock = macro SourceInfoTransform.noArgDummy
-
   /** @group SourceInfoTransformMacro */
   def do_asClock(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Clock = pushOp(
     DefPrim(sourceInfo, Clock(), AsClockOp, ref)
@@ -1484,12 +1394,6 @@ package experimental {
       */
     final def unary_- : FixedPoint = macro SourceInfoTransform.noArg
 
-    @deprecated(
-      "Calling this function with an empty argument list is invalid in Scala 3. Use the form without parentheses instead",
-      "Chisel 3.5"
-    )
-    final def unary_-(dummy: Int*): FixedPoint = macro SourceInfoTransform.noArgDummy
-
     /** Unary negation (constant width)
       *
       * @return a hardware $coll equal to zero minus `this` shifted right by one
@@ -1497,11 +1401,6 @@ package experimental {
       * @group Arithmetic
       */
     final def unary_-% : FixedPoint = macro SourceInfoTransform.noArg
-    @deprecated(
-      "Calling this function with an empty argument list is invalid in Scala 3. Use the form without parentheses instead",
-      "Chisel 3.5"
-    )
-    final def unary_-%(dummy: Int*): FixedPoint = macro SourceInfoTransform.noArgDummy
 
     /** @group SourceInfoTransformMacro */
     def do_unary_-(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): FixedPoint =
@@ -1991,19 +1890,7 @@ package experimental {
 
     final def unary_- : Interval = macro SourceInfoTransform.noArg
 
-    @deprecated(
-      "Calling this function with an empty argument list is invalid in Scala 3. Use the form without parentheses instead",
-      "Chisel 3.5"
-    )
-    final def unary_-(dummy: Int*): Interval = macro SourceInfoTransform.noArgDummy
-
     final def unary_-% : Interval = macro SourceInfoTransform.noArg
-
-    @deprecated(
-      "Calling this function with an empty argument list is invalid in Scala 3. Use the form without parentheses instead",
-      "Chisel 3.5"
-    )
-    final def unary_-%(dummy: Int*): Interval = macro SourceInfoTransform.noArgDummy
 
     /** @group SourceInfoTransformMacro */
     def do_unary_-(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Interval = {

--- a/core/src/main/scala/chisel3/Clock.scala
+++ b/core/src/main/scala/chisel3/Clock.scala
@@ -35,12 +35,6 @@ sealed class Clock(private[chisel3] val width: Width = Width(1)) extends Element
   /** Returns the contents of the clock wire as a [[Bool]]. */
   final def asBool: Bool = macro SourceInfoTransform.noArg
 
-  @deprecated(
-    "Calling this function with an empty argument list is invalid in Scala 3. Use the form without parentheses instead",
-    "Chisel 3.5"
-  )
-  final def asBool(dummy: Int*): Bool = macro SourceInfoTransform.noArgDummy
-
   def do_asBool(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool = this.asUInt.asBool
 
   override def do_asUInt(implicit sourceInfo: SourceInfo, connectCompileOptions: CompileOptions): UInt = pushOp(

--- a/core/src/main/scala/chisel3/Data.scala
+++ b/core/src/main/scala/chisel3/Data.scala
@@ -455,7 +455,6 @@ object Flipped {
   */
 abstract class Data extends HasId with NamedComponent with SourceInfoDoc {
   // This is a bad API that punches through object boundaries.
-  @deprecated("pending removal once all instances replaced", "chisel3")
   private[chisel3] def flatten: IndexedSeq[Element] = {
     this match {
       case elt: Aggregate => elt.getElements.toIndexedSeq.flatMap { _.flatten }

--- a/core/src/main/scala/chisel3/Data.scala
+++ b/core/src/main/scala/chisel3/Data.scala
@@ -579,10 +579,6 @@ abstract class Data extends HasId with NamedComponent with SourceInfoDoc {
   // User-friendly representation of the binding as a helper function for toString.
   // Provides a unhelpful fallback for literals, which should have custom rendering per
   // Data-subtype.
-  // TODO Is this okay for sample_element? It *shouldn't* be visible to users
-  @deprecated("This was never intended to be visible to user-defined types", "Chisel 3.5.0")
-  protected def bindingToString: String = _bindingToString(topBinding)
-
   private[chisel3] def _bindingToString(topBindingOpt: TopBinding): String =
     topBindingOpt match {
       case OpBinding(_, _)           => "OpResult"
@@ -808,34 +804,16 @@ abstract class Data extends HasId with NamedComponent with SourceInfoDoc {
 
   def isLit: Boolean = litOption.isDefined
 
-  @deprecated(
-    "Calling this function with an empty argument list is invalid in Scala 3. Use the form without parentheses instead",
-    "Chisel 3.5"
-  )
-  def isLit(dummy: Int*): Boolean = isLit
-
   /**
     * If this is a literal that is representable as bits, returns the value as a BigInt.
     * If not a literal, or not representable as bits (for example, is or contains Analog), returns None.
     */
   def litOption: Option[BigInt]
 
-  @deprecated(
-    "Calling this function with an empty argument list is invalid in Scala 3. Use the form without parentheses instead",
-    "Chisel 3.5"
-  )
-  def litOption(dummy: Int*): Option[BigInt] = litOption
-
   /**
     * Returns the literal value if this is a literal that is representable as bits, otherwise crashes.
     */
   def litValue: BigInt = litOption.get
-
-  @deprecated(
-    "Calling this function with an empty argument list is invalid in Scala 3. Use the form without parentheses instead",
-    "Chisel 3.5"
-  )
-  def litValue(dummy: Int*): BigInt = litValue
 
   /** Returns the width, in bits, if currently known. */
   final def getWidth: Int =
@@ -881,12 +859,6 @@ abstract class Data extends HasId with NamedComponent with SourceInfoDoc {
     * in the least-significant bits of the result.
     */
   final def asUInt: UInt = macro SourceInfoTransform.noArg
-
-  @deprecated(
-    "Calling this function with an empty argument list is invalid in Scala 3. Use the form without parentheses instead",
-    "Chisel 3.5"
-  )
-  final def asUInt(dummy: Int*): UInt = macro SourceInfoTransform.noArgDummy
 
   /** @group SourceInfoTransformMacro */
   def do_asUInt(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): UInt

--- a/core/src/main/scala/chisel3/Num.scala
+++ b/core/src/main/scala/chisel3/Num.scala
@@ -31,7 +31,7 @@ trait Num[T <: Data] {
   self: Num[T] =>
   // def << (b: T): T
   // def >> (b: T): T
-  //def unary_-(): T
+  //def unary_-: T
 
   // REVIEW TODO: double check ops conventions against FIRRTL
 

--- a/core/src/main/scala/chisel3/StrongEnum.scala
+++ b/core/src/main/scala/chisel3/StrongEnum.scala
@@ -153,7 +153,7 @@ abstract class EnumType(private[chisel3] val factory: EnumFactory, selfAnnotatin
     * @return a hardware [[Bool]] that indicates if this value matches any of the given values
     */
   final def isOneOf(s: Seq[EnumType])(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool = {
-    VecInit(s.map(this === _)).asUInt().orR()
+    VecInit(s.map(this === _)).asUInt.orR
   }
 
   /** Test if this enumeration is equal to any of the values given as arguments

--- a/core/src/main/scala/chisel3/VerificationStatement.scala
+++ b/core/src/main/scala/chisel3/VerificationStatement.scala
@@ -185,7 +185,7 @@ object assert extends VerifPrintMacrosDoc {
     compileOptions:      CompileOptions
   ): Assert = {
     val id = new Assert()
-    when(!Module.reset.asBool()) {
+    when(!Module.reset.asBool) {
       failureMessage("Assertion", line, cond, message.map(Printable.pack(_, data: _*)))
       Builder.pushCommand(Verification(id, Formal.Assert, sourceInfo, Module.clock.ref, cond.ref, ""))
     }
@@ -203,7 +203,7 @@ object assert extends VerifPrintMacrosDoc {
   ): Assert = {
     val id = new Assert()
     message.foreach(Printable.checkScope(_))
-    when(!Module.reset.asBool()) {
+    when(!Module.reset.asBool) {
       failureMessage("Assertion", line, cond, message)
       Builder.pushCommand(Verification(id, Formal.Assert, sourceInfo, Module.clock.ref, cond.ref, ""))
     }
@@ -375,7 +375,7 @@ object assume extends VerifPrintMacrosDoc {
     compileOptions:      CompileOptions
   ): Assume = {
     val id = new Assume()
-    when(!Module.reset.asBool()) {
+    when(!Module.reset.asBool) {
       failureMessage("Assumption", line, cond, message.map(Printable.pack(_, data: _*)))
       Builder.pushCommand(Verification(id, Formal.Assume, sourceInfo, Module.clock.ref, cond.ref, ""))
     }
@@ -393,7 +393,7 @@ object assume extends VerifPrintMacrosDoc {
   ): Assume = {
     val id = new Assume()
     message.foreach(Printable.checkScope(_))
-    when(!Module.reset.asBool()) {
+    when(!Module.reset.asBool) {
       failureMessage("Assumption", line, cond, message)
       Builder.pushCommand(Verification(id, Formal.Assume, sourceInfo, Module.clock.ref, cond.ref, ""))
     }
@@ -464,7 +464,7 @@ object cover extends VerifPrintMacrosDoc {
     compileOptions:      CompileOptions
   ): Cover = {
     val id = new Cover()
-    when(!Module.reset.asBool()) {
+    when(!Module.reset.asBool) {
       Builder.pushCommand(Verification(id, Formal.Cover, sourceInfo, Module.clock.ref, cond.ref, ""))
     }
     id

--- a/docs/src/cookbooks/cookbook.md
+++ b/docs/src/cookbooks/cookbook.md
@@ -40,7 +40,7 @@ Please note that these examples make use of [Chisel's scala-style printing](../e
 
 ### How do I create a UInt from an instance of a Bundle?
 
-Call [`asUInt`](https://www.chisel-lang.org/api/latest/chisel3/Bundle.html#asUInt():chisel3.UInt) on the [`Bundle`](https://www.chisel-lang.org/api/latest/chisel3/Bundle.html) instance.
+Call [`asUInt`](https://www.chisel-lang.org/api/latest/chisel3/Bundle.html#asUInt:chisel3.UInt) on the [`Bundle`](https://www.chisel-lang.org/api/latest/chisel3/Bundle.html) instance.
 
 ```scala mdoc:silent:reset
 import chisel3._
@@ -127,7 +127,7 @@ ChiselStage.emitVerilog(new Foo(new MyBundle))
 ```
 ### How do I create a Vec of Bools from a UInt?
 
-Use [`VecInit`](https://www.chisel-lang.org/api/latest/chisel3/VecInit$.html) given a `Seq[Bool]` generated using the [`asBools`](https://www.chisel-lang.org/api/latest/chisel3/UInt.html#asBools():Seq[chisel3.Bool]) method.
+Use [`VecInit`](https://www.chisel-lang.org/api/latest/chisel3/VecInit$.html) given a `Seq[Bool]` generated using the [`asBools`](https://www.chisel-lang.org/api/latest/chisel3/UInt.html#asBools:Seq[chisel3.Bool]) method.
 
 ```scala mdoc:silent:reset
 import chisel3._
@@ -153,7 +153,7 @@ getVerilogString(new Foo)
 
 ### How do I create a UInt from a Vec of Bool?
 
-Use the builtin function [`asUInt`](https://www.chisel-lang.org/api/latest/chisel3/Vec.html#asUInt():chisel3.UInt)
+Use the builtin function [`asUInt`](https://www.chisel-lang.org/api/latest/chisel3/Vec.html#asUInt:chisel3.UInt)
 
 ```scala mdoc:silent:reset
 import chisel3._

--- a/integration-tests/src/test/scala/chisel3/std/BarrelShifter.scala
+++ b/integration-tests/src/test/scala/chisel3/std/BarrelShifter.scala
@@ -17,7 +17,7 @@ class VecLeftRotater[T <: Data](len: Int, gen: T, layerSize: Int = 1) extends Mo
   outputs := BarrelShifter.leftRotate(inputs, shift, layerSize)
 
   // Note: see note in VecLeftShifter
-  assert(inputs.asUInt().rotateRight(shift * gen.getWidth.U) === outputs.asUInt())
+  assert(inputs.asUInt.rotateRight(shift * gen.getWidth.U) === outputs.asUInt)
 }
 
 class VecLeftShifter[T <: Data](len: Int, gen: T, layerSize: Int = 1) extends Module {
@@ -29,7 +29,7 @@ class VecLeftShifter[T <: Data](len: Int, gen: T, layerSize: Int = 1) extends Mo
   outputs := BarrelShifter.leftShift(inputs, shift, layerSize)
 
   // Note: left shift for Vec is right shift for UInt
-  assert((inputs.asUInt() >> (shift * gen.getWidth.U)).pad(inputs.getWidth) === outputs.asUInt())
+  assert((inputs.asUInt >> (shift * gen.getWidth.U)).pad(inputs.getWidth) === outputs.asUInt)
 }
 
 class VecRightRotater[T <: Data](len: Int, gen: T, layerSize: Int = 1) extends Module {
@@ -41,7 +41,7 @@ class VecRightRotater[T <: Data](len: Int, gen: T, layerSize: Int = 1) extends M
   outputs := BarrelShifter.rightRotate(inputs, shift, layerSize)
 
   // Note: see note in VecRightShifter
-  assert(inputs.asUInt().rotateLeft(shift * gen.getWidth.U) === outputs.asUInt())
+  assert(inputs.asUInt.rotateLeft(shift * gen.getWidth.U) === outputs.asUInt)
 }
 
 class VecRightShifter[T <: Data](len: Int, gen: T, layerSize: Int = 1) extends Module {
@@ -54,7 +54,7 @@ class VecRightShifter[T <: Data](len: Int, gen: T, layerSize: Int = 1) extends M
 
   // Note: right shift for Vec is left shift for UInt
   // on << shift width: UInt(this.width + that)
-  assert(((inputs.asUInt() << (shift * gen.getWidth.U))(inputs.getWidth - 1, 0)) === outputs.asUInt())
+  assert(((inputs.asUInt << (shift * gen.getWidth.U))(inputs.getWidth - 1, 0)) === outputs.asUInt)
 }
 
 class BarrelShifterTester extends AnyFlatSpec with ChiselScalatestTester with Formal {

--- a/src/main/scala/chisel3/util/pla.scala
+++ b/src/main/scala/chisel3/util/pla.scala
@@ -95,7 +95,7 @@ object pla {
           }
         }
         .flatten
-      if (andMatrixInput.nonEmpty) t.toString -> Cat(andMatrixInput).andR() else t.toString -> true.B
+      if (andMatrixInput.nonEmpty) t.toString -> Cat(andMatrixInput).andR else t.toString -> true.B
     }.toMap
 
     // the OR matrix
@@ -111,7 +111,7 @@ object pla {
                 andMatrixOutputs(inputTerm.toString)
             }
           if (andMatrixLines.isEmpty) false.B
-          else Cat(andMatrixLines).orR()
+          else Cat(andMatrixLines).orR
         }
         .reverse
     )

--- a/src/test/scala/chiselTests/BundleLiteralSpec.scala
+++ b/src/test/scala/chiselTests/BundleLiteralSpec.scala
@@ -33,7 +33,7 @@ class BundleLiteralSpec extends ChiselFlatSpec with Utils {
       new BasicTester {
         val bundleLit = (new MyBundle).Lit(_.a -> 42.U, _.b -> false.B, _.c -> MyEnum.sB)
         bundleLit.litOption should equal(Some(169)) // packed as 42 (8-bit), false=0 (1-bit), sB=1 (1-bit)
-        chisel3.assert(bundleLit.asUInt() === bundleLit.litOption.get.U) // sanity-check consistency with runtime
+        chisel3.assert(bundleLit.asUInt === bundleLit.litOption.get.U) // sanity-check consistency with runtime
 
         val longBundleLit =
           (new LongBundle).Lit(_.a -> 0xdeaddeadbeefL.U, _.b -> (-0x0beef00dL).S(32.W), _.c -> 4.5.F(16.W, 4.BP))
@@ -44,7 +44,7 @@ class BundleLiteralSpec extends ChiselFlatSpec with Utils {
               + BigInt(72)
           )
         )
-        chisel3.assert(longBundleLit.asUInt() === longBundleLit.litOption.get.U)
+        chisel3.assert(longBundleLit.asUInt === longBundleLit.litOption.get.U)
 
         stop()
       }
@@ -59,8 +59,8 @@ class BundleLiteralSpec extends ChiselFlatSpec with Utils {
         chisel3.assert(outsideBundleLit.a === 42.U)
         chisel3.assert(outsideBundleLit.b === true.B)
         chisel3.assert(outsideBundleLit.c === MyEnum.sB)
-        chisel3.assert(outsideBundleLit.isLit())
-        chisel3.assert(outsideBundleLit.litValue().U === outsideBundleLit.asUInt())
+        chisel3.assert(outsideBundleLit.isLit)
+        chisel3.assert(outsideBundleLit.litValue.U === outsideBundleLit.asUInt)
         val bundleLit = (new MyBundle).Lit(_.a -> 42.U, _.b -> true.B, _.c -> MyEnum.sB)
         chisel3.assert(bundleLit.a === 42.U)
         chisel3.assert(bundleLit.b === true.B)
@@ -136,8 +136,8 @@ class BundleLiteralSpec extends ChiselFlatSpec with Utils {
         chisel3.assert(explicitBundleLit.a.a === 42.U)
         chisel3.assert(explicitBundleLit.a.b === true.B)
         chisel3.assert(explicitBundleLit.a.c === MyEnum.sB)
-        chisel3.assert(explicitBundleLit.a.isLit())
-        chisel3.assert(explicitBundleLit.a.litValue().U === explicitBundleLit.a.asUInt())
+        chisel3.assert(explicitBundleLit.a.isLit)
+        chisel3.assert(explicitBundleLit.a.litValue.U === explicitBundleLit.a.asUInt)
 
         // Specify the inner Bundle fields directly
         val expandedBundleLit = (new MyOuterBundle).Lit(
@@ -154,10 +154,10 @@ class BundleLiteralSpec extends ChiselFlatSpec with Utils {
         chisel3.assert(expandedBundleLit.b.c === false.B)
         chisel3.assert(expandedBundleLit.b.d === 255.U)
         chisel3.assert(expandedBundleLit.b.e === MyEnum.sB)
-        chisel3.assert(!expandedBundleLit.a.isLit()) // element e is missing
-        chisel3.assert(expandedBundleLit.b.isLit())
-        chisel3.assert(!expandedBundleLit.isLit()) // element a.e is missing
-        chisel3.assert(expandedBundleLit.b.litValue().U === expandedBundleLit.b.asUInt())
+        chisel3.assert(!expandedBundleLit.a.isLit) // element e is missing
+        chisel3.assert(expandedBundleLit.b.isLit)
+        chisel3.assert(!expandedBundleLit.isLit) // element a.e is missing
+        chisel3.assert(expandedBundleLit.b.litValue.U === expandedBundleLit.b.asUInt)
 
         // Anonymously contruct the inner Bundle literal
         // A bit of weird syntax that depends on implementation details of the Bundle literal constructor
@@ -166,9 +166,9 @@ class BundleLiteralSpec extends ChiselFlatSpec with Utils {
         chisel3.assert(childBundleLit.b.c === false.B)
         chisel3.assert(childBundleLit.b.d === 255.U)
         chisel3.assert(childBundleLit.b.e === MyEnum.sB)
-        chisel3.assert(childBundleLit.b.isLit())
-        chisel3.assert(!childBundleLit.isLit()) // elements a and f are missing
-        chisel3.assert(childBundleLit.b.litValue().U === childBundleLit.b.asUInt())
+        chisel3.assert(childBundleLit.b.isLit)
+        chisel3.assert(!childBundleLit.isLit) // elements a and f are missing
+        chisel3.assert(childBundleLit.b.litValue.U === childBundleLit.b.asUInt)
 
         stop()
       }

--- a/src/test/scala/chiselTests/BundleWire.scala
+++ b/src/test/scala/chiselTests/BundleWire.scala
@@ -37,7 +37,7 @@ class BundleToUnitTester extends BasicTester {
   bundle2.a := 0.U
   bundle2.b := 27.U
 
-  assert(bundle1.asUInt() === bundle2.asUInt())
+  assert(bundle1.asUInt === bundle2.asUInt)
 
   stop()
 }

--- a/src/test/scala/chiselTests/CompatibilitySpec.scala
+++ b/src/test/scala/chiselTests/CompatibilitySpec.scala
@@ -55,7 +55,7 @@ class CompatibilitySpec extends ChiselFlatSpec with ScalaCheckDrivenPropertyChec
     l shouldBe a[UInt]
     l shouldBe 'lit
     l.getWidth shouldEqual BigInt(value).bitLength
-    l.litValue() shouldEqual value
+    l.litValue shouldEqual value
   }
 
   it should "map utility objects into the package object" in {

--- a/src/test/scala/chiselTests/IntervalSpec.scala
+++ b/src/test/scala/chiselTests/IntervalSpec.scala
@@ -217,10 +217,10 @@ class ClipSqueezeWrapDemo(
 
   printf(
     "       %d       %d          %d         %d\n",
-    counter.asSInt(),
-    clipped.asSInt(),
-    squeezed.asSInt(),
-    wrapped.asSInt()
+    counter.asSInt,
+    clipped.asSInt,
+    squeezed.asSInt,
+    wrapped.asSInt
   )
 }
 
@@ -245,7 +245,7 @@ class SqueezeFunctionalityTester(range: IntervalRange, startNum: BigDecimal, end
   squeezeTemplate := toSqueeze.squeeze(squeezeInterval)
 
   printf(
-    cf"SqueezeTest $counter%d ${toSqueeze.asSInt()}%d.squeeze($range) => ${squeezeTemplate.asSInt()}%d\n"
+    cf"SqueezeTest $counter%d ${toSqueeze.asSInt}%d.squeeze($range) => ${squeezeTemplate.asSInt}%d\n"
   )
 }
 
@@ -478,8 +478,8 @@ class IntervalSpec extends AnyFreeSpec with Matchers with ChiselRunners {
       val inputRange = range"[-6, 6].2"
       val in1 = (-6.0).I(inputRange)
       val in2 = 6.0.I(inputRange)
-      BigDecimal(in1.litValue()) / (1 << inputRange.binaryPoint.get) should be(-6)
-      BigDecimal(in2.litValue()) / (1 << inputRange.binaryPoint.get) should be(6)
+      BigDecimal(in1.litValue) / (1 << inputRange.binaryPoint.get) should be(-6)
+      BigDecimal(in2.litValue) / (1 << inputRange.binaryPoint.get) should be(6)
       intercept[ChiselException] {
         (-6.25).I(inputRange)
       }
@@ -491,8 +491,8 @@ class IntervalSpec extends AnyFreeSpec with Matchers with ChiselRunners {
       val inputRange = range"(-6, 6).2"
       val in1 = (-5.75).I(inputRange)
       val in2 = 5.75.I(inputRange)
-      BigDecimal(in1.litValue()) / (1 << inputRange.binaryPoint.get) should be(-5.75)
-      BigDecimal(in2.litValue()) / (1 << inputRange.binaryPoint.get) should be(5.75)
+      BigDecimal(in1.litValue) / (1 << inputRange.binaryPoint.get) should be(-5.75)
+      BigDecimal(in2.litValue) / (1 << inputRange.binaryPoint.get) should be(5.75)
       intercept[ChiselException] {
         (-6.0).I(inputRange)
       }
@@ -504,8 +504,8 @@ class IntervalSpec extends AnyFreeSpec with Matchers with ChiselRunners {
       val inputRange = range"(-6, 6).2"
       val in1 = (-5.95).I(inputRange)
       val in2 = 5.95.I(inputRange)
-      BigDecimal(in1.litValue()) / (1 << inputRange.binaryPoint.get) should be(-5.75)
-      BigDecimal(in2.litValue()) / (1 << inputRange.binaryPoint.get) should be(5.75)
+      BigDecimal(in1.litValue) / (1 << inputRange.binaryPoint.get) should be(-5.75)
+      BigDecimal(in2.litValue) / (1 << inputRange.binaryPoint.get) should be(5.75)
       intercept[ChiselException] {
         (-6.1).I(inputRange)
       }
@@ -870,7 +870,7 @@ class IntervalSpec extends AnyFreeSpec with Matchers with ChiselRunners {
 
           // Useful for debugging
           // printf(s"source value $sourceValue clipped gold value %d compare to clipped value %d\n",
-          //  goldClippedValue.asSInt(), clippedValue.asSInt())
+          //  goldClippedValue.asSInt, clippedValue.asSInt)
 
           chisel3.assert(goldClippedValue === clippedValue)
 
@@ -884,7 +884,7 @@ class IntervalSpec extends AnyFreeSpec with Matchers with ChiselRunners {
 
           // Useful for debugging
           // printf(s"source value $sourceValue wrapped gold value %d compare to wrapped value %d\n",
-          //  goldWrappedValue.asSInt(), wrappedValue.asSInt())
+          //  goldWrappedValue.asSInt, wrappedValue.asSInt)
 
           chisel3.assert(goldWrappedValue === wrappedValue)
         }
@@ -915,7 +915,7 @@ class IntervalSpec extends AnyFreeSpec with Matchers with ChiselRunners {
 
           // Useful for debugging
           // printf(s"source value $sourceValue squeezed gold value %d compare to squeezed value %d\n",
-          //   goldSqueezedValue.asSInt(), squeezedValue.asSInt())
+          //   goldSqueezedValue.asSInt, squeezedValue.asSInt)
 
           chisel3.assert(goldSqueezedValue === squeezedValue)
         }

--- a/src/test/scala/chiselTests/LiteralExtractorSpec.scala
+++ b/src/test/scala/chiselTests/LiteralExtractorSpec.scala
@@ -95,8 +95,8 @@ class LiteralExtractorSpec extends ChiselFlatSpec {
         }
       } else {
         val literal = value.I(range)
-        literal.isLit() should be(true)
-        literal.litValue().toDouble / 4.0 should be(value)
+        literal.isLit should be(true)
+        literal.litValue.toDouble / 4.0 should be(value)
       }
     }
   }

--- a/src/test/scala/chiselTests/OneHotMuxSpec.scala
+++ b/src/test/scala/chiselTests/OneHotMuxSpec.scala
@@ -125,7 +125,7 @@ class ParameterizedOneHotTester extends BasicTester {
     val dut = Module(new ParameterizedOneHot(values.map(_.S), SInt(8.W)))
     dut.io.selectors := (1 << i).U(4.W).asBools
 
-    assert(dut.io.out.asUInt() === v.S(8.W).asUInt())
+    assert(dut.io.out.asUInt === v.S(8.W).asUInt)
   }
 
   stop()
@@ -180,7 +180,7 @@ class ParameterizedAggregateOneHotTester extends BasicTester {
     val dut = Module(new ParameterizedAggregateOneHot(Agg1, new Agg1))
     dut.io.selectors := (1 << i).U(4.W).asBools
 
-    assert(dut.io.out.asUInt() === values(i).asUInt())
+    assert(dut.io.out.asUInt === values(i).asUInt)
   }
 
   stop()

--- a/src/test/scala/chiselTests/QueueSpec.scala
+++ b/src/test/scala/chiselTests/QueueSpec.scala
@@ -21,7 +21,7 @@ class ThingsPassThroughTester(
     extends BasicTester {
   val q = Module(new Queue(UInt(bitWidth.W), queueDepth, useSyncReadMem = useSyncReadMem, hasFlush = hasFlush))
   val elems = VecInit(elements.map {
-    _.asUInt()
+    _.asUInt
   })
   val inCnt = Counter(elements.length + 1)
   val outCnt = Counter(elements.length + 1)
@@ -47,7 +47,7 @@ class QueueReasonableReadyValid(elements: Seq[Int], queueDepth: Int, bitWidth: I
     extends BasicTester {
   val q = Module(new Queue(UInt(bitWidth.W), queueDepth, useSyncReadMem = useSyncReadMem))
   val elems = VecInit(elements.map {
-    _.asUInt()
+    _.asUInt
   })
   val inCnt = Counter(elements.length + 1)
   val outCnt = Counter(elements.length + 1)
@@ -157,7 +157,7 @@ class QueueFlowTester(elements: Seq[Int], queueDepth: Int, bitWidth: Int, tap: I
     extends BasicTester {
   val q = Module(new Queue(UInt(bitWidth.W), queueDepth, flow = true, useSyncReadMem = useSyncReadMem))
   val elems = VecInit(elements.map {
-    _.asUInt()
+    _.asUInt
   })
   val inCnt = Counter(elements.length + 1)
   val outCnt = Counter(elements.length + 1)
@@ -188,7 +188,7 @@ class QueueFactoryTester(elements: Seq[Int], queueDepth: Int, bitWidth: Int, tap
   val deq = Queue(enq, queueDepth, useSyncReadMem = useSyncReadMem)
 
   val elems = VecInit(elements.map {
-    _.asUInt()
+    _.asUInt
   })
   val inCnt = Counter(elements.length + 1)
   val outCnt = Counter(elements.length + 1)

--- a/src/test/scala/chiselTests/Risc.scala
+++ b/src/test/scala/chiselTests/Risc.scala
@@ -74,8 +74,8 @@ class RiscTester(c: Risc) extends Tester(c) {
     step(1)
   }
   def I (op: UInt, rc: Int, ra: Int, rb: Int) = {
-    // val cr = Cat(op, rc.asUInt(8.W), ra.asUInt(8.W), rb.asUInt(8.W)).litValue()
-    val cr = op.litValue() << 24 | rc << 16 | ra << 8 | rb
+    // val cr = Cat(op, rc.asUInt(8.W), ra.asUInt(8.W), rb.asUInt(8.W)).litValue
+    val cr = op.litValue << 24 | rc << 16 | ra << 8 | rb
     println("I = " + cr)
     cr
   }

--- a/src/test/scala/chiselTests/StrongEnum.scala
+++ b/src/test/scala/chiselTests/StrongEnum.scala
@@ -51,7 +51,7 @@ class CastToUInt extends Module {
     val out = Output(UInt())
   })
 
-  io.out := io.in.asUInt()
+  io.out := io.in.asUInt
 }
 
 class CastFromLit(in: UInt) extends Module {
@@ -238,12 +238,12 @@ class EnumOpsTester extends BasicTester {
     mod.io.x := x
     mod.io.y := y
 
-    assert(mod.io.lt === (x.asUInt() < y.asUInt()))
-    assert(mod.io.le === (x.asUInt() <= y.asUInt()))
-    assert(mod.io.gt === (x.asUInt() > y.asUInt()))
-    assert(mod.io.ge === (x.asUInt() >= y.asUInt()))
-    assert(mod.io.eq === (x.asUInt() === y.asUInt()))
-    assert(mod.io.ne === (x.asUInt() =/= y.asUInt()))
+    assert(mod.io.lt === (x.asUInt < y.asUInt))
+    assert(mod.io.le === (x.asUInt <= y.asUInt))
+    assert(mod.io.gt === (x.asUInt > y.asUInt))
+    assert(mod.io.ge === (x.asUInt >= y.asUInt))
+    assert(mod.io.eq === (x.asUInt === y.asUInt))
+    assert(mod.io.ne === (x.asUInt =/= y.asUInt))
   }
   stop()
 }

--- a/src/test/scala/chiselTests/UIntOps.scala
+++ b/src/test/scala/chiselTests/UIntOps.scala
@@ -251,7 +251,7 @@ class UIntOpsSpec extends ChiselPropSpec with Matchers with Utils {
         val in = Input(UInt(8.W))
         val out = Output(Bool())
       })
-      io.out := io.in.asBools()(2)
+      io.out := io.in.asBools(2)
     })
   }
 

--- a/src/test/scala/chiselTests/Vec.scala
+++ b/src/test/scala/chiselTests/Vec.scala
@@ -100,9 +100,9 @@ class TabulateTester(n: Int) extends BasicTester {
   val x = VecInit(Array.tabulate(n) { i => (i * 2).asUInt })
   val u = VecInit.tabulate(n)(i => (i * 2).asUInt)
 
-  assert(v.asUInt() === x.asUInt())
-  assert(v.asUInt() === u.asUInt())
-  assert(x.asUInt() === u.asUInt())
+  assert(v.asUInt === x.asUInt)
+  assert(v.asUInt === u.asUInt)
+  assert(x.asUInt === u.asUInt)
 
   stop()
 }
@@ -111,7 +111,7 @@ class FillTester(n: Int, value: Int) extends BasicTester {
   val x = VecInit(Array.fill(n)(value.U))
   val u = VecInit.fill(n)(value.U)
 
-  assert(x.asUInt() === u.asUInt(), cf"Expected Vec to be filled like $x, instead VecInit.fill created $u")
+  assert(x.asUInt === u.asUInt, cf"Expected Vec to be filled like $x, instead VecInit.fill created $u")
   stop()
 }
 
@@ -234,8 +234,8 @@ class IterateTester(start: Int, len: Int)(f: UInt => UInt) extends BasicTester {
   val controlVec = VecInit(Seq.iterate(start.U, len)(f))
   val testVec = VecInit.iterate(start.U, len)(f)
   assert(
-    controlVec.asUInt() === testVec.asUInt(),
-    cf"Expected Vec to be filled like $controlVec, instead created $testVec\n"
+    controlVec.asUInt === testVec.asUInt,
+    cf"Expected Vec to be filled like $controlVec, instead creaeted $testVec\n"
   )
   stop()
 }

--- a/src/test/scala/chiselTests/VecLiteralSpec.scala
+++ b/src/test/scala/chiselTests/VecLiteralSpec.scala
@@ -175,8 +175,8 @@ class VecLiteralSpec extends ChiselFreeSpec with Utils {
       val vec1 = Vec(4, UInt(16.W)).Lit(0 -> 0xdd.U, 1 -> 0xcc.U, 2 -> 0xbb.U, 3 -> 0xaa.U)
 
       val vec2 = VecInit(Seq(0xdd.U, 0xcc.U, 0xbb.U, 0xaa.U))
-      printf("vec1 %x\n", vec1.asUInt())
-      printf("vec2 %x\n", vec2.asUInt())
+      printf("vec1 %x\n", vec1.asUInt)
+      printf("vec2 %x\n", vec2.asUInt)
       stop()
     })
   }
@@ -221,7 +221,7 @@ class VecLiteralSpec extends ChiselFreeSpec with Utils {
         chisel3.assert(outsideVecLit(2) === 0xbb.U)
         chisel3.assert(outsideVecLit(3) === 0xaa.U)
 
-        chisel3.assert(outsideVecLit.litValue.U === outsideVecLit.asUInt())
+        chisel3.assert(outsideVecLit.litValue.U === outsideVecLit.asUInt)
 
         val insideVecLit = Vec(4, UInt(16.W)).Lit(0 -> 0xdd.U, 1 -> 0xcc.U, 2 -> 0xbb.U, 3 -> 0xaa.U)
         chisel3.assert(insideVecLit(0) === 0xdd.U)
@@ -331,7 +331,7 @@ class VecLiteralSpec extends ChiselFreeSpec with Utils {
 
         vecWire1 := vecLit1
         vecWire1 := vecLit2
-        printf("vw1(0) %x  vw1(1) %x\n", vecWire1(0).asUInt(), vecWire1(1).asUInt())
+        printf("vw1(0) %x  vw1(1) %x\n", vecWire1(0).asUInt, vecWire1(1).asUInt)
         chisel3.assert(vecWire1(0) === (1.5).F(8.W, 4.BP))
         chisel3.assert(vecWire1(1) === (3.25).F(8.W, 4.BP))
         stop()
@@ -352,7 +352,7 @@ class VecLiteralSpec extends ChiselFreeSpec with Utils {
         vecWire1 := vecLit1
         vecWire2 := vecLit2
         vecWire1(1) := (0.5).F(8.W, 4.BP)
-        printf("vw1(0) %x  vw1(1) %x\n", vecWire1(0).asUInt(), vecWire1(1).asUInt())
+        printf("vw1(0) %x  vw1(1) %x\n", vecWire1(0).asUInt, vecWire1(1).asUInt)
         chisel3.assert(vecWire1(0) === (1.5).F(8.W, 4.BP))
         chisel3.assert(vecWire1(1) === (0.5).F(8.W, 4.BP)) // Last connect won
         chisel3.assert(vecWire2(1) === (3.25).F(8.W, 4.BP))

--- a/src/test/scala/chiselTests/aop/InjectionSpec.scala
+++ b/src/test/scala/chiselTests/aop/InjectionSpec.scala
@@ -56,7 +56,7 @@ object InjectionHierarchy {
     when(counter >= values.length.U) {
       stop()
     }.otherwise {
-      when(reset.asBool() === false.B) {
+      when(reset.asBool === false.B) {
         assert(counter === values(counter))
       }
     }
@@ -119,7 +119,7 @@ class InjectionSpec extends ChiselFlatSpec with Utils {
     },
     { m: Module =>
       val wire = Wire(Bool())
-      wire := m.reset.asBool()
+      wire := m.reset.asBool
       dontTouch(wire)
       stop()
     }

--- a/src/test/scala/chiselTests/aop/SelectSpec.scala
+++ b/src/test/scala/chiselTests/aop/SelectSpec.scala
@@ -19,7 +19,7 @@ class SelectTester(results: Seq[Int]) extends BasicTester {
   val added = counter + 1.U
   counter := added
   val overflow = counter >= values.length.U
-  val nreset = reset.asBool() === false.B
+  val nreset = reset.asBool === false.B
   val selected = values(counter)
   val zero = 0.U + 0.U
   var p: printf.Printf = null

--- a/stdlib/src/main/scala/chisel3/std/BarrelShifter.scala
+++ b/stdlib/src/main/scala/chisel3/std/BarrelShifter.scala
@@ -44,9 +44,9 @@ object BarrelShifter {
     require(shiftGranularity > 0)
     val elementType: T = chiselTypeOf(inputs.head)
     shiftInput
-      .asBools()
+      .asBools
       .grouped(shiftGranularity)
-      .map(VecInit(_).asUInt())
+      .map(VecInit(_).asUInt)
       .zipWithIndex
       .foldLeft(inputs) {
         case (prev, (shiftBits, layer)) =>


### PR DESCRIPTION
Remove all deprecations from Bool.scala and Clock.scala
Deleted deprecated `asBool()` form.
Change all `asBool()` to `asBool`
Deleted deprecated parenthesized form of unary ~
Deleted deprecated parenthesized form of `asBools()`
Changed   occurrences to `asBools`
Deleted deprecated parenthesized form of `asBools()`
Changed   occurrences to `asBools`
Deleted deprecated parenthesized form of `unary_-`
Deleted deprecated parenthesized form of `unary_-`
Deleted deprecated parenthesized form of `unary_-%`
Deleted deprecated parenthesized form of `asyncReset()`
Deleted deprecated parenthesized form of `asClock()`
Deleted deprecated parenthesized form of `unqary_-()`
Deleted deprecated parenthesized form of `unqary_-()`
Deleted deprecated parenthesized form of `unqary_-()`
orR()
orR()
unary_!()
unary_!()
unary_!()
unary_!()

Goes through rest of chisel3 to comply with above work

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [ ] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [ ] Did you state the API impact?
- [ ] Did you specify the code generation impact?
- [ ] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
