### PR TITLE
Don't modify the Builder prefix if reinvoking suggestName on a Data

### DIFF
--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -162,8 +162,11 @@ private[chisel3] trait HasId extends InstanceId {
     * @return this object
     */
   def suggestName(seed: => String): this.type = {
-    if (suggested_seed.isEmpty) suggested_seedVar = seed
-    naming_prefix = Builder.getPrefix
+    if (suggested_seed.isEmpty) {
+      suggested_seedVar = seed
+      // Only set the prefix if a seed hasn't been suggested
+      naming_prefix = Builder.getPrefix
+    }
     this
   }
 

--- a/src/test/scala/chiselTests/naming/PrefixSpec.scala
+++ b/src/test/scala/chiselTests/naming/PrefixSpec.scala
@@ -521,4 +521,17 @@ class PrefixSpec extends ChiselPropSpec with Utils {
       Select.wires(top).map(_.instanceName) should be(List("nonData_value", "value"))
     }
   }
+  property("Prefixing should not be affected by repeated calls of suggestName") {
+    class Test extends Module {
+      val bundle = new Bundle {
+        val wire = Wire(UInt(3.W)).suggestName("wire")
+      }
+      // Does not change the instanceName since it was already suggested, but also
+      // should not remove the "bundle_" prefix either
+      bundle.wire.suggestName("should_not_prefix")
+    }
+    aspectTest(() => new Test) { top: Test =>
+      Select.wires(top).map(_.instanceName) should be(List("bundle_wire")) // In contrast to "wire"
+    }
+  }
 }


### PR DESCRIPTION
Changes `suggestName` so that it only updates the naming prefix when the first initial seed is suggested, but not on additional suggestion attempts.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
- bug fix
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

No change

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

Squash and merge

#### Release Notes

- Fix `suggestName` so that it doesn't tamper with prefixing when calling `suggestName` more than once

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
- [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
- [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
