### PR TITLE
Add BufferedProcessLogger and thread it through assertTesterPasses

### DIFF
--- a/src/test/scala/chiselTests/ChiselSpec.scala
+++ b/src/test/scala/chiselTests/ChiselSpec.scala
@@ -218,6 +218,7 @@ class BufferedProcessLogger extends ProcessLogger {
   def out(s:       => String): Unit = buffer += s
   def err(s:       => String): Unit = buffer += s
   def buffer[T](f: => T):      T = f
+  def value: String = buffer.mkString
 }
 
 trait Utils {
@@ -377,5 +378,5 @@ trait Utils {
 
   }
 
-  def bufferedProcessLogger: ProcessLogger = new BufferedProcessLogger
+  def bufferedProcessLogger: BufferedProcessLogger = new BufferedProcessLogger
 }

--- a/src/test/scala/chiselTests/ChiselSpec.scala
+++ b/src/test/scala/chiselTests/ChiselSpec.scala
@@ -213,6 +213,13 @@ abstract class ChiselPropSpec extends AnyPropSpec with ChiselRunners with ScalaC
   } yield (w, i, j)
 }
 
+class BufferedProcessLogger extends ProcessLogger {
+  private val buffer = ArrayBuffer[String]()
+  def out(s:       => String): Unit = buffer += s
+  def err(s:       => String): Unit = buffer += s
+  def buffer[T](f: => T):      T = f
+}
+
 trait Utils {
 
   /** Run some Scala thunk and return STDOUT and STDERR as strings.
@@ -369,4 +376,6 @@ trait Utils {
     }
 
   }
+
+  def bufferedProcessLogger: ProcessLogger = new BufferedProcessLogger
 }

--- a/src/test/scala/chiselTests/ChiselSpec.scala
+++ b/src/test/scala/chiselTests/ChiselSpec.scala
@@ -213,13 +213,6 @@ abstract class ChiselPropSpec extends AnyPropSpec with ChiselRunners with ScalaC
   } yield (w, i, j)
 }
 
-class BufferedProcessLogger extends ProcessLogger {
-  private val buffer = ArrayBuffer[String]()
-  def out(s:       => String): Unit = buffer += s
-  def err(s:       => String): Unit = buffer += s
-  def buffer[T](f: => T):      T = f
-}
-
 trait Utils {
 
   /** Run some Scala thunk and return STDOUT and STDERR as strings.
@@ -376,6 +369,4 @@ trait Utils {
     }
 
   }
-
-  def bufferedProcessLogger: ProcessLogger = new BufferedProcessLogger
 }

--- a/src/test/scala/chiselTests/StrongEnum.scala
+++ b/src/test/scala/chiselTests/StrongEnum.scala
@@ -590,7 +590,7 @@ class StrongEnumSpec extends ChiselFlatSpec with Utils {
   }
 
   it should "work with Printables" in {
-    val (log, _, _) = grabStdOutErr(assertTesterPasses { new PrintableExecutionTest })
+    val (log, _) = grabLog(assertTesterPasses(new PrintableExecutionTest, logger = bufferedProcessLogger))
     log should include("load")
     log should include("imm")
     log should include("auipc")

--- a/src/test/scala/chiselTests/StrongEnum.scala
+++ b/src/test/scala/chiselTests/StrongEnum.scala
@@ -590,7 +590,7 @@ class StrongEnumSpec extends ChiselFlatSpec with Utils {
   }
 
   it should "work with Printables" in {
-    val (log, _) = grabLog(assertTesterPasses { new PrintableExecutionTest })
+    val (log, _) = grabLog(assertTesterPasses(new PrintableExecutionTest, logger = bufferedProcessLogger))
     log should include("load")
     log should include("imm")
     log should include("auipc")

--- a/src/test/scala/chiselTests/StrongEnum.scala
+++ b/src/test/scala/chiselTests/StrongEnum.scala
@@ -590,7 +590,7 @@ class StrongEnumSpec extends ChiselFlatSpec with Utils {
   }
 
   it should "work with Printables" in {
-    val (log, _) = grabLog(assertTesterPasses(new PrintableExecutionTest, logger = bufferedProcessLogger))
+    val (log, _, _) = grabStdOutErr(assertTesterPasses(new PrintableExecutionTest, logger = bufferedProcessLogger))
     log should include("load")
     log should include("imm")
     log should include("auipc")

--- a/src/test/scala/chiselTests/StrongEnum.scala
+++ b/src/test/scala/chiselTests/StrongEnum.scala
@@ -590,7 +590,9 @@ class StrongEnumSpec extends ChiselFlatSpec with Utils {
   }
 
   it should "work with Printables" in {
-    val (log, _) = grabLog(assertTesterPasses(new PrintableExecutionTest, logger = bufferedProcessLogger))
+    val processLogger = bufferedProcessLogger
+    assertTesterPasses(new PrintableExecutionTest, logger = processLogger)
+    val log = processLogger.value
     log should include("load")
     log should include("imm")
     log should include("auipc")

--- a/src/test/scala/chiselTests/StrongEnum.scala
+++ b/src/test/scala/chiselTests/StrongEnum.scala
@@ -590,7 +590,7 @@ class StrongEnumSpec extends ChiselFlatSpec with Utils {
   }
 
   it should "work with Printables" in {
-    val (log, _, _) = grabStdOutErr(assertTesterPasses(new PrintableExecutionTest, logger = bufferedProcessLogger))
+    val (log, _) = grabLog(assertTesterPasses { new PrintableExecutionTest })
     log should include("load")
     log should include("imm")
     log should include("auipc")


### PR DESCRIPTION
When running CI tests the logger interacts with global state which affects the log being output. the `BufferedProcessLogger` creates a stable buffer for the log stdout which is required for tests relying on a stdout.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
  - bug fix                    
 - new feature/API   

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->
Adds a new `ProcessLogger` subclass for buffering stdout and stderr

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->
N/A

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
  - Squash: The PR will be squashed and merged (choose this if you have no preference. 
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
Add BufferedProcessLogger for stable stdout logging

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
