### PR TITLE
Fix for <> to BlackBox.IO with Compatibility Bundles 

### DIFF
--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -1108,7 +1108,12 @@ abstract class Record(private[chisel3] implicit val compileOptions: CompileOptio
   def elements: SeqMap[String, Data]
 
   /** Name for Pretty Printing */
-  def className: String = this.getClass.getSimpleName
+  def className: String = try {
+    this.getClass.getSimpleName
+  } catch {
+    // This happens if your class is defined in an object and is anonymous
+    case e: java.lang.InternalError if e.getMessage == "Malformed class name" => this.getClass.toString
+  }
 
   private[chisel3] override def typeEquivalent(that: Data): Boolean = that match {
     case that: Record =>
@@ -1228,10 +1233,15 @@ abstract class Bundle(implicit compileOptions: CompileOptions) extends Record wi
       "Please see https://github.com/chipsalliance/chisel3#build-your-own-chisel-projects."
   assert(_usingPlugin, mustUsePluginMsg)
 
-  override def className: String = this.getClass.getSimpleName match {
-    case name if name.startsWith("$anon$") => "AnonymousBundle" // fallback for anonymous Bundle case
-    case ""                                => "AnonymousBundle" // ditto, but on other platforms
-    case name                              => name
+  override def className: String = try {
+    this.getClass.getSimpleName match {
+      case name if name.startsWith("$anon$") => "AnonymousBundle" // fallback for anonymous Bundle case
+      case ""                                => "AnonymousBundle" // ditto, but on other platforms
+      case name                              => name
+    }
+  } catch {
+    // This happens if you have nested objects which your class is defined in
+    case e: java.lang.InternalError if e.getMessage == "Malformed class name" => this.getClass.toString
   }
 
   /** The collection of [[Data]]

--- a/core/src/main/scala/chisel3/internal/BiConnect.scala
+++ b/core/src/main/scala/chisel3/internal/BiConnect.scala
@@ -231,9 +231,10 @@ private[chisel3] object BiConnect {
     val recordConnectFieldsMustMatch =
       left_r.compileOptions.connectFieldsMustMatch || right_r.compileOptions.connectFieldsMustMatch
 
+    val connectFieldsMustMatch = /*connectCompileOptions.connectFieldsMustMatch &&*/ recordConnectFieldsMustMatch
     // For each field in left, descend with right.
     // Don't bother doing this check if we don't expect it to necessarily pass.
-    if (connectCompileOptions.connectFieldsMustMatch || recordConnectFieldsMustMatch) {
+    if (connectFieldsMustMatch) {
       for ((field, right_sub) <- right_r.elements) {
         if (!left_r.elements.isDefinedAt(field)) {
           throw MissingLeftFieldException(field)
@@ -246,7 +247,7 @@ private[chisel3] object BiConnect {
         right_r.elements.get(field) match {
           case Some(right_sub) => connect(sourceInfo, connectCompileOptions, left_sub, right_sub, context_mod)
           case None => {
-            if (connectCompileOptions.connectFieldsMustMatch || recordConnectFieldsMustMatch) {
+            if (connectFieldsMustMatch) {
               throw MissingRightFieldException(field)
             }
           }

--- a/core/src/main/scala/chisel3/internal/BiConnect.scala
+++ b/core/src/main/scala/chisel3/internal/BiConnect.scala
@@ -162,8 +162,10 @@ private[chisel3] object BiConnect {
           left_r.compileOptions.emitStrictConnects && right_r.compileOptions.emitStrictConnects
 
         // chisel3 <> is commutative but FIRRTL <- is not
+        println(s"Determining flipConnection of ${left_r} <> ${right_r}")
         val flipConnection =
           !MonoConnect.canBeSink(left_r, context_mod) || !MonoConnect.canBeSource(right_r, context_mod)
+        println(s"DONE: flipConnection is ${flipConnection}")
         val (newLeft, newRight) = if (flipConnection) (right_r, left_r) else (left_r, right_r)
 
         val leftReified:  Option[Aggregate] = if (isView(newLeft)) reifyToAggregate(newLeft) else Some(newLeft)
@@ -296,7 +298,12 @@ private[chisel3] object BiConnect {
     }
 
     // check data can flow between provided aggregates
-    def flow_check = MonoConnect.canBeSink(sink, context_mod) && MonoConnect.canBeSource(source, context_mod)
+    def flow_check = {
+      println(s"Doing Flow Check... of ${sink} <= ${source}")
+      val result = MonoConnect.canBeSink(sink, context_mod) && MonoConnect.canBeSource(source, context_mod)
+      println(s"Done: flowcheck is $result")
+      result
+    }
 
     // do not bulk connect source literals (results in infinite recursion from calling .ref)
     def sourceNotLiteralCheck = source.topBinding match {

--- a/core/src/main/scala/chisel3/internal/BiConnect.scala
+++ b/core/src/main/scala/chisel3/internal/BiConnect.scala
@@ -179,10 +179,9 @@ private[chisel3] object BiConnect {
           )
         ) {
           pushCommand(Connect(sourceInfo, leftReified.get.lref, rightReified.get.lref))
+        } else if (!emitStrictConnects) {
+          newLeft.legacyConnect(newRight)(sourceInfo)
         } else {
-          // May be connecting to a blackbox or have missing fields in compatibility mode, etc
-          // Emitting a legacyConnect here may do the wrong thing w.r.t directionality, so
-          // blast out the connection so we can perform the proper analysis.
           recordConnect(sourceInfo, connectCompileOptions, left_r, right_r, context_mod)
         }
 
@@ -228,17 +227,10 @@ private[chisel3] object BiConnect {
     context_mod:           RawModule
   ): Unit = {
     // Verify right has no extra fields that left doesn't have
-    // The semantic we allow here is the most relaxed -- ONLY if:
-    // - both sides of the connection are chisel3._
-    // - AND the <> operator itself is in chisel3._ code
-    // do we require that all the fields match.
-    val recordConnectFieldsCanMismatch =
-      !left_r.compileOptions.connectFieldsMustMatch || !right_r.compileOptions.connectFieldsMustMatch
-    val connectFieldsMustMatch = !(!connectCompileOptions.connectFieldsMustMatch || recordConnectFieldsCanMismatch)
-
+ 
     // For each field in left, descend with right.
     // Don't bother doing this check if we don't expect it to necessarily pass.
-    if (connectFieldsMustMatch) {
+    if (connectCompileOptions.connectFieldsMustMatch) {
       for ((field, right_sub) <- right_r.elements) {
         if (!left_r.elements.isDefinedAt(field)) {
           throw MissingLeftFieldException(field)
@@ -251,7 +243,7 @@ private[chisel3] object BiConnect {
         right_r.elements.get(field) match {
           case Some(right_sub) => connect(sourceInfo, connectCompileOptions, left_sub, right_sub, context_mod)
           case None => {
-            if (connectFieldsMustMatch) {
+            if (connectCompileOptions.connectFieldsMustMatch) {
               throw MissingRightFieldException(field)
             }
           }

--- a/core/src/main/scala/chisel3/internal/BiConnect.scala
+++ b/core/src/main/scala/chisel3/internal/BiConnect.scala
@@ -162,10 +162,8 @@ private[chisel3] object BiConnect {
           left_r.compileOptions.emitStrictConnects && right_r.compileOptions.emitStrictConnects
 
         // chisel3 <> is commutative but FIRRTL <- is not
-        println(s"Determining flipConnection of ${left_r} <> ${right_r}")
         val flipConnection =
           !MonoConnect.canBeSink(left_r, context_mod) || !MonoConnect.canBeSource(right_r, context_mod)
-        println(s"DONE: flipConnection is ${flipConnection}")
         val (newLeft, newRight) = if (flipConnection) (right_r, left_r) else (left_r, right_r)
 
         val leftReified:  Option[Aggregate] = if (isView(newLeft)) reifyToAggregate(newLeft) else Some(newLeft)
@@ -298,12 +296,7 @@ private[chisel3] object BiConnect {
     }
 
     // check data can flow between provided aggregates
-    def flow_check = {
-      println(s"Doing Flow Check... of ${sink} <= ${source}")
-      val result = MonoConnect.canBeSink(sink, context_mod) && MonoConnect.canBeSource(source, context_mod)
-      println(s"Done: flowcheck is $result")
-      result
-    }
+    def flow_check = MonoConnect.canBeSink(sink, context_mod) && MonoConnect.canBeSource(source, context_mod)
 
     // do not bulk connect source literals (results in infinite recursion from calling .ref)
     def sourceNotLiteralCheck = source.topBinding match {

--- a/core/src/main/scala/chisel3/internal/BiConnect.scala
+++ b/core/src/main/scala/chisel3/internal/BiConnect.scala
@@ -229,7 +229,7 @@ private[chisel3] object BiConnect {
     context_mod:           RawModule
   ): Unit = {
     // Verify right has no extra fields that left doesn't have
- 
+
     // For each field in left, descend with right.
     // Don't bother doing this check if we don't expect it to necessarily pass.
     if (connectCompileOptions.connectFieldsMustMatch) {

--- a/core/src/main/scala/chisel3/internal/BiConnect.scala
+++ b/core/src/main/scala/chisel3/internal/BiConnect.scala
@@ -228,10 +228,14 @@ private[chisel3] object BiConnect {
     context_mod:           RawModule
   ): Unit = {
     // Verify right has no extra fields that left doesn't have
-    val recordConnectFieldsMustMatch =
-      left_r.compileOptions.connectFieldsMustMatch || right_r.compileOptions.connectFieldsMustMatch
+    // The semantic we allow here is the most relaxed -- ONLY if:
+    // - both sides of the connection are chisel3._
+    // - AND the <> operator itself is in chisel3._ code
+    // do we require that all the fields match.
+    val recordConnectFieldsCanMismatch =
+      !left_r.compileOptions.connectFieldsMustMatch || !right_r.compileOptions.connectFieldsMustMatch
+    val connectFieldsMustMatch = !(!connectCompileOptions.connectFieldsMustMatch || recordConnectFieldsCanMismatch)
 
-    val connectFieldsMustMatch = /*connectCompileOptions.connectFieldsMustMatch &&*/ recordConnectFieldsMustMatch
     // For each field in left, descend with right.
     // Don't bother doing this check if we don't expect it to necessarily pass.
     if (connectFieldsMustMatch) {

--- a/core/src/main/scala/chisel3/internal/MonoConnect.scala
+++ b/core/src/main/scala/chisel3/internal/MonoConnect.scala
@@ -329,14 +329,14 @@ private[chisel3] object MonoConnect {
    * Always returns true if the Data does not actually correspond to a Port.
   */
   @tailrec private[chisel3] def traceFlow(wantToBeSink: Boolean, currentlyFlipped: Boolean, data: Data, context_mod: RawModule): Boolean = {
-    println("Tracing flow of data, wantToBeSink, currentlyFlipped, context_mod)")
-    println(s"               $data, $wantToBeSink, $currentlyFlipped, $context_mod")
+    println("Tracing flow of data, wantToBeSink, currentlyFlipped, context_mod) with specifiedDirection")
+    println(s"               $data, $wantToBeSink, $currentlyFlipped, $context_mod) with ${data.specifiedDirection}")
 
     val sdir = data.specifiedDirection
     val coercedFlip = sdir == SpecifiedDirection.Input
     val coercedAlign = sdir == SpecifiedDirection.Output
     val flipped = sdir == SpecifiedDirection.Flip
-    val traceFlipped = ((flipped ^ !currentlyFlipped) || coercedFlip) && (!coercedAlign)
+    val traceFlipped = ((flipped ^ currentlyFlipped) || coercedFlip) && (!coercedAlign)
     println(s"        traceFlipped = ((flipped ^ !currentlyFlipped) || coercedFlip) && (!coercedAlign)")
     println(s"        $traceFlipped    = (($flipped ^ !$currentlyFlipped) || $coercedFlip) && (!$coercedAlign)")
 
@@ -352,7 +352,7 @@ private[chisel3] object MonoConnect {
         println(s"     PortBinding: returning !(wantToBeSink ^ childPort ^ traceFlipped)}")
         println(s"     PortBinding: returning ${!(wantToBeSink ^ childPort ^ traceFlipped)} = !($wantToBeSink ^ $childPort ^ $traceFlipped) = ")
 
-        !(wantToBeSink ^ childPort ^ traceFlipped)
+        (wantToBeSink ^ childPort ^ traceFlipped)
       }
       case other => {
         println(s"    $other: returning true")

--- a/core/src/main/scala/chisel3/internal/MonoConnect.scala
+++ b/core/src/main/scala/chisel3/internal/MonoConnect.scala
@@ -323,12 +323,17 @@ private[chisel3] object MonoConnect {
   }
 
   /** Trace flow from child Data to its parent. Returns true if,
-   * given the context,
-   * this signal can be a sink when currentlyFlipped = true,
-   * or if it can be a source when currentlyFlipped = false.
-   * Always returns true if the Data does not actually correspond to a Port.
-  */
-  @tailrec private[chisel3] def traceFlow(wantToBeSink: Boolean, currentlyFlipped: Boolean, data: Data, context_mod: RawModule): Boolean = {
+    * given the context,
+    * this signal can be a sink when currentlyFlipped = true,
+    * or if it can be a source when currentlyFlipped = false.
+    * Always returns true if the Data does not actually correspond to a Port.
+    */
+  @tailrec private[chisel3] def traceFlow(
+    wantToBeSink:     Boolean,
+    currentlyFlipped: Boolean,
+    data:             Data,
+    context_mod:      RawModule
+  ): Boolean = {
     println("Tracing flow of data, wantToBeSink, currentlyFlipped, context_mod) with specifiedDirection")
     println(s"               $data, $wantToBeSink, $currentlyFlipped, $context_mod) with ${data.specifiedDirection}")
 
@@ -340,7 +345,6 @@ private[chisel3] object MonoConnect {
     println(s"        traceFlipped = ((flipped ^ !currentlyFlipped) || coercedFlip) && (!coercedAlign)")
     println(s"        $traceFlipped    = (($flipped ^ !$currentlyFlipped) || $coercedFlip) && (!$coercedAlign)")
 
-
     data.binding.get match {
       case ChildBinding(parent) => {
         println(s"    ChildBinding, recurse... traceFlow(wantToBeSink, traceFlipped, parent, context_mod)")
@@ -350,7 +354,9 @@ private[chisel3] object MonoConnect {
       case PortBinding(enclosure) => {
         val childPort = enclosure != context_mod
         println(s"     PortBinding: returning !(wantToBeSink ^ childPort ^ traceFlipped)}")
-        println(s"     PortBinding: returning ${!(wantToBeSink ^ childPort ^ traceFlipped)} = !($wantToBeSink ^ $childPort ^ $traceFlipped) = ")
+        println(
+          s"     PortBinding: returning ${!(wantToBeSink ^ childPort ^ traceFlipped)} = !($wantToBeSink ^ $childPort ^ $traceFlipped) = "
+        )
 
         (wantToBeSink ^ childPort ^ traceFlipped)
       }

--- a/core/src/main/scala/chisel3/internal/MonoConnect.scala
+++ b/core/src/main/scala/chisel3/internal/MonoConnect.scala
@@ -322,21 +322,28 @@ private[chisel3] object MonoConnect {
     else false
   }
 
-  /** Trace flow from child Data to its parent. */
-  @tailrec private[chisel3] def traceFlow(currentlyFlipped: Boolean, data: Data, context_mod: RawModule): Boolean = {
-    import SpecifiedDirection.{Input => SInput, Flip => SFlip}
+  /** Trace flow from child Data to its parent. Returns true if,
+   * given the context,
+   * this signal can be a sink when currentlyFlipped = true,
+   * or if it can be a source when currentlyFlipped = false.
+   * Always returns true if the Data does not actually correspond to a Port.
+  */
+  @tailrec private[chisel3] def traceFlow(wantToBeSink: Boolean, currentlyFlipped: Boolean, data: Data, context_mod: RawModule): Boolean = {
     val sdir = data.specifiedDirection
-    val flipped = sdir == SInput || sdir == SFlip
+    val coercedFlip = sdir == SpecifiedDirection.Input
+    val coercedAlign = sdir == SpecifiedDirection.Output
+    val flipped = sdir == SpecifiedDirection.Flip
+    val traceFlipped = ((flipped ^ !currentlyFlipped) || coercedFlip) && (!coercedAlign)
     data.binding.get match {
-      case ChildBinding(parent) => traceFlow(flipped ^ currentlyFlipped, parent, context_mod)
+      case ChildBinding(parent) => traceFlow(wantToBeSink, traceFlipped, parent, context_mod)
       case PortBinding(enclosure) =>
         val childPort = enclosure != context_mod
-        childPort ^ flipped ^ currentlyFlipped
+        !(wantToBeSink ^ childPort ^ traceFlipped)
       case _ => true
     }
   }
-  def canBeSink(data:   Data, context_mod: RawModule): Boolean = traceFlow(true, data, context_mod)
-  def canBeSource(data: Data, context_mod: RawModule): Boolean = traceFlow(false, data, context_mod)
+  def canBeSink(data:   Data, context_mod: RawModule): Boolean = traceFlow(true, false, data, context_mod)
+  def canBeSource(data: Data, context_mod: RawModule): Boolean = traceFlow(false, false, data, context_mod)
 
   /** Check whether two aggregates can be bulk connected (<=) in FIRRTL. (MonoConnect case)
     *

--- a/core/src/main/scala/chisel3/internal/MonoConnect.scala
+++ b/core/src/main/scala/chisel3/internal/MonoConnect.scala
@@ -325,8 +325,8 @@ private[chisel3] object MonoConnect {
   /** Trace flow from child Data to its parent.
     *
     * Returns true if, given the context,
-    * this signal can be a sink when currentlyFlipped = true,
-    * or if it can be a source when currentlyFlipped = false.
+    * this signal can be a sink when wantsToBeSink = true,
+    * or if it can be a source when wantsToBeSink = false.
     * Always returns true if the Data does not actually correspond
     * to a Port.
     */

--- a/src/test/scala/chiselTests/BulkConnectSpec.scala
+++ b/src/test/scala/chiselTests/BulkConnectSpec.scala
@@ -21,7 +21,9 @@ class BulkConnectSpec extends ChiselPropSpec {
     chirrtl should include("io.outBi <= io.inBi")
   }
 
-  property("Chisel connects should not emit FIRRTL bulk connects for Stringly-typed connections") {
+  property(
+    "Chisel connects should blast out to FIRRTL bulk connects for mistmatched, Stringly-typed connections (ignoring the context of the <>)"
+  ) {
     object Foo {
       import Chisel._
       // Chisel._ bundle
@@ -54,7 +56,10 @@ class BulkConnectSpec extends ChiselPropSpec {
     })
 
     chirrtl should include("out.buzz.foo <= in.buzz.foo")
-    chirrtl shouldNot include("deq <= enq")
+    chirrtl should include("deq.valid <= enq.valid")
+    chirrtl should include("enq.ready <= deq.ready")
+    chirrtl should include("deq.bits.foo <= enq.bits.foo")
+    chirrtl shouldNot include("deq.bits.bar")
   }
 
   property("Chisel connects should not emit FIRRTL bulk connects between differing FIRRTL types") {

--- a/src/test/scala/chiselTests/BulkConnectSpec.scala
+++ b/src/test/scala/chiselTests/BulkConnectSpec.scala
@@ -22,7 +22,7 @@ class BulkConnectSpec extends ChiselPropSpec {
   }
 
   property(
-    "Chisel connects should blast out to FIRRTL bulk connects for mistmatched, Stringly-typed connections (ignoring the context of the <>)"
+    "Chisel connects should blast out to FIRRTL bulk connects for mismatched, Stringly-typed connections (ignoring the context of the <>)"
   ) {
     object Foo {
       import Chisel._
@@ -79,7 +79,10 @@ class BulkConnectSpec extends ChiselPropSpec {
       out <> in
     })
     // out <- in is illegal FIRRTL
-    chirrtl should include("out.foo.bar <= in.foo.bar")
+    exactly(2, chirrtl.split('\n')) should include("out.foo.bar <= in.foo.bar")
+    chirrtl shouldNot include("out <= in")
+    chirrtl shouldNot include("out <- in")
+
   }
 
   property("Chisel connects should not emit a FIRRTL bulk connect for a bidirectional MonoConnect") {
@@ -96,6 +99,9 @@ class BulkConnectSpec extends ChiselPropSpec {
     })
 
     chirrtl shouldNot include("wire <= enq")
+    chirrtl should include("wire.bits <= enq.bits")
+    chirrtl should include("wire.valid <= enq.valid")
+    chirrtl should include("wire.ready <= enq.ready")
     chirrtl should include("deq <= enq")
   }
 

--- a/src/test/scala/chiselTests/BulkConnectSpec.scala
+++ b/src/test/scala/chiselTests/BulkConnectSpec.scala
@@ -21,9 +21,7 @@ class BulkConnectSpec extends ChiselPropSpec {
     chirrtl should include("io.outBi <= io.inBi")
   }
 
-  property(
-    "Chisel connects should blast out to FIRRTL bulk connects for mismatched, Stringly-typed connections (ignoring the context of the <>)"
-  ) {
+  property("Chisel connects should not emit FIRRTL bulk connects for Stringly-typed connections") {
     object Foo {
       import Chisel._
       // Chisel._ bundle
@@ -56,9 +54,14 @@ class BulkConnectSpec extends ChiselPropSpec {
     })
 
     chirrtl should include("out.buzz.foo <= in.buzz.foo")
+    chirrtl should include("out.fizz <= in.fizz")
+    chirrtl should include("deq.bits <- enq.bits")
     chirrtl should include("deq.valid <= enq.valid")
     chirrtl should include("enq.ready <= deq.ready")
-    chirrtl should include("deq.bits.foo <= enq.bits.foo")
+
+    chirrtl shouldNot include("deq <= enq")
+    chirrtl shouldNot include("deq.bits.foo <= enq.bits.foo")
+    chirrtl shouldNot include("deq.bits.foo <- enq.bits.foo")
     chirrtl shouldNot include("deq.bits.bar")
   }
 
@@ -82,7 +85,6 @@ class BulkConnectSpec extends ChiselPropSpec {
     exactly(2, chirrtl.split('\n')) should include("out.foo.bar <= in.foo.bar")
     chirrtl shouldNot include("out <= in")
     chirrtl shouldNot include("out <- in")
-
   }
 
   property("Chisel connects should not emit a FIRRTL bulk connect for a bidirectional MonoConnect") {

--- a/src/test/scala/chiselTests/CompatibilityInteroperabilitySpec.scala
+++ b/src/test/scala/chiselTests/CompatibilityInteroperabilitySpec.scala
@@ -441,6 +441,6 @@ class CompatibilityInteroperabilitySpec extends ChiselFlatSpec {
       }
     }
 
-    (new chisel3.stage.ChiselStage).emitVerilog(new Chisel3.Top, Array("--full-stacktrace"))
+    compile(new Chisel3.Top)
   }
 }

--- a/src/test/scala/chiselTests/CompatibilityInteroperabilitySpec.scala
+++ b/src/test/scala/chiselTests/CompatibilityInteroperabilitySpec.scala
@@ -310,20 +310,6 @@ class CompatibilityInteroperabilitySpec extends ChiselFlatSpec {
         enq <> deq
         deq <> enq
       }
-      val chirrtl = (new chisel3.stage.ChiselStage).emitChirrtl(new RawModule {
-        val deq = IO(new Bar)
-        val enq = IO(Flipped(new Bar))
-        // Also important to check connections to child ports
-        val c1 = Module(new Child)
-        val c2 = Module(new Child)
-        c1.enq <> enq
-        enq <> c1.enq
-        c2.enq <> c1.deq
-        c1.deq <> c2.enq
-        deq <> c2.deq
-        c2.deq <> deq
-      })
-      println(s"chirrtl is ${chirrtl}")
       new RawModule {
         val deq = IO(new Bar)
         val enq = IO(Flipped(new Bar))
@@ -338,7 +324,6 @@ class CompatibilityInteroperabilitySpec extends ChiselFlatSpec {
         c2.deq <> deq
       }
     }
-
   }
 
   "A unidirectional but flipped Bundle" should "bulk connect in import chisel3._ code correctly" in {

--- a/src/test/scala/chiselTests/CompatibilityInteroperabilitySpec.scala
+++ b/src/test/scala/chiselTests/CompatibilityInteroperabilitySpec.scala
@@ -465,13 +465,12 @@ class CompatibilityInteroperabilitySpec extends ChiselFlatSpec {
         out <> in
       }
     }
-    // No connections should happen but code should compile.
     val chirrtl0 = chisel3.stage.ChiselStage.emitChirrtl(new Chisel3.MyModule(true))
-    (chirrtl0 should not).include("<=")
-    (chirrtl0 should not).include("<-")
+    chirrtl0 shouldNot include("<=")
+    chirrtl0 should include("out <- in")
     val chirrtl1 = chisel3.stage.ChiselStage.emitChirrtl(new Chisel3.MyModule(true))
-    (chirrtl1 should not).include("<=")
-    (chirrtl1 should not).include("<-")
+    chirrtl1 shouldNot include("<=")
+    chirrtl1 should include("out <- in")
 
   }
   it should "work with missing fields in the Chisel._" in {
@@ -497,13 +496,11 @@ class CompatibilityInteroperabilitySpec extends ChiselFlatSpec {
       }
     }
     val chirrtl0 = chisel3.stage.ChiselStage.emitChirrtl(new Chisel3.MyModule(true))
-    chirrtl0 should include("out.foo <= in.foo")
-    (chirrtl0 should not).include("out <- in")
-    (chirrtl0 should not).include("out <= in")
-    val chirrtl1 = chisel3.stage.ChiselStage.emitChirrtl(new Chisel3.MyModule(false))
-    chirrtl0 should include("out.foo <= in.foo")
-    (chirrtl0 should not).include("out <- in")
-    (chirrtl0 should not).include("out <= in")
+    chirrtl0 shouldNot include("<=")
+    chirrtl0 should include("out <- in")
+    val chirrtl1 = chisel3.stage.ChiselStage.emitChirrtl(new Chisel3.MyModule(true))
+    chirrtl1 shouldNot include("<=")
+    chirrtl1 should include("out <- in")
   }
 
   it should "work with missing fields in the chisel3._" in {
@@ -529,13 +526,11 @@ class CompatibilityInteroperabilitySpec extends ChiselFlatSpec {
       }
     }
     val chirrtl0 = chisel3.stage.ChiselStage.emitChirrtl(new Chisel3.MyModule(true))
-    chirrtl0 should include("out.foo <= in.foo")
-    (chirrtl0 should not).include("out <- in")
-    (chirrtl0 should not).include("out <= in")
-    val chirrtl1 = chisel3.stage.ChiselStage.emitChirrtl(new Chisel3.MyModule(false))
-    chirrtl0 should include("out.foo <= in.foo")
-    (chirrtl0 should not).include("out <- in")
-    (chirrtl0 should not).include("out <= in")
+    chirrtl0 shouldNot include("<=")
+    chirrtl0 should include("out <- in")
+    val chirrtl1 = chisel3.stage.ChiselStage.emitChirrtl(new Chisel3.MyModule(true))
+    chirrtl1 shouldNot include("<=")
+    chirrtl1 should include("out <- in")
   }
   it should "emit FIRRTL connects if possible" in {
     object Compat {
@@ -562,10 +557,10 @@ class CompatibilityInteroperabilitySpec extends ChiselFlatSpec {
     }
     val chirrtl0 = chisel3.stage.ChiselStage.emitChirrtl(new Chisel3.MyModule(true))
     chirrtl0 should include("out <= in")
-    (chirrtl0 should not).include("out <- in")
+    chirrtl0 shouldNot include("out <- in")
     val chirrtl1 = chisel3.stage.ChiselStage.emitChirrtl(new Chisel3.MyModule(true))
     chirrtl0 should include("out <= in")
-    (chirrtl0 should not).include("out <- in")
+    chirrtl0 shouldNot include("out <- in")
   }
 
 }

--- a/src/test/scala/chiselTests/CompatibilityInteroperabilitySpec.scala
+++ b/src/test/scala/chiselTests/CompatibilityInteroperabilitySpec.scala
@@ -310,6 +310,20 @@ class CompatibilityInteroperabilitySpec extends ChiselFlatSpec {
         enq <> deq
         deq <> enq
       }
+      val chirrtl = (new chisel3.stage.ChiselStage).emitChirrtl(new RawModule {
+        val deq = IO(new Bar)
+        val enq = IO(Flipped(new Bar))
+        // Also important to check connections to child ports
+        val c1 = Module(new Child)
+        val c2 = Module(new Child)
+        c1.enq <> enq
+        enq <> c1.enq
+        c2.enq <> c1.deq
+        c1.deq <> c2.enq
+        deq <> c2.deq
+        c2.deq <> deq
+      })
+      println(s"chirrtl is ${chirrtl}")
       new RawModule {
         val deq = IO(new Bar)
         val enq = IO(Flipped(new Bar))
@@ -324,6 +338,7 @@ class CompatibilityInteroperabilitySpec extends ChiselFlatSpec {
         c2.deq <> deq
       }
     }
+    
   }
 
   "A unidirectional but flipped Bundle" should "bulk connect in import chisel3._ code correctly" in {

--- a/src/test/scala/chiselTests/CompatibilityInteroperabilitySpec.scala
+++ b/src/test/scala/chiselTests/CompatibilityInteroperabilitySpec.scala
@@ -413,20 +413,23 @@ class CompatibilityInteroperabilitySpec extends ChiselFlatSpec {
         val q = Flipped(Valid(new Compat.LegacyChiselIO))
       }
       class FooModule extends Module {
-        val io = IO(new FooModuleIO())
+        val io = IO(new FooModuleIO)
         io <> DontCare
       }
       class FooMirrorBlackBox extends BlackBox {
-        val io = IO(Flipped(new FooModuleIO()))
+        val io = IO(Flipped(new FooModuleIO))
       }
       class Top extends Module {
         val foo = Module(new FooModule)
-        val mirror = Module(new FooMirrorBlackBox())
+        val mirror = Module(new FooMirrorBlackBox)
         foo.io <> mirror.io
-        foo.io <> DontCare
       }
     }
-    compile(new Chisel3.Top)
+    val chirrtl = emitChirrtl(new Chisel3.Top)
+    chirrtl should include("foo.io.bar <= mirror.bar")
+    chirrtl should include("mirror.foo <= foo.io.foo")
+    chirrtl should include("foo.io.quz.q.bits <- mirror.quz.q.bits")
+    chirrtl should include("foo.io.quz.q.valid <= mirror.quz.q.valid")
   }
 
   "A chisel3.Bundle bulk connected to a Chisel Bundle in either direction" should "work even with mismatched fields" in {

--- a/src/test/scala/chiselTests/CompatibilityInteroperabilitySpec.scala
+++ b/src/test/scala/chiselTests/CompatibilityInteroperabilitySpec.scala
@@ -428,10 +428,6 @@ class CompatibilityInteroperabilitySpec extends ChiselFlatSpec {
         io <> DontCare
       }
 
-      class FooMirrorModule extends Module {
-        val io = IO(Flipped(new FooModuleIO()))
-        io <> DontCare
-      }
       class FooMirrorBlackBox extends BlackBox {
         val io = IO(Flipped(new FooModuleIO()))
       }
@@ -439,14 +435,8 @@ class CompatibilityInteroperabilitySpec extends ChiselFlatSpec {
       class Top() extends Module {
 
         val foo = Module(new FooModule)
-        //val mirror = Module(new FooMirrorBlackBox)
-        val mirror = Module(new FooMirrorModule())
+        val mirror = Module(new FooMirrorBlackBox())
         foo.io <> mirror.io
-        // foo.io <> mirror.io
-        // foo.io is 'aligned' and mirror is 'flipped' so this would be determined by BiConnect to be equivalent to:
-        // mirror.io :<>= foo.io
-        // mirror.io.quz is Input, so should be flipped again...
-        // but specified Direction of .quz is Input?? why is it not a ChildBinding?
         foo.io <> DontCare
       }
     }

--- a/src/test/scala/chiselTests/CompatibilityInteroperabilitySpec.scala
+++ b/src/test/scala/chiselTests/CompatibilityInteroperabilitySpec.scala
@@ -338,7 +338,7 @@ class CompatibilityInteroperabilitySpec extends ChiselFlatSpec {
         c2.deq <> deq
       }
     }
-    
+
   }
 
   "A unidirectional but flipped Bundle" should "bulk connect in import chisel3._ code correctly" in {


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [N/A] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
   - bug fix                           
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

This will correctly get the direction of the `<-` right when there are `Input` or `Output` that coerce parts of compatibility mode Bundles that connect to Black Box IOs. (non BB or chisel3._ Ios would just emit `<=` properly, but if we were dropping into the field-by-field case the flip was wrong).

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

This doesnt change emitted verilog because the failing cases prevented generation of verilog

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
  - Squash: The PR will be squashed and merged (choose this if you have no preference. 
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

- Fix #2796, Correct directionality for <> to black box IO which contains Chisel.Bundle and coerced Input/Output subfields.
- Also minor improvement to getClassName especially useful in test case printf debugging

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
