### PR TITLE
Default Non-Analog Elements specified directions to Output, remove fixups and Unspecified handling. Fixes #2794 

### DIFF
--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -62,7 +62,7 @@ sealed abstract class Aggregate extends Data {
     val childDirections = getElements.map(_.direction).toSet - ActualDirection.Empty
     direction = ActualDirection.fromChildren(childDirections, resolvedDirection) match {
       case Some(dir) => dir
-      case None => throw new UnexpectedUnspecifiedException("this should never happen")
+      case None      => throw new UnexpectedUnspecifiedException("this should never happen")
     }
   }
 
@@ -586,7 +586,7 @@ object VecInit extends SourceInfoDoc {
     implicit sourceInfo: SourceInfo,
     compileOptions:      CompileOptions
   ): (T, T) => Unit = proto.direction match {
-    case ActualDirection.Input | ActualDirection.Output | ActualDirection.Unspecified =>
+    case ActualDirection.Input | ActualDirection.Output =>
       // When internal wires are involved, driver / sink must be specified explicitly, otherwise
       // the system is unable to infer which is driver / sink
       (x, y) => x := y
@@ -595,6 +595,8 @@ object VecInit extends SourceInfoDoc {
       // Bulk connecting two wires may not succeed because Chisel frontend does not infer
       // directions.
       (x, y) => x <> y
+    case ActualDirection.Unspecified =>
+      throw new UnexpectedUnspecifiedException("We don't expect unspecified Actual Directions")
   }
 
   /** Creates a new [[Vec]] composed of elements of the input Seq of [[Data]]

--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -62,13 +62,7 @@ sealed abstract class Aggregate extends Data {
     val childDirections = getElements.map(_.direction).toSet - ActualDirection.Empty
     direction = ActualDirection.fromChildren(childDirections, resolvedDirection) match {
       case Some(dir) => dir
-      case None =>
-        val resolvedDirection = SpecifiedDirection.fromParent(parentDirection, specifiedDirection)
-        resolvedDirection match {
-          case SpecifiedDirection.Unspecified => ActualDirection.Bidirectional(ActualDirection.Default)
-          case SpecifiedDirection.Flip        => ActualDirection.Bidirectional(ActualDirection.Flipped)
-          case _                              => ActualDirection.Bidirectional(ActualDirection.Default)
-        }
+      case None => throw new UnexpectedUnspecifiedException("this should never happen")
     }
   }
 

--- a/core/src/main/scala/chisel3/Data.scala
+++ b/core/src/main/scala/chisel3/Data.scala
@@ -109,7 +109,7 @@ object ActualDirection {
   }
 
   /** Determine the actual binding of a container given directions of its children.
-    * Returns None in the case of mixed specified / unspecified directionality.
+    * Returns None if there are any Unspecified directions since this is not expected.
     */
   def fromChildren(
     childDirections:    Set[ActualDirection],
@@ -120,8 +120,6 @@ object ActualDirection {
         case ActualDirection.Unspecified => Some(ActualDirection.Empty) // empty direction if relative / no direction
         case dir                         => Some(dir) // use assigned direction if specified
       }
-    } else if (childDirections == Set(ActualDirection.Unspecified)) {
-      Some(ActualDirection.Unspecified)
     } else if (childDirections == Set(ActualDirection.Input)) {
       Some(ActualDirection.Input)
     } else if (childDirections == Set(ActualDirection.Output)) {
@@ -491,19 +489,6 @@ abstract class Data extends HasId with NamedComponent with SourceInfoDoc {
   private[chisel3] def specifiedDirection: SpecifiedDirection = _specifiedDirection
   private[chisel3] def specifiedDirection_=(direction: SpecifiedDirection) = {
     _specifiedDirection = direction
-  }
-
-  /** This overwrites a relative SpecifiedDirection with an explicit one, and is used to implement
-    * the compatibility layer where, at the elements, Flip is Input and unspecified is Output.
-    * DO NOT USE OUTSIDE THIS PURPOSE. THIS OPERATION IS DANGEROUS!
-    */
-  private[chisel3] def _assignCompatibilityExplicitDirection: Unit = {
-    (this, _specifiedDirection) match {
-      case (_: Analog, _) => // nothing to do
-      case (_, SpecifiedDirection.Unspecified)                       => _specifiedDirection = SpecifiedDirection.Output
-      case (_, SpecifiedDirection.Flip)                              => _specifiedDirection = SpecifiedDirection.Input
-      case (_, SpecifiedDirection.Input | SpecifiedDirection.Output) => // nothing to do
-    }
   }
 
   // Binding stores information about this node's position in the hardware graph.

--- a/core/src/main/scala/chisel3/Element.scala
+++ b/core/src/main/scala/chisel3/Element.scala
@@ -13,6 +13,11 @@ import chisel3.internal._
   * @define coll element
   */
 abstract class Element extends Data {
+
+  // Instead of doing a fixup later, just make all Elements default their specified direction
+  // to "Output".
+  super.specifiedDirection = SpecifiedDirection.Output
+
   private[chisel3] final def allElements: Seq[Element] = Seq(this)
   def widthKnown:                         Boolean = width.known
   def name:                               String = getRef.name

--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -106,6 +106,38 @@ object Module extends SourceInfoDoc {
 
     module
   }
+
+  /**  Assign directionality on any IOs that are still Unspecified/Flipped
+    *
+    *  Chisel2 did not require explicit direction on nodes
+    *  (unspecified treated as output, and flip on nothing was input).
+    *  As of 3.6, chisel3 is now also using these semantics, so we need to make it work
+    *  even for chisel3 code.
+    *  This assigns the explicit directions required by both semantics on all Bundles.
+    * This recursively walks the tree, and assigns directions if no explicit
+    *   direction given by upper-levels (override Input / Output)
+    */
+  private[chisel3] def assignCompatDir(data: Data): Unit = {
+    data match {
+      case data: Element => data._assignCompatibilityExplicitDirection
+      case data: Aggregate =>
+        data.specifiedDirection match {
+          // Recurse into children to ensure explicit direction set somewhere
+          case SpecifiedDirection.Unspecified | SpecifiedDirection.Flip =>
+            data match {
+              case record: Record =>
+                record.getElements.foreach(assignCompatDir(_))
+              case vec: Vec[_] =>
+                vec.getElements.foreach(assignCompatDir(_))
+                assignCompatDir(vec.sample_element) // This is used in fromChildren computation
+            }
+          case SpecifiedDirection.Input | SpecifiedDirection.Output =>
+          // forced assign, nothing to do
+          // The .bind algorithm will automatically assign the direction here.
+          // Thus, no implicit assignment is necessary.
+        }
+    }
+  }
 }
 
 /** Abstract base class for Modules, which behave much like Verilog modules.
@@ -252,6 +284,10 @@ package internal {
           new ClonePorts(proto.getChiselPorts :+ ("io" -> b._io.get): _*)
         case _ => new ClonePorts(proto.getChiselPorts: _*)
       }
+      // getChiselPorts (nor cloneTypeFull in general)
+      // does not recursively copy the right specifiedDirection,
+      // still need to fix it up here.
+      Module.assignCompatDir(clonePorts)
       clonePorts.bind(PortBinding(cloneParent))
       clonePorts.setAllParents(Some(cloneParent))
       cloneParent._portsRecord = clonePorts
@@ -524,35 +560,9 @@ package experimental {
       * io, then do operations on it. This binds a Chisel type in-place (mutably) as an IO.
       */
     protected def _bindIoInPlace(iodef: Data)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Unit = {
-      // Compatibility code: Chisel2 did not require explicit direction on nodes
-      //   (unspecified treated as output, and flip on nothing was input).
-      // However, we are going to go back to Chisel2 semantics, so we need to make it work
-      //   even for chisel3 code.
-      // This assigns the explicit directions required by both semantics on all Bundles.
-      // This recursively walks the tree, and assigns directions if no explicit
-      //   direction given by upper-levels (override Input / Output)
-      def assignCompatDir(data: Data): Unit = {
-        data match {
-          case data: Element => data._assignCompatibilityExplicitDirection
-          case data: Aggregate =>
-            data.specifiedDirection match {
-              // Recurse into children to ensure explicit direction set somewhere
-              case SpecifiedDirection.Unspecified | SpecifiedDirection.Flip =>
-                data match {
-                  case record: Record =>
-                    record.getElements.foreach(assignCompatDir(_))
-                  case vec: Vec[_] =>
-                    vec.getElements.foreach(assignCompatDir(_))
-                }
-              case SpecifiedDirection.Input | SpecifiedDirection.Output =>
-              // forced assign, nothing to do
-              // Note this is because Input and Output recurse down their types to align all fields to that SpecifiedDirection
-              // Thus, no implicit assigment is necessary.
-            }
-        }
-      }
 
-      assignCompatDir(iodef)
+      // Assign any signals (Chisel or chisel3) with Unspecified/Flipped directions to Output/Input
+      Module.assignCompatDir(iodef)
 
       iodef.bind(PortBinding(this))
       _ports += iodef -> sourceInfo

--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -106,38 +106,6 @@ object Module extends SourceInfoDoc {
 
     module
   }
-
-  /**  Assign directionality on any IOs that are still Unspecified/Flipped
-    *
-    *  Chisel2 did not require explicit direction on nodes
-    *  (unspecified treated as output, and flip on nothing was input).
-    *  As of 3.6, chisel3 is now also using these semantics, so we need to make it work
-    *  even for chisel3 code.
-    *  This assigns the explicit directions required by both semantics on all Bundles.
-    * This recursively walks the tree, and assigns directions if no explicit
-    *   direction given by upper-levels (override Input / Output)
-    */
-  private[chisel3] def assignCompatDir(data: Data): Unit = {
-    data match {
-      case data: Element => data._assignCompatibilityExplicitDirection
-      case data: Aggregate =>
-        data.specifiedDirection match {
-          // Recurse into children to ensure explicit direction set somewhere
-          case SpecifiedDirection.Unspecified | SpecifiedDirection.Flip =>
-            data match {
-              case record: Record =>
-                record.getElements.foreach(assignCompatDir(_))
-              case vec: Vec[_] =>
-                vec.getElements.foreach(assignCompatDir(_))
-                assignCompatDir(vec.sample_element) // This is used in fromChildren computation
-            }
-          case SpecifiedDirection.Input | SpecifiedDirection.Output =>
-          // forced assign, nothing to do
-          // The .bind algorithm will automatically assign the direction here.
-          // Thus, no implicit assignment is necessary.
-        }
-    }
-  }
 }
 
 /** Abstract base class for Modules, which behave much like Verilog modules.
@@ -284,10 +252,6 @@ package internal {
           new ClonePorts(proto.getChiselPorts :+ ("io" -> b._io.get): _*)
         case _ => new ClonePorts(proto.getChiselPorts: _*)
       }
-      // getChiselPorts (nor cloneTypeFull in general)
-      // does not recursively copy the right specifiedDirection,
-      // still need to fix it up here.
-      Module.assignCompatDir(clonePorts)
       clonePorts.bind(PortBinding(cloneParent))
       clonePorts.setAllParents(Some(cloneParent))
       cloneParent._portsRecord = clonePorts
@@ -561,8 +525,6 @@ package experimental {
       */
     protected def _bindIoInPlace(iodef: Data)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Unit = {
 
-      // Assign any signals (Chisel or chisel3) with Unspecified/Flipped directions to Output/Input
-      Module.assignCompatDir(iodef)
 
       iodef.bind(PortBinding(this))
       _ports += iodef -> sourceInfo

--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -525,7 +525,6 @@ package experimental {
       */
     protected def _bindIoInPlace(iodef: Data)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Unit = {
 
-
       iodef.bind(PortBinding(this))
       _ports += iodef -> sourceInfo
     }

--- a/core/src/main/scala/chisel3/experimental/Analog.scala
+++ b/core/src/main/scala/chisel3/experimental/Analog.scala
@@ -36,6 +36,9 @@ import scala.collection.mutable
   * @note This API is experimental and subject to change
   */
 final class Analog private (private[chisel3] val width: Width) extends Element {
+  // Element sets its default to Output, but we need to undo that for analog.
+  super.specifiedDirection = SpecifiedDirection.Unspecified
+
   require(width.known, "Since Analog is only for use in BlackBoxes, width must be known")
 
   override def toString: String = stringAccessor(s"Analog$width")

--- a/core/src/main/scala/chisel3/internal/MonoConnect.scala
+++ b/core/src/main/scala/chisel3/internal/MonoConnect.scala
@@ -357,7 +357,7 @@ private[chisel3] object MonoConnect {
 
     // Check that the Aggregate can be driven (not bidirectional or an input) to match Chisel semantics
     def sinkCanBeDrivenCheck: Boolean =
-      sink.direction == ActualDirection.Output || sink.direction == ActualDirection.Unspecified
+      sink.direction == ActualDirection.Output
 
     biConnectCheck && sinkCanBeDrivenCheck
   }

--- a/core/src/main/scala/chisel3/package.scala
+++ b/core/src/main/scala/chisel3/package.scala
@@ -375,9 +375,9 @@ package object chisel3 {
     */
   case class ExpectedHardwareException(message: String) extends BindingException(message)
 
-  /** An aggregate had a mix of specified and unspecified directionality children
+  /** We dont expect direction to end up as Unspecified anymore
     */
-  case class MixedDirectionAggregateException(message: String) extends BindingException(message)
+  case class UnexpectedUnspecifiedException(message: String) extends BindingException(message)
 
   /** Attempted to re-bind an already bound (directionality or hardware) object
     */

--- a/src/test/scala/chiselTests/CompatibilityInteroperabilitySpec.scala
+++ b/src/test/scala/chiselTests/CompatibilityInteroperabilitySpec.scala
@@ -392,14 +392,6 @@ class CompatibilityInteroperabilitySpec extends ChiselFlatSpec {
   }
 
   "A Chisel.Bundle with only unspecified directions" should "work with D/I" in {
-    /* Fails on the instance <>:
-    [info] A Chisel.Bundle with only unspecified directions
-    [info] - should work with D/I *** FAILED ***
-    [info]   java.lang.RuntimeException: Unexpected port element direction 'Unspecified'
-    [info]   at chisel3.internal.BindingDirection$.from(Binding.scala:62)
-    [info]   at chisel3.internal.BiConnect$.elemConnect(BiConnect.scala:357)
-    [info]   at chisel3.internal.BiConnect$.connect(BiConnect.scala:103)
-     */
 
     object Compat {
       import Chisel._
@@ -432,16 +424,6 @@ class CompatibilityInteroperabilitySpec extends ChiselFlatSpec {
 
   "A Chisel.Bundle with mixed Specified and Unspecified directions" should "work with D/I" in {
 
-    /**
-      *       A Chisel.Bundle with mixed Specified and Unspecified directions
-      *       [info] - should work with D/I *** FAILED ***
-      *       [info]   java.lang.RuntimeException: Unexpected port element direction 'Unspecified'
-      *       [info]   at chisel3.internal.BindingDirection$.from(Binding.scala:62)
-      *       [info]   at chisel3.internal.BiConnect$.elemConnect(BiConnect.scala:357)
-      *       [info]   at chisel3.internal.BiConnect$.connect(BiConnect.scala:103)
-      *      [info]   at chisel3.Data.bulkConnect(Data.scala:658)
-      */
-
     object Compat {
       import Chisel._
       import chisel3.experimental.hierarchy.{instantiable, public}
@@ -473,24 +455,6 @@ class CompatibilityInteroperabilitySpec extends ChiselFlatSpec {
   }
   "A Chisel.Bundle with only unspecified vec direction" should "work with D/I" in {
 
-    /**
-      * A Chisel.Bundle with only unspecified vec direction
-      * [info] - should work with D/I *** FAILED ***
-      * [info]   java.lang.RuntimeException: Unexpected port element direction 'Unspecified'
-      * [info]   at chisel3.internal.BindingDirection$.from(Binding.scala:62)
-      * [info]   at chisel3.internal.BiConnect$.elemConnect(BiConnect.scala:357)
-      * [info]   at chisel3.internal.BiConnect$.connect(BiConnect.scala:103)
-      * [info]   at chisel3.internal.BiConnect$.$anonfun$connect$1(BiConnect.scala:129)
-      * [info]   at scala.collection.immutable.Range.foreach$mVc$sp(Range.scala:158)
-      * [info]   at chisel3.internal.BiConnect$.connect(BiConnect.scala:126)
-      * [info]   at chisel3.Data.bulkConnect(Data.scala:658
-      */
-    /* After first fix, it worked, but I tightened the check now we get:
-[info] A chisel3.Bundle with only unspecified vec direction
-[info] - should work with D/I *** FAILED ***
-[info]   chisel3.package$UnspecifiedDirectionException: Chisel internal error: All children should have specified directions, there is no reason for this to be ambiguous. Vector((MyModule.io_in: IO[Bool[3]],Unspecified), (MyModule.io_out: IO[Bool[3]],Unspecified)). Please submit a bug report at https://github.com/chipsalliance/chisel3/issues
-[info]   at chisel3.Aggregate.bind(Aggregate.scala:66)
-     */
     object Compat {
       import Chisel._
       import chisel3.experimental.hierarchy.{instantiable, public}
@@ -522,14 +486,6 @@ class CompatibilityInteroperabilitySpec extends ChiselFlatSpec {
 
   "A chisel3.Bundle with only unspecified directions" should "work with D/I" in {
 
-    /*
-    A chisel3.Bundle with only unspecified directions
-[info] - should work with D/I *** FAILED ***
-[info]   java.lang.RuntimeException: Unexpected port element direction 'Unspecified'
-[info]   at chisel3.internal.BindingDirection$.from(Binding.scala:62)
-[info]   at chisel3.internal.BiConnect$.elemConnect(BiConnect.scala:357)
-     */
-
     // This test is NOT expected to work on 3.5.x, it should throw an error in the IO construction.
 
     object Chisel3 {
@@ -560,15 +516,6 @@ class CompatibilityInteroperabilitySpec extends ChiselFlatSpec {
 
   "A chisel3.Bundle with mixed Specified and Unspecified directions" should "work with D/I" in {
 
-    /*
-    A chisel3.Bundle with mixed Specified and Unspecified directions
-[info] - should work with D/I *** FAILED ***
-[info]   java.lang.RuntimeException: Unexpected port element direction 'Unspecified'
-[info]   at chisel3.internal.BindingDirection$.from(Binding.scala:62)
-[info]   at chisel3.internal.BiConnect$.elemConnect(BiConnect.scala:357)
-[info]   at chisel3.internal.BiConnect$.connect(BiConnect.scala:103)
-[info]   at chisel3.Data.bulkConnect(Data.scala:658)
-     */
     // This test is NOT expected to work on 3.5.x, it should throw an error in the IO construction.
 
     object Chisel3 {
@@ -598,19 +545,8 @@ class CompatibilityInteroperabilitySpec extends ChiselFlatSpec {
   }
 
   "A chisel3.Bundle with only unspecified vec direction" should "work with D/I" in {
-    /*
-    [info] A chisel3.Bundle with only unspecified vec direction
-    [info] - should work with D/I *** FAILED ***
-    [info]   java.lang.RuntimeException: Unexpected port element direction 'Unspecified'
-     */
+
     // This test is NOT expected to work on 3.5.x, it should throw an error in the IO construction
-    /* Also fails after only first fix:
-      A chisel3.Bundle with only unspecified vec direction
-     [info] - should work with D/I *** FAILED ***
-     [info]   chisel3.package$UnspecifiedDirectionException: At this point all children should have specified directions, there is no reason for this to be ambiguous anymore
-     [info]   at chisel3.Aggregate.bind(Aggregate.scala:64)
-     [info]
-     */
 
     object Chisel3 {
       import chisel3._
@@ -640,20 +576,8 @@ class CompatibilityInteroperabilitySpec extends ChiselFlatSpec {
 
   "A chisel3.Bundle with only unspecified vec direction within an unspecified direction parent Bundle" should "work with D/I" in {
 
-    /*
- A chisel3.Bundle with only unspecified vec direction within an unspecified direction parent Bundle
-[info] - should work with D/I *** FAILED ***
-[info]   chisel3.package$UnspecifiedDirectionException: At this point all children should have specified directions, there is no reason for this to be ambiguous anymore
-[info]   at chisel3.Aggregate.bind(Aggregate.scala:64)
-[info]
-     */
-// after first fix and adding tighter requirements:
+    // This test is NOT expected to work in 3.5.x, it should throw an error in the IO construction.
 
-    /*
-[info] A chisel3.Bundle with only unspecified vec direction within an unspecified direction parent Bundle
-[info] - should work with D/I *** FAILED ***
-[info]   chisel3.package$UnspecifiedDirectionException: Chisel internal error: All children should have specified directions, there is no reason for this to be ambiguous. Vector((MyModule.io_vec: IO[Bool[3]],Unspecified)). Please submit a bug report at https://github.com/chipsalliance/chisel3/issues
-     */
     object Chisel3 {
       import chisel3._
       import chisel3.experimental.hierarchy.{instantiable, public, Instance}
@@ -687,24 +611,8 @@ class CompatibilityInteroperabilitySpec extends ChiselFlatSpec {
 
   "A undirectioned Chisel.Bundle used in a MixedVec " should "bulk connect in import chisel3._ code correctly" in {
 
-    /*
-    A undirectioned Chisel.Bundle used in a MixedVec
-[info] - should bulk connect in import chisel3._ code correctly *** FAILED ***
-[info]   chisel3.package$UnspecifiedDirectionException: At this point all children should have specified directions, there is no reason for this to be ambiguous anymore
-[info]   at ... ()
-[info]   at chiselTests.CompatibilityInteroperabilitySpec$Compat$15$ChiselModule.<init>(CompatibilityInteroperabilitySpec.scala:674)
-[info]   at chiselTests.CompatibilityInteroperabilitySpec$Chisel3$15$Example.$anonfun$oldMod$2(CompatibilityInteroperabilitySpec.scala:684)
-[info]
-     */
-
     // This test is NOT expected to work on 3.5.x, it should throw an error in the IO construction.
 
-    // After first fix and tightening the requirements:
-    /*
-[info] A undirectioned Chisel.Bundle used in a MixedVec
-[info] - should bulk connect in import chisel3._ code correctly *** FAILED ***
-[info]   chisel3.package$UnspecifiedDirectionException: Chisel internal error: All children should have specified directions, there is no reason for this to be ambiguous. Vector((ChiselModule.elts_0: Reg[Bool],Unspecified), (ChiselModule.elts_1: Reg[Bool],Unspecified), (ChiselModule.elts_2: Reg[Bool],Unspecified)). Please submit a bug report at https://github.com/chipsalliance/chisel3/issues
-     */
     object Compat {
 
       import Chisel._
@@ -743,7 +651,6 @@ class CompatibilityInteroperabilitySpec extends ChiselFlatSpec {
     object Compat {
 
       import Chisel._
-      import chisel3.util.MixedVec
 
       class ChiselModule(gen: () => Data) extends Module {
         val io = IO(new Bundle {
@@ -756,9 +663,8 @@ class CompatibilityInteroperabilitySpec extends ChiselFlatSpec {
       import chisel3._
       import scala.collection.immutable.SeqMap
 
-      class MyRecord(gen: () => Data) extends Record {
+      class MyRecord(gen: () => Data) extends Record with chisel3.experimental.AutoCloneType {
         val elements = SeqMap("genDirectioned" -> Output(gen()), "genUndirectioned" -> gen())
-        override def cloneType: this.type = (new MyRecord(gen)).asInstanceOf[this.type]
       }
 
       class Example extends Module {


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
  - bug fix  
<!--   - performance improvement            -->
<!--   - documentation                      -->
  - code refactoring    
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

The main thing this does is that, now that we agree that "Output" and "Unspecified" are basically the same thing aka "Aligned", and are going through hoops to fix this up on ports, is to just make that done at the leaves themselves for non-Analog Elements. This avoids the need to do fixups and confusion/errors around `cloneTypeFull` which does not do the same recursion

This is an alternative to #2792 . Fixes https://github.com/chipsalliance/chisel3/issues/2794

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

This shouldn't change generated verilog unless there were bugs.

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
- Squash: The PR will be squashed and merged (choose this if you have no preference.
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

Assumption that elements with Unspecified specified Direction == Output is now done in the Element constructor itself rather than as a fixup step. Fixes #2794 to ensure that D/I works with modules with IO with Bundles with Unspecified directions.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
