### PR TITLE
Fix scalaVersion in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ For example, in SBT this could be expressed as:
 
 ```scala
 // build.sbt
-scalaVersion := "2.13.10"
+scalaVersion := "2.13.8"
 addCompilerPlugin("edu.berkeley.cs" % "chisel3-plugin" % "3.5.4" cross CrossVersion.full)
 libraryDependencies += "edu.berkeley.cs" %% "chisel3" % "3.5.4"
 // We also recommend using chiseltest for writing unit tests


### PR DESCRIPTION
Chisel 3.5.4 predates Scala 2.13.10 so the plugin is not published for 2.13.10.

