### PR TITLE
Add opt-in AutoCloneType for Records

### DIFF
--- a/plugin/src/main/scala/chisel3/internal/plugin/BundleComponent.scala
+++ b/plugin/src/main/scala/chisel3/internal/plugin/BundleComponent.scala
@@ -42,6 +42,8 @@ private[plugin] class BundleComponent(val global: Global, arguments: ChiselPlugi
     def inferType(t: Tree): Type = localTyper.typed(t, nsc.Mode.TYPEmode).tpe
 
     val bundleTpe:      Type = inferType(tq"chisel3.Bundle")
+    val recordTpe:      Type = inferType(tq"chisel3.Record")
+    val autoCloneTpe:   Type = inferType(tq"chisel3.experimental.AutoCloneType")
     val dataTpe:        Type = inferType(tq"chisel3.Data")
     val ignoreSeqTpe:   Type = inferType(tq"chisel3.IgnoreSeqInBundle")
     val seqOfDataTpe:   Type = inferType(tq"scala.collection.Seq[chisel3.Data]")
@@ -49,7 +51,11 @@ private[plugin] class BundleComponent(val global: Global, arguments: ChiselPlugi
     val itStringAnyTpe: Type = inferType(tq"scala.collection.Iterable[(String,Any)]")
 
     // Not cached because it should only be run once per class (thus once per Type)
-    def isBundle(sym: Symbol): Boolean = { sym.tpe <:< bundleTpe }
+    def isABundle(sym: Symbol): Boolean = { sym.tpe <:< bundleTpe }
+
+    def isARecord(sym: Symbol): Boolean = { sym.tpe <:< recordTpe }
+
+    def isAnAutoCloneType(sym: Symbol): Boolean = { sym.tpe <:< autoCloneTpe }
 
     def isIgnoreSeqInBundle(sym: Symbol): Boolean = { sym.tpe <:< ignoreSeqTpe }
 
@@ -86,7 +92,7 @@ private[plugin] class BundleComponent(val global: Global, arguments: ChiselPlugi
 
     def isVarArgs(sym: Symbol): Boolean = definitions.isRepeatedParamType(sym.tpe)
 
-    def getConstructorAndParams(body: List[Tree]): (Option[DefDef], Seq[Symbol]) = {
+    def getConstructorAndParams(body: List[Tree], isBundle: Boolean): (Option[DefDef], Seq[Symbol]) = {
       val paramAccessors = mutable.ListBuffer[Symbol]()
       var primaryConstructor: Option[DefDef] = None
       body.foreach {
@@ -96,152 +102,173 @@ private[plugin] class BundleComponent(val global: Global, arguments: ChiselPlugi
           primaryConstructor = Some(con)
         case d: DefDef if isNullaryMethodNamed("_cloneTypeImpl", d) =>
           val msg = "Users cannot override _cloneTypeImpl. Let the compiler plugin generate it."
-          global.globalError(d.pos, msg)
-        case d: DefDef if isNullaryMethodNamed("_elementsImpl", d) =>
+          global.reporter.error(d.pos, msg)
+        case d: DefDef if isNullaryMethodNamed("_elementsImpl", d) && isBundle =>
           val msg = "Users cannot override _elementsImpl. Let the compiler plugin generate it."
-          global.globalError(d.pos, msg)
-        case d: DefDef if isNullaryMethodNamed("_usingPlugin", d) =>
+          global.reporter.error(d.pos, msg)
+        case d: DefDef if isNullaryMethodNamed("_usingPlugin", d) && isBundle =>
           val msg = "Users cannot override _usingPlugin, it is for the compiler plugin's use only."
-          global.globalError(d.pos, msg)
+          global.reporter.error(d.pos, msg)
         case d: DefDef if isNullaryMethodNamed("cloneType", d) =>
-          val msg = "Users cannot override cloneType.  Let the compiler plugin generate it."
-          global.globalError(d.pos, msg)
+          val prefix = if (isBundle) "Bundles" else "Records extending AutoCloneType"
+          val msg = s"$prefix cannot override cloneType. Let the compiler plugin generate it."
+          global.reporter.error(d.pos, msg)
         case _ =>
       }
       (primaryConstructor, paramAccessors.toList)
     }
 
+    def warnOnCloneType(body: List[Tree]): Unit = {
+      body.foreach {
+        case d: DefDef if isNullaryMethodNamed("cloneType", d) =>
+          val msg = "It is no longer necessary to implement cloneType. " +
+            "Mix in chisel3.experimental.AutoCloneType to let the compiler plugin generate it. " +
+            "This will become an error in Chisel 3.6."
+          global.reporter.warning(d.pos, msg)
+        case _ => // Do nothing
+      }
+    }
+
+    def generateAutoCloneType(record: ClassDef, thiz: global.This, isBundle: Boolean): Option[Tree] = {
+      val (con, params) = getConstructorAndParams(record.impl.body, isBundle)
+      if (con.isEmpty) {
+        global.reporter.warning(record.pos, "Unable to determine primary constructor!")
+        return None
+      }
+
+      val constructor = con.get
+
+      // The params have spaces after them (Scalac implementation detail)
+      val paramLookup: String => Symbol = params.map(sym => sym.name.toString.trim -> sym).toMap
+
+      // Create a this.<ref> for each field matching order of constructor arguments
+      // List of Lists because we can have multiple parameter lists
+      val conArgs: List[List[Tree]] =
+        constructor.vparamss.map(_.map { vp =>
+          val p = paramLookup(vp.name.toString)
+          // Make this.<ref>
+          val select = gen.mkAttributedSelect(thiz.asInstanceOf[Tree], p)
+          // Clone any Data parameters to avoid field aliasing, need full clone to include direction
+          val cloned = if (isData(vp.symbol)) cloneTypeFull(select.asInstanceOf[Tree]) else select
+          // Need to splat varargs
+          if (isVarArgs(vp.symbol)) q"$cloned: _*" else cloned
+        })
+
+      val tparamList = record.tparams.map { t => Ident(t.symbol) }
+      val ttpe =
+        if (tparamList.nonEmpty) AppliedTypeTree(Ident(record.symbol), tparamList) else Ident(record.symbol)
+      val newUntyped = New(ttpe, conArgs)
+      val neww = localTyper.typed(newUntyped)
+
+      // Create the symbol for the method and have it be associated with the Record class
+      val cloneTypeSym =
+        record.symbol.newMethod(TermName("_cloneTypeImpl"), record.symbol.pos.focus, Flag.OVERRIDE | Flag.PROTECTED)
+      // Handwritten cloneTypes don't have the Method flag set, unclear if it matters
+      cloneTypeSym.resetFlag(Flags.METHOD)
+
+      // Need to set the return type correctly for the override to work
+      // For binary compatibility reasons in 3.5, Bundles have to return chisel3.Bundle
+      val returnType = if (isBundle) bundleTpe else recordTpe
+      cloneTypeSym.setInfo(NullaryMethodType(returnType))
+
+      Some(localTyper.typed(DefDef(cloneTypeSym, neww)))
+    }
+
+    def generateElements(bundle: ClassDef, thiz: global.This): Tree = {
+      /* extract the true fields from the super classes a given bundle
+       * depth argument can be helpful for debugging
+       */
+      def getAllBundleFields(bundleSymbol: Symbol, depth: Int = 0): List[(String, Tree)] = {
+
+        def isBundleField(member: Symbol): Boolean = {
+          if (!member.isAccessor) {
+            false
+          } else if (isData(member.tpe.typeSymbol)) {
+            true
+          } else if (isOptionOfData(member)) {
+            true
+          } else if (isSeqOfData(member)) {
+            // This field is passed along, even though it is illegal
+            // An error for this will be generated in `Bundle.elements`
+            // It would be possible here to check for Seq[Data] and make a compiler error, but
+            // that would be a API error difference. See reference in docs/chisel-plugin.md
+            // If Bundle is subclass of IgnoreSeqInBundle then don't pass this field along
+
+            !isIgnoreSeqInBundle(bundleSymbol)
+          } else {
+            // none of the above
+            false
+          }
+        }
+
+        val currentFields = bundleSymbol.info.members.flatMap {
+
+          case member if member.isPublic =>
+            if (isBundleField(member)) {
+              // The params have spaces after them (Scalac implementation detail)
+              Some(member.name.toString.trim -> gen.mkAttributedSelect(thiz.asInstanceOf[Tree], member))
+            } else {
+              None
+            }
+
+          case _ => None
+        }.toList
+
+        val allParentFields = bundleSymbol.parentSymbols.flatMap { parentSymbol =>
+          val fieldsFromParent = if (depth < 1 && !isExactBundle(bundleSymbol)) {
+            val foundFields = getAllBundleFields(parentSymbol, depth + 1)
+            foundFields
+          } else {
+            List()
+          }
+          fieldsFromParent
+        }
+        allParentFields ++ currentFields
+      }
+
+      val elementArgs = getAllBundleFields(bundle.symbol)
+
+      val elementsImplSym =
+        bundle.symbol.newMethod(TermName("_elementsImpl"), bundle.symbol.pos.focus, Flag.OVERRIDE | Flag.PROTECTED)
+      elementsImplSym.resetFlag(Flags.METHOD)
+      elementsImplSym.setInfo(NullaryMethodType(itStringAnyTpe))
+
+      val elementsImpl = localTyper.typed(
+        DefDef(elementsImplSym, q"scala.collection.immutable.Vector.apply[(String, Any)](..$elementArgs)")
+      )
+
+      elementsImpl
+    }
+
     override def transform(tree: Tree): Tree = tree match {
 
-      case bundle: ClassDef if isBundle(bundle.symbol) && !bundle.mods.hasFlag(Flag.ABSTRACT) =>
+      case record: ClassDef if isARecord(record.symbol) && !record.mods.hasFlag(Flag.ABSTRACT) =>
+        val isBundle:        Boolean = isABundle(record.symbol)
+        val isAutoCloneType: Boolean = isAnAutoCloneType(record.symbol)
+
+        if (!isAutoCloneType) {
+          warnOnCloneType(record.impl.body)
+          // Other than warning, there is nothing to do on Records that don't mixin AutoCloneType
+          return super.transform(record)
+        }
+
+        val thiz: global.This = gen.mkAttributedThis(record.symbol)
+
         // ==================== Generate _cloneTypeImpl ====================
-        val (con, params) = getConstructorAndParams(bundle.impl.body)
-        if (con.isEmpty) {
-          global.reporter.warning(bundle.pos, "Unable to determine primary constructor!")
-          return super.transform(tree)
-        }
+        val cloneTypeImplOpt = generateAutoCloneType(record, thiz, isBundle)
 
-        val constructor = con.get
-        val thiz = gen.mkAttributedThis(bundle.symbol)
-
-        // The params have spaces after them (Scalac implementation detail)
-        val paramLookup: String => Symbol = params.map(sym => sym.name.toString.trim -> sym).toMap
-
-        val cloneTypeImplOpt = if (!bundle.mods.hasFlag(Flag.ABSTRACT)) {
-          // Create a this.<ref> for each field matching order of constructor arguments
-          // List of Lists because we can have multiple parameter lists
-          val conArgs: List[List[Tree]] =
-            constructor.vparamss.map(_.map { vp =>
-              val p = paramLookup(vp.name.toString)
-              // Make this.<ref>
-              val select = gen.mkAttributedSelect(thiz.asInstanceOf[Tree], p)
-              // Clone any Data parameters to avoid field aliasing, need full clone to include direction
-              val cloned = if (isData(vp.symbol)) cloneTypeFull(select.asInstanceOf[Tree]) else select
-              // Need to splat varargs
-              if (isVarArgs(vp.symbol)) q"$cloned: _*" else cloned
-            })
-
-          val tparamList = bundle.tparams.map { t => Ident(t.symbol) }
-          val ttpe =
-            if (tparamList.nonEmpty) AppliedTypeTree(Ident(bundle.symbol), tparamList) else Ident(bundle.symbol)
-          val newUntyped = New(ttpe, conArgs)
-          val neww = localTyper.typed(newUntyped)
-
-          // Create the symbol for the method and have it be associated with the Bundle class
-          val cloneTypeSym =
-            bundle.symbol.newMethod(TermName("_cloneTypeImpl"), bundle.symbol.pos.focus, Flag.OVERRIDE | Flag.PROTECTED)
-          // Handwritten cloneTypes don't have the Method flag set, unclear if it matters
-          cloneTypeSym.resetFlag(Flags.METHOD)
-          // Need to set the type to chisel3.Bundle for the override to work
-          cloneTypeSym.setInfo(NullaryMethodType(bundleTpe))
-
-          Some(localTyper.typed(DefDef(cloneTypeSym, neww)))
-        } else {
-          // Don't create if this Bundle is abstract
-          None
-        }
-
-        // ==================== Generate val elements ====================
-
-        /* Test to see if the bundle found is amenable to having it's elements
-         * converted to an immediate form that will not require reflection
-         */
-        def isSupportedBundleType: Boolean = !bundle.mods.hasFlag(Flag.ABSTRACT)
-
-        val elementsImplOpt = if (isSupportedBundleType) {
-          /* extract the true fields from the super classes a given bundle
-           * depth argument can be helpful for debugging
-           */
-          def getAllBundleFields(bundleSymbol: Symbol, depth: Int = 0): List[(String, Tree)] = {
-
-            def isBundleField(member: Symbol): Boolean = {
-              if (!member.isAccessor) {
-                false
-              } else if (isData(member.tpe.typeSymbol)) {
-                true
-              } else if (isOptionOfData(member)) {
-                true
-              } else if (isSeqOfData(member)) {
-                // This field is passed along, even though it is illegal
-                // An error for this will be generated in `Bundle.elements`
-                // It would be possible here to check for Seq[Data] and make a compiler error, but
-                // that would be a API error difference. See reference in docs/chisel-plugin.md
-                // If Bundle is subclass of IgnoreSeqInBundle then don't pass this field along
-
-                !isIgnoreSeqInBundle(bundleSymbol)
-              } else {
-                // none of the above
-                false
-              }
-            }
-
-            val currentFields = bundleSymbol.info.members.flatMap {
-
-              case member if member.isPublic =>
-                if (isBundleField(member)) {
-                  // The params have spaces after them (Scalac implementation detail)
-                  Some(member.name.toString.trim -> gen.mkAttributedSelect(thiz.asInstanceOf[Tree], member))
-                } else {
-                  None
-                }
-
-              case _ => None
-            }.toList
-
-            val allParentFields = bundleSymbol.parentSymbols.flatMap { parentSymbol =>
-              val fieldsFromParent = if (depth < 1 && !isExactBundle(bundleSymbol)) {
-                val foundFields = getAllBundleFields(parentSymbol, depth + 1)
-                foundFields
-              } else {
-                List()
-              }
-              fieldsFromParent
-            }
-            allParentFields ++ currentFields
-          }
-
-          val elementArgs = getAllBundleFields(bundle.symbol)
-
-          val elementsImplSym =
-            bundle.symbol.newMethod(TermName("_elementsImpl"), bundle.symbol.pos.focus, Flag.OVERRIDE | Flag.PROTECTED)
-          elementsImplSym.resetFlag(Flags.METHOD)
-          elementsImplSym.setInfo(NullaryMethodType(itStringAnyTpe))
-
-          val elementsImpl = localTyper.typed(
-            DefDef(elementsImplSym, q"scala.collection.immutable.Vector.apply[(String, Any)](..$elementArgs)")
-          )
-
-          Some(elementsImpl)
-        } else {
-          // No code generated for elements accessor
-          None
-        }
+        // ==================== Generate val elements (Bundles only) ====================
+        val elementsImplOpt = if (isBundle) Some(generateElements(record, thiz)) else None
 
         // ==================== Generate _usingPlugin ====================
-        // Unclear why quasiquotes work here but didn't for cloneTypeSym, maybe they could.
-        val usingPluginOpt = Some(localTyper.typed(q"override protected def _usingPlugin: Boolean = true"))
+        val usingPluginOpt = if (isBundle) {
+          // Unclear why quasiquotes work here but didn't for cloneTypeSym, maybe they could.
+          Some(localTyper.typed(q"override protected def _usingPlugin: Boolean = true"))
+        } else {
+          None
+        }
 
-        val withMethods = deriveClassDef(bundle) { t =>
+        val withMethods = deriveClassDef(record) { t =>
           deriveTemplate(t)(_ ++ cloneTypeImplOpt ++ usingPluginOpt ++ elementsImplOpt)
         }
 

--- a/src/main/scala/chisel3/util/MixedVec.scala
+++ b/src/main/scala/chisel3/util/MixedVec.scala
@@ -3,6 +3,7 @@
 package chisel3.util
 
 import chisel3._
+import chisel3.experimental.AutoCloneType
 import chisel3.internal.requireIsChiselType
 
 import scala.collection.immutable.ListMap
@@ -87,7 +88,10 @@ object MixedVec {
   * v(2) := 101.U(32.W)
   * }}}
   */
-final class MixedVec[T <: Data](private val eltsIn: Seq[T]) extends Record with collection.IndexedSeq[T] {
+final class MixedVec[T <: Data](private val eltsIn: Seq[T])
+    extends Record
+    with collection.IndexedSeq[T]
+    with AutoCloneType {
   // We want to create MixedVec only with Chisel types.
   if (compileOptions.declaredTypeMustBeUnbound) {
     eltsIn.foreach(e => requireIsChiselType(e))
@@ -124,9 +128,6 @@ final class MixedVec[T <: Data](private val eltsIn: Seq[T]) extends Record with 
   def length: Int = elts.length
 
   override val elements = ListMap(elts.zipWithIndex.map { case (element, index) => (index.toString, element) }: _*)
-
-  // Need to re-clone again since we could have been bound since object creation.
-  override def cloneType: this.type = MixedVec(elts.map(_.cloneTypeFull)).asInstanceOf[this.type]
 
   // IndexedSeq has its own hashCode/equals that we must not use
   override def hashCode: Int = super[Record].hashCode


### PR DESCRIPTION
There is a new trait, chisel3.experimental.AutoCloneType that is mixed in to Bundle and can optionally be mixed in to user-defined Records. The compiler plugin prints a deprecation warning on any user-defined implementation of cloneType, telling the user to mix in AutoCloneType before upgrading to 3.6.

This is intended to be backported to 3.5.x for release in 3.5.5. I have checked that this backports to 3.5.x [relatively] cleanly and is binary compatible (with the one caveat that MixedVec mixing in `AutoCloneType` changes the tyep of it's `cloneType` in a way that violates binary compatibility. It might be a false positive, but regardless I will revert that aspect of this PR on the backport).

I also intend to follow this PR with a version making cloneType generation mandatory for Records in 3.6.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

  - code refactoring  
  - new feature/API

#### API Impact

This makes it possible for users to opt-in to autoclonetype for Records. Implementing `cloneType` for Records will be deprecated in 3.5.5 and an error in 3.6. This PR does not yet change the API but the API change is coming.

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

 - Squash

#### Release Notes

Implement autoclonetype for `Records` with new `chisel3.experimental.AutoCloneType`. Implementing `cloneType` yourself is now a warning and will become an error in Chisel 3.6.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
