### PR TITLE
Bump to Scala 2.13.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         system: ["ubuntu-20.04"]
         jvm: ["adopt@1.8"]
-        scala: ["2.13.9", "2.12.17"]
+        scala: ["2.13.10", "2.12.17"]
         espresso: ["2.4"]
         circt: ["sifive/1/15/0"]
     runs-on: ${{ matrix.system }}
@@ -108,7 +108,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        scala: [ "2.13.9", "2.12.17" ]
+        scala: [ "2.13.10", "2.12.17" ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -221,11 +221,11 @@ For example, in SBT this could be expressed as:
 
 ```scala
 // build.sbt
-scalaVersion := "2.13.8"
-addCompilerPlugin("edu.berkeley.cs" % "chisel3-plugin" % "3.5.3" cross CrossVersion.full)
-libraryDependencies += "edu.berkeley.cs" %% "chisel3" % "3.5.3"
+scalaVersion := "2.13.10"
+addCompilerPlugin("edu.berkeley.cs" % "chisel3-plugin" % "3.5.4" cross CrossVersion.full)
+libraryDependencies += "edu.berkeley.cs" %% "chisel3" % "3.5.4"
 // We also recommend using chiseltest for writing unit tests
-libraryDependencies += "edu.berkeley.cs" %% "chiseltest" % "0.5.3" % "test"
+libraryDependencies += "edu.berkeley.cs" %% "chiseltest" % "0.5.4" % "test"
 ```
 
 ### Guide For New Contributors

--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ lazy val commonSettings = Seq(
   version := "3.6-SNAPSHOT",
   autoAPIMappings := true,
   scalaVersion := "2.12.17",
-  crossScalaVersions := Seq("2.13.9", "2.12.17"),
+  crossScalaVersions := Seq("2.13.10", "2.12.17"),
   scalacOptions := Seq("-deprecation", "-feature"),
   libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value,
   // Macros paradise is integrated into 2.13 but requires a scalacOption
@@ -117,7 +117,8 @@ lazy val pluginScalaVersions = Seq(
   "2.13.6",
   "2.13.7",
   "2.13.8",
-  "2.13.9"
+  "2.13.9",
+  "2.13.10",
 )
 
 lazy val plugin = (project in file("plugin"))

--- a/build.sc
+++ b/build.sc
@@ -6,7 +6,7 @@ import coursier.maven.MavenRepository
 import $ivy.`com.lihaoyi::mill-contrib-buildinfo:$MILL_VERSION`
 import mill.contrib.buildinfo.BuildInfo
 
-object chisel3 extends mill.Cross[chisel3CrossModule]("2.13.9", "2.12.17")
+object chisel3 extends mill.Cross[chisel3CrossModule]("2.13.10", "2.12.17")
 
 object v {
   val firrtl = ivy"edu.berkeley.cs::firrtl:1.6-SNAPSHOT"


### PR DESCRIPTION
2.13.9 [has a binary compatibility regression](https://github.com/scala/scala/releases/tag/v2.13.10) so should be avoided.

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

 - bug fix

#### API Impact

No impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

 - Squash

#### Release Notes

Bump to Scala 2.13.10

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
