### PR TITLE
Add unit tests and fix for #2794 , add unit tests for #2773 

### DIFF
--- a/src/test/scala/chiselTests/CompatibilityInteroperabilitySpec.scala
+++ b/src/test/scala/chiselTests/CompatibilityInteroperabilitySpec.scala
@@ -392,6 +392,290 @@ class CompatibilityInteroperabilitySpec extends ChiselFlatSpec {
     compile(new Top(false))
   }
 
+  "A Chisel.Bundle with only unspecified directions" should "work with D/I" in {
+
+    object Compat {
+      import Chisel._
+      import chisel3.experimental.hierarchy.{instantiable, public}
+
+      class CompatBiDirUnspecifiedBundle extends Bundle {
+        val out = Bool()
+        val in = Flipped(Bool())
+      }
+
+      @instantiable
+      class CompatModule extends Module {
+        @public val io = IO(new CompatBiDirUnspecifiedBundle)
+      }
+    }
+
+    object Chisel3 {
+      import chisel3._
+      import chisel3.experimental.hierarchy.Instance
+      class Example extends Module {
+        val mod = Module(new Compat.CompatModule())
+        mod.io.in <> DontCare
+        val inst = Instance(mod.toDefinition)
+        inst.io.in <> mod.io.out
+        mod.io.in <> inst.io.out
+      }
+    }
+    compile(new Chisel3.Example)
+  }
+
+  "A Chisel.Bundle with mixed Specified and Unspecified directions" should "work with D/I" in {
+
+    object Compat {
+      import Chisel._
+      import chisel3.experimental.hierarchy.{instantiable, public}
+
+      class CompatBiDirMixedBundle extends Bundle {
+        val out = Bool()
+        val in = Flipped(Bool())
+        val explicit = Output(Bool())
+      }
+
+      @instantiable
+      class CompatModule extends Module {
+        @public val io = IO(new CompatBiDirMixedBundle)
+      }
+    }
+
+    object Chisel3 {
+      import chisel3._
+      import chisel3.experimental.hierarchy.Instance
+      class Example extends Module {
+        val mod = Module(new Compat.CompatModule)
+        mod.io.in <> DontCare
+        val inst = Instance(mod.toDefinition)
+        inst.io.in <> mod.io.out
+        mod.io.in <> inst.io.out
+      }
+    }
+    compile(new Chisel3.Example)
+  }
+
+  "A Chisel.Bundle with only unspecified vec direction" should "work with D/I" in {
+
+    object Compat {
+      import Chisel._
+      import chisel3.experimental.hierarchy.{instantiable, public}
+
+      class CompatBiDirUnspecifiedVecBundle extends Bundle {
+        val out = Vec(3, Bool())
+        val in = Flipped(Vec(3, Bool()))
+      }
+
+      @instantiable
+      class CompatModule extends Module {
+        @public val io = IO(new CompatBiDirUnspecifiedVecBundle)
+      }
+    }
+
+    object Chisel3 {
+      import chisel3._
+      import chisel3.experimental.hierarchy.Instance
+      class Example extends Module {
+        val mod = Module(new Compat.CompatModule())
+        mod.io.in <> DontCare
+        val inst = Instance(mod.toDefinition)
+        inst.io.in <> mod.io.out
+        mod.io.in <> inst.io.out
+      }
+    }
+    compile(new Chisel3.Example)
+  }
+
+  "A chisel3.Bundle with only unspecified directions" should "work with D/I" in {
+
+    // This test is NOT expected to work on 3.5.x, it should throw an error in the IO construction.
+
+    object Chisel3 {
+      import chisel3._
+      import chisel3.experimental.hierarchy.{instantiable, public, Instance}
+
+      class BiDirUnspecifiedBundle extends Bundle {
+        val out = Bool()
+        val in = Flipped(Bool())
+      }
+
+      @instantiable
+      class MyModule extends Module {
+        @public val io = IO(new BiDirUnspecifiedBundle)
+        io <> DontCare
+      }
+
+      class Example extends Module {
+        val mod = Module(new MyModule())
+        mod.io.in <> DontCare
+        val inst = Instance(mod.toDefinition)
+        inst.io.in <> mod.io.out
+        mod.io.in <> inst.io.out
+      }
+    }
+    compile(new Chisel3.Example)
+  }
+
+  "A chisel3.Bundle with mixed Specified and Unspecified directions" should "work with D/I" in {
+
+    // This test is NOT expected to work on 3.5.x, it should throw an error in the IO construction.
+
+    object Chisel3 {
+      import chisel3._
+      import chisel3.experimental.hierarchy.{instantiable, public, Instance}
+
+      class BiDirMixedBundle extends Bundle {
+        val out = Bool()
+        val in = Flipped(Bool())
+        val explicit = Output(Bool())
+      }
+
+      @instantiable
+      class MyModule extends Module {
+        @public val io = IO(new BiDirMixedBundle)
+        io <> DontCare
+      }
+      class Example extends Module {
+        val mod = Module(new MyModule)
+        mod.io.in <> DontCare
+        val inst = Instance(mod.toDefinition)
+        inst.io.in <> mod.io.out
+        mod.io.in <> inst.io.out
+      }
+    }
+    compile(new Chisel3.Example)
+  }
+
+  "A chisel3.Bundle with only unspecified vec direction" should "work with D/I" in {
+
+    // This test is NOT expected to work on 3.5.x, it should throw an error in the IO construction
+
+    object Chisel3 {
+      import chisel3._
+      import chisel3.experimental.hierarchy.{instantiable, public, Instance}
+
+      class BiDirUnspecifiedVecBundle extends Bundle {
+        val out = Vec(3, Bool())
+        val in = Flipped(Vec(3, Bool()))
+      }
+
+      @instantiable
+      class MyModule extends Module {
+        @public val io = IO(new BiDirUnspecifiedVecBundle)
+        io <> DontCare
+      }
+
+      class Example extends Module {
+        val mod = Module(new MyModule())
+        mod.io.in <> DontCare
+        val inst = Instance(mod.toDefinition)
+        inst.io.in <> mod.io.out
+        mod.io.in <> inst.io.out
+      }
+    }
+    compile(new Chisel3.Example)
+  }
+
+  "A chisel3.Bundle with only unspecified vec direction within an unspecified direction parent Bundle" should "work with D/I" in {
+
+    // This test is NOT expected to work in 3.5.x, it should throw an error in the IO construction.
+
+    object Chisel3 {
+      import chisel3._
+      import chisel3.experimental.hierarchy.{instantiable, public, Instance}
+
+      class UnspecifiedVecBundle extends Bundle {
+        val vec = Vec(3, Bool())
+      }
+
+      class UnspecifiedParentBundle extends Bundle {
+        val out = new UnspecifiedVecBundle
+      }
+
+      @instantiable
+      class MyModule extends Module {
+        @public val io = IO(new UnspecifiedParentBundle)
+        io <> DontCare
+      }
+
+      class Example extends Module {
+        val mod = Module(new MyModule())
+
+        val wire = Wire(new UnspecifiedParentBundle)
+        wire.out.vec <> mod.io.out.vec
+        val inst = Instance(mod.toDefinition)
+        wire.out.vec <> inst.io.out.vec
+
+      }
+    }
+    compile(new Chisel3.Example)
+  }
+
+  "A undirectioned Chisel.Bundle used in a MixedVec " should "bulk connect in import chisel3._ code correctly" in {
+
+    // This test is NOT expected to work on 3.5.x, it should throw an error in the IO construction.
+
+    object Compat {
+
+      import Chisel._
+      import chisel3.util.MixedVec
+
+      class ChiselModule extends Module {
+        val io = IO(new Bundle {
+          val out = MixedVec(Seq.fill(3) { Bool() })
+          val in = Flipped(MixedVec(Seq.fill(3) { Bool() }))
+        })
+        io.out := RegNext(io.in)
+      }
+
+    }
+    object Chisel3 {
+      import chisel3._
+
+      class Chisel3Module extends Compat.ChiselModule
+
+      class Example extends Module {
+        val oldMod = Module(new Compat.ChiselModule)
+        val newMod = Module(new Chisel3Module)
+
+        oldMod.io.in <> DontCare
+        newMod.io.in <> DontCare
+
+      }
+    }
+    compile(new Chisel3.Example)
+  }
+
+  "A undirectioned Chisel.Bundle with Records with undirectioned and directioned fields " should "work" in {
+
+    // This test should fail on 3.5.x
+
+    object Compat {
+
+      import Chisel._
+
+      class ChiselModule(gen: () => Data) extends Module {
+        val io = IO(new Bundle {
+          val mixed = new Chisel3.MyRecord(gen)
+        })
+      }
+
+    }
+    object Chisel3 {
+      import chisel3._
+      import scala.collection.immutable.SeqMap
+
+      class MyRecord(gen: () => Data) extends Record with chisel3.experimental.AutoCloneType {
+        val elements = SeqMap("genDirectioned" -> Output(gen()), "genUndirectioned" -> gen())
+      }
+
+      class Example extends Module {
+        val newMod = Module(new Compat.ChiselModule(() => Bool()))
+      }
+    }
+    compile(new Chisel3.Example)
+  }
+
   "A BlackBox with Chisel._ fields in its IO" should "bulk connect in import chisel3._ code correctly" in {
     object Compat {
       import Chisel._


### PR DESCRIPTION
### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [NO] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [NO] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
 - bug fix
 - unit tests that fail on backport branches to be fixed further there

<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

This ensures that Definition/Instance will work well when there are IOs where we need to assume directionality

This also adds unit test for MixedVec scenarios that are allowd on master but should fail more gracefully on the backport.

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

This only changes generated verilog for D/I case

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
   - Squash: The PR will be squashed and merged (choose this if you have no preference. 
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

Fix an issue with connecting to ports on Instances of Modules where directionality must be inferred

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
