### PR TITLE
Fixes #2796 for assigning to BlackBoxes with Chisel._ fields in their IOs

### DIFF
--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -1108,7 +1108,12 @@ abstract class Record(private[chisel3] implicit val compileOptions: CompileOptio
   def elements: SeqMap[String, Data]
 
   /** Name for Pretty Printing */
-  def className: String = this.getClass.getSimpleName
+  def className: String = try {
+    this.getClass.getSimpleName
+  } catch {
+    // This happens if your class is defined in an object and is anonymous
+    case e: java.lang.InternalError if e.getMessage == "Malformed class name" => this.getClass.toString
+  }
 
   private[chisel3] override def typeEquivalent(that: Data): Boolean = that match {
     case that: Record =>
@@ -1228,10 +1233,15 @@ abstract class Bundle(implicit compileOptions: CompileOptions) extends Record wi
       "Please see https://github.com/chipsalliance/chisel3#build-your-own-chisel-projects."
   assert(_usingPlugin, mustUsePluginMsg)
 
-  override def className: String = this.getClass.getSimpleName match {
-    case name if name.startsWith("$anon$") => "AnonymousBundle" // fallback for anonymous Bundle case
-    case ""                                => "AnonymousBundle" // ditto, but on other platforms
-    case name                              => name
+  override def className: String = try {
+    this.getClass.getSimpleName match {
+      case name if name.startsWith("$anon$") => "AnonymousBundle" // fallback for anonymous Bundle case
+      case ""                                => "AnonymousBundle" // ditto, but on other platforms
+      case name                              => name
+    }
+  } catch {
+    // This happens if you have nested objects which your class is defined in
+    case e: java.lang.InternalError if e.getMessage == "Malformed class name" => this.getClass.toString
   }
 
   /** The collection of [[Data]]

--- a/core/src/main/scala/chisel3/internal/BiConnect.scala
+++ b/core/src/main/scala/chisel3/internal/BiConnect.scala
@@ -231,9 +231,10 @@ private[chisel3] object BiConnect {
     val recordConnectFieldsMustMatch =
       left_r.compileOptions.connectFieldsMustMatch || right_r.compileOptions.connectFieldsMustMatch
 
+    val connectFieldsMustMatch = /*connectCompileOptions.connectFieldsMustMatch &&*/ recordConnectFieldsMustMatch
     // For each field in left, descend with right.
     // Don't bother doing this check if we don't expect it to necessarily pass.
-    if (connectCompileOptions.connectFieldsMustMatch || recordConnectFieldsMustMatch) {
+    if (connectFieldsMustMatch) {
       for ((field, right_sub) <- right_r.elements) {
         if (!left_r.elements.isDefinedAt(field)) {
           throw MissingLeftFieldException(field)
@@ -246,7 +247,7 @@ private[chisel3] object BiConnect {
         right_r.elements.get(field) match {
           case Some(right_sub) => connect(sourceInfo, connectCompileOptions, left_sub, right_sub, context_mod)
           case None => {
-            if (connectCompileOptions.connectFieldsMustMatch || recordConnectFieldsMustMatch) {
+            if (connectFieldsMustMatch) {
               throw MissingRightFieldException(field)
             }
           }

--- a/core/src/main/scala/chisel3/internal/BiConnect.scala
+++ b/core/src/main/scala/chisel3/internal/BiConnect.scala
@@ -228,10 +228,14 @@ private[chisel3] object BiConnect {
     context_mod:           RawModule
   ): Unit = {
     // Verify right has no extra fields that left doesn't have
-    val recordConnectFieldsMustMatch =
-      left_r.compileOptions.connectFieldsMustMatch || right_r.compileOptions.connectFieldsMustMatch
+    // The semantic we allow here is the most relaxed -- ONLY if:
+    // - both sides of the connection are chisel3._
+    // - AND the <> operator itself is in chisel3._ code
+    // do we require that all the fields match.
+    val recordConnectFieldsCanMismatch =
+      !left_r.compileOptions.connectFieldsMustMatch || !right_r.compileOptions.connectFieldsMustMatch
+    val connectFieldsMustMatch = !(!connectCompileOptions.connectFieldsMustMatch || recordConnectFieldsCanMismatch)
 
-    val connectFieldsMustMatch = /*connectCompileOptions.connectFieldsMustMatch &&*/ recordConnectFieldsMustMatch
     // For each field in left, descend with right.
     // Don't bother doing this check if we don't expect it to necessarily pass.
     if (connectFieldsMustMatch) {

--- a/src/test/scala/chiselTests/BulkConnectSpec.scala
+++ b/src/test/scala/chiselTests/BulkConnectSpec.scala
@@ -21,7 +21,9 @@ class BulkConnectSpec extends ChiselPropSpec {
     chirrtl should include("io.outBi <= io.inBi")
   }
 
-  property("Chisel connects should not emit FIRRTL bulk connects for Stringly-typed connections") {
+  property(
+    "Chisel connects should blast out to FIRRTL bulk connects for mistmatched, Stringly-typed connections (ignoring the context of the <>)"
+  ) {
     object Foo {
       import Chisel._
       // Chisel._ bundle
@@ -54,7 +56,10 @@ class BulkConnectSpec extends ChiselPropSpec {
     })
 
     chirrtl should include("out.buzz.foo <= in.buzz.foo")
-    chirrtl shouldNot include("deq <= enq")
+    chirrtl should include("deq.valid <= enq.valid")
+    chirrtl should include("enq.ready <= deq.ready")
+    chirrtl should include("deq.bits.foo <= enq.bits.foo")
+    chirrtl shouldNot include("deq.bits.bar")
   }
 
   property("Chisel connects should not emit FIRRTL bulk connects between differing FIRRTL types") {

--- a/src/test/scala/chiselTests/BulkConnectSpec.scala
+++ b/src/test/scala/chiselTests/BulkConnectSpec.scala
@@ -22,7 +22,7 @@ class BulkConnectSpec extends ChiselPropSpec {
   }
 
   property(
-    "Chisel connects should blast out to FIRRTL bulk connects for mistmatched, Stringly-typed connections (ignoring the context of the <>)"
+    "Chisel connects should blast out to FIRRTL bulk connects for mismatched, Stringly-typed connections (ignoring the context of the <>)"
   ) {
     object Foo {
       import Chisel._
@@ -79,7 +79,10 @@ class BulkConnectSpec extends ChiselPropSpec {
       out <> in
     })
     // out <- in is illegal FIRRTL
-    chirrtl should include("out.foo.bar <= in.foo.bar")
+    exactly(2, chirrtl.split('\n')) should include("out.foo.bar <= in.foo.bar")
+    chirrtl shouldNot include("out <= in")
+    chirrtl shouldNot include("out <- in")
+
   }
 
   property("Chisel connects should not emit a FIRRTL bulk connect for a bidirectional MonoConnect") {
@@ -96,6 +99,9 @@ class BulkConnectSpec extends ChiselPropSpec {
     })
 
     chirrtl shouldNot include("wire <= enq")
+    chirrtl should include("wire.bits <= enq.bits")
+    chirrtl should include("wire.valid <= enq.valid")
+    chirrtl should include("wire.ready <= enq.ready")
     chirrtl should include("deq <= enq")
   }
 

--- a/src/test/scala/chiselTests/CompatibilityInteroperabilitySpec.scala
+++ b/src/test/scala/chiselTests/CompatibilityInteroperabilitySpec.scala
@@ -441,6 +441,6 @@ class CompatibilityInteroperabilitySpec extends ChiselFlatSpec {
       }
     }
 
-    (new chisel3.stage.ChiselStage).emitVerilog(new Chisel3.Top, Array("--full-stacktrace"))
+    compile(new Chisel3.Top)
   }
 }

--- a/src/test/scala/chiselTests/CompatibilityInteroperabilitySpec.scala
+++ b/src/test/scala/chiselTests/CompatibilityInteroperabilitySpec.scala
@@ -428,10 +428,6 @@ class CompatibilityInteroperabilitySpec extends ChiselFlatSpec {
         io <> DontCare
       }
 
-      class FooMirrorModule extends Module {
-        val io = IO(Flipped(new FooModuleIO()))
-        io <> DontCare
-      }
       class FooMirrorBlackBox extends BlackBox {
         val io = IO(Flipped(new FooModuleIO()))
       }
@@ -439,14 +435,8 @@ class CompatibilityInteroperabilitySpec extends ChiselFlatSpec {
       class Top() extends Module {
 
         val foo = Module(new FooModule)
-        //val mirror = Module(new FooMirrorBlackBox)
-        val mirror = Module(new FooMirrorModule())
+        val mirror = Module(new FooMirrorBlackBox())
         foo.io <> mirror.io
-        // foo.io <> mirror.io
-        // foo.io is 'aligned' and mirror is 'flipped' so this would be determined by BiConnect to be equivalent to:
-        // mirror.io :<>= foo.io
-        // mirror.io.quz is Input, so should be flipped again...
-        // but specified Direction of .quz is Input?? why is it not a ChildBinding?
         foo.io <> DontCare
       }
     }


### PR DESCRIPTION

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [N/A] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
   - bug fix                           
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->
This fixes #2796, but it also greatly changes how many `<=` vs `<-` we will emit. Previously when connecting two records if we decided we couldn't emit a `<=`, if we were allowed to we would just emit a `<-`. This code path is hittable when connecting a BlackBox IO becasue we are not "allowed" to emit `<=` for blackboxes, but the legacyConnect does not do proper analysis about the directionality before issuing the connect.

The solution here is to stop treating compatibility mode so specially in this case, and just go into the `recordConnect` function and within *that* do/waive the check about mismatching fields, which should be the only reason we can't connect at this point.

This would create a substantial difference in generated firrtl if there are other cases where we are relying on the legacy connect to allow us to connect mismatched Chisel bundles, because now we will emit them as individual `<=` where applicable instead of relying on `<-` semantics to do the same in the firrtl compiler. This *might* not be correct / equivalent (may be more or less strict than `<-` would be) so I would defer to the reviewers if this is acceptable change.

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

Many more blasted-out `<=` instead of `<-` in cases where fields don't match up in compatbility bundle assignments.

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
   - Squash: The PR will be squashed and merged (choose this if you have no preference.
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

Change the emission of records with Compatibility fields that connect to blackboxes or have mismatched fields to be blasted out to individual fields vs relying on emitting `<-`. Fixes #2796.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
