### PR TITLE
Deprecate Fixed Point and Intervals

### DIFF
--- a/core/src/main/scala/chisel3/Bits.scala
+++ b/core/src/main/scala/chisel3/Bits.scala
@@ -1852,11 +1852,13 @@ package experimental {
     *
     * @param range       a range specifies min, max and binary point
     */
+  @deprecated(deprecatedMFCMessage, "Chisel 3.6")
   sealed class Interval private[chisel3] (val range: chisel3.internal.firrtl.IntervalRange)
       extends Bits(range.getWidth)
       with Num[Interval]
       with HasBinaryPoint {
 
+    @deprecated(deprecatedMFCMessage, "Chisel 3.6")
     override def toString: String = {
       litOption match {
         case Some(value) => s"Interval$width($value)"
@@ -1864,9 +1866,11 @@ package experimental {
       }
     }
 
+    @deprecated(deprecatedMFCMessage, "Chisel 3.6")
     private[chisel3] override def cloneTypeWidth(w: Width): this.type =
       new Interval(range).asInstanceOf[this.type]
 
+    @deprecated(deprecatedMFCMessage, "Chisel 3.6")
     def toType: String = {
       val zdec1 = """([+\-]?[0-9]\d*)(\.[0-9]*[1-9])(0*)""".r
       val zdec2 = """([+\-]?[0-9]\d*)(\.0*)""".r
@@ -1902,8 +1906,10 @@ package experimental {
     private[chisel3] override def typeEquivalent(that: Data): Boolean =
       that.isInstanceOf[Interval] && this.width == that.width
 
+    @deprecated(deprecatedMFCMessage, "Chisel 3.6")
     def binaryPoint: BinaryPoint = range.binaryPoint
 
+    @deprecated(deprecatedMFCMessage, "Chisel 3.6")
     override def connect(that: Data)(implicit sourceInfo: SourceInfo, connectCompileOptions: CompileOptions): Unit = {
       that match {
         case _: Interval | DontCare => super.connect(that)
@@ -1911,8 +1917,10 @@ package experimental {
       }
     }
 
+    @deprecated(deprecatedMFCMessage, "Chisel 3.6")
     final def unary_- : Interval = macro SourceInfoTransform.noArg
 
+    @deprecated(deprecatedMFCMessage, "Chisel 3.6")
     final def unary_-% : Interval = macro SourceInfoTransform.noArg
 
     /** @group SourceInfoTransformMacro */
@@ -1939,15 +1947,19 @@ package experimental {
       throwException(s"mod is illegal on Interval types")
 
     /** add (width +1) operator */
+    @deprecated(deprecatedMFCMessage, "Chisel 3.6")
     final def +&(that: Interval): Interval = macro SourceInfoTransform.thatArg
 
     /** add (no growth) operator */
+    @deprecated(deprecatedMFCMessage, "Chisel 3.6")
     final def +%(that: Interval): Interval = macro SourceInfoTransform.thatArg
 
     /** subtract (width +1) operator */
+    @deprecated(deprecatedMFCMessage, "Chisel 3.6")
     final def -&(that: Interval): Interval = macro SourceInfoTransform.thatArg
 
     /** subtract (no growth) operator */
+    @deprecated(deprecatedMFCMessage, "Chisel 3.6")
     final def -%(that: Interval): Interval = macro SourceInfoTransform.thatArg
 
     def do_+&(that: Interval)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Interval = {
@@ -1966,8 +1978,11 @@ package experimental {
       throwException(s"Non-growing subtraction is not supported on Intervals: ${sourceInfo}, try squeeze")
     }
 
+    @deprecated(deprecatedMFCMessage, "Chisel 3.6")
     final def &(that: Interval): Interval = macro SourceInfoTransform.thatArg
+    @deprecated(deprecatedMFCMessage, "Chisel 3.6")
     final def |(that: Interval): Interval = macro SourceInfoTransform.thatArg
+    @deprecated(deprecatedMFCMessage, "Chisel 3.6")
     final def ^(that: Interval): Interval = macro SourceInfoTransform.thatArg
 
     def do_&(that: Interval)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Interval =
@@ -1977,6 +1992,7 @@ package experimental {
     def do_^(that: Interval)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Interval =
       throwException(s"Xor is illegal between $this and $that")
 
+    @deprecated(deprecatedMFCMessage, "Chisel 3.6")
     final def setPrecision(that: Int): Interval = macro SourceInfoTransform.thatArg
 
     // Precision change changes range -- see firrtl PrimOps (requires floor)
@@ -1992,6 +2008,7 @@ package experimental {
       * @param that    how many bits to shift binary point
       * @return
       */
+    @deprecated(deprecatedMFCMessage, "Chisel 3.6")
     final def increasePrecision(that: Int): Interval = macro SourceInfoTransform.thatArg
 
     def do_increasePrecision(that: Int)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Interval = {
@@ -2007,6 +2024,7 @@ package experimental {
       * @param that    number of bits to move binary point
       * @return
       */
+    @deprecated(deprecatedMFCMessage, "Chisel 3.6")
     final def decreasePrecision(that: Int): Interval = macro SourceInfoTransform.thatArg
 
     def do_decreasePrecision(that: Int)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Interval = {
@@ -2029,8 +2047,11 @@ package experimental {
     override def do_>=(that: Interval)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool =
       compop(sourceInfo, GreaterEqOp, that)
 
-    final def !=(that:  Interval): Bool = macro SourceInfoTransform.thatArg
+    @deprecated(deprecatedMFCMessage, "Chisel 3.6")
+    final def !=(that: Interval): Bool = macro SourceInfoTransform.thatArg
+    @deprecated(deprecatedMFCMessage, "Chisel 3.6")
     final def =/=(that: Interval): Bool = macro SourceInfoTransform.thatArg
+    @deprecated(deprecatedMFCMessage, "Chisel 3.6")
     final def ===(that: Interval): Bool = macro SourceInfoTransform.thatArg
 
     def do_!=(that: Interval)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool =
@@ -2075,6 +2096,7 @@ package experimental {
       * @param that
       * @return
       */
+    @deprecated(deprecatedMFCMessage, "Chisel 3.6")
     final def squeeze(that: Interval): Interval = macro SourceInfoTransform.thatArg
     def do_squeeze(that: Interval)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Interval = {
       val other = that
@@ -2091,6 +2113,7 @@ package experimental {
       * @param that an UInt whose properties determine the squeezing
       * @return
       */
+    @deprecated(deprecatedMFCMessage, "Chisel 3.6")
     final def squeeze(that: UInt): Interval = macro SourceInfoTransform.thatArg
     def do_squeeze(that: UInt)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Interval = {
       that.widthOption match {
@@ -2109,6 +2132,7 @@ package experimental {
       * @param that an SInt whose properties determine the squeezing
       * @return
       */
+    @deprecated(deprecatedMFCMessage, "Chisel 3.6")
     final def squeeze(that: SInt): Interval = macro SourceInfoTransform.thatArg
     def do_squeeze(that: SInt)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Interval = {
       that.widthOption match {
@@ -2127,6 +2151,7 @@ package experimental {
       * @param that an Interval whose properties determine the squeezing
       * @return
       */
+    @deprecated(deprecatedMFCMessage, "Chisel 3.6")
     final def squeeze(that: IntervalRange): Interval = macro SourceInfoTransform.thatArg
     def do_squeeze(that: IntervalRange)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Interval = {
       val intervalLitOpt = Interval.getSmallestLegalLit(that)
@@ -2143,6 +2168,7 @@ package experimental {
       * @param that
       * @return
       */
+    @deprecated(deprecatedMFCMessage, "Chisel 3.6")
     final def wrap(that: Interval): Interval = macro SourceInfoTransform.thatArg
 
     def do_wrap(that: Interval)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Interval = {
@@ -2158,6 +2184,7 @@ package experimental {
       * @param that an UInt whose properties determine the wrap
       * @return
       */
+    @deprecated(deprecatedMFCMessage, "Chisel 3.6")
     final def wrap(that: UInt): Interval = macro SourceInfoTransform.thatArg
     def do_wrap(that: UInt)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Interval = {
       that.widthOption match {
@@ -2175,6 +2202,7 @@ package experimental {
       * @param that an SInt whose properties determine the bounds of the wrap
       * @return
       */
+    @deprecated(deprecatedMFCMessage, "Chisel 3.6")
     final def wrap(that: SInt): Interval = macro SourceInfoTransform.thatArg
     def do_wrap(that: SInt)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Interval = {
       that.widthOption match {
@@ -2195,6 +2223,7 @@ package experimental {
       * @param that an Interval whose properties determine the bounds of the wrap
       * @return
       */
+    @deprecated(deprecatedMFCMessage, "Chisel 3.6")
     final def wrap(that: IntervalRange): Interval = macro SourceInfoTransform.thatArg
     def do_wrap(that: IntervalRange)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Interval = {
       (that.lowerBound, that.upperBound) match {
@@ -2212,6 +2241,7 @@ package experimental {
       * @param that an Interval whose properties determine the clipping
       * @return
       */
+    @deprecated(deprecatedMFCMessage, "Chisel 3.6")
     final def clip(that: Interval): Interval = macro SourceInfoTransform.thatArg
     def do_clip(that: Interval)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Interval = {
       binop(sourceInfo, Interval(this.range.clip(that.range)), ClipOp, that)
@@ -2223,6 +2253,7 @@ package experimental {
       * @param that an UInt whose width determines the clipping
       * @return
       */
+    @deprecated(deprecatedMFCMessage, "Chisel 3.6")
     final def clip(that: UInt): Interval = macro SourceInfoTransform.thatArg
     def do_clip(that: UInt)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Interval = {
       require(that.widthKnown, "UInt clip width must be known")
@@ -2236,6 +2267,7 @@ package experimental {
       * @param that   an SInt whose width determines the clipping
       * @return
       */
+    @deprecated(deprecatedMFCMessage, "Chisel 3.6")
     final def clip(that: SInt): Interval = macro SourceInfoTransform.thatArg
     def do_clip(that: SInt)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Interval = {
       require(that.widthKnown, "SInt clip width must be known")
@@ -2251,6 +2283,7 @@ package experimental {
       * @param that   an SInt whose width determines the clipping
       * @return
       */
+    @deprecated(deprecatedMFCMessage, "Chisel 3.6")
     final def clip(that: IntervalRange): Interval = macro SourceInfoTransform.thatArg
     def do_clip(that: IntervalRange)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Interval = {
       (that.lowerBound, that.upperBound) match {
@@ -2319,12 +2352,15 @@ package experimental {
     * Factory and convenience methods for the Interval class
     * IMPORTANT: The API provided here is experimental and may change in the future.
     */
+  @deprecated(deprecatedMFCMessage, "Chisel 3.6")
   object Interval extends NumObject {
 
     /** Create an Interval type with inferred width and binary point. */
+    @deprecated(deprecatedMFCMessage, "Chisel 3.6")
     def apply(): Interval = Interval(range"[?,?]")
 
     /** Create an Interval type with specified width. */
+    @deprecated(deprecatedMFCMessage, "Chisel 3.6")
     def apply(binaryPoint: BinaryPoint): Interval = {
       val binaryPointString = binaryPoint match {
         case KnownBinaryPoint(value) => s"$value"
@@ -2334,9 +2370,11 @@ package experimental {
     }
 
     /** Create an Interval type with specified width. */
+    @deprecated(deprecatedMFCMessage, "Chisel 3.6")
     def apply(width: Width): Interval = Interval(width, 0.BP)
 
     /** Create an Interval type with specified width and binary point */
+    @deprecated(deprecatedMFCMessage, "Chisel 3.6")
     def apply(width: Width, binaryPoint: BinaryPoint): Interval = {
       Interval(IntervalRange(width, binaryPoint))
     }
@@ -2344,11 +2382,13 @@ package experimental {
     /** Create an Interval type with specified range.
       * @param range  defines the properties
       */
+    @deprecated(deprecatedMFCMessage, "Chisel 3.6")
     def apply(range: IntervalRange): Interval = {
       new Interval(range)
     }
 
     /** Creates a Interval connected to a Interval literal with the value zero */
+    @deprecated(deprecatedMFCMessage, "Chisel 3.6")
     def Zero: Interval = Lit(0, 1.W, 0.BP)
 
     /** Creates an Interval zero that supports the given range
@@ -2359,6 +2399,7 @@ package experimental {
       * @param range
       * @return
       */
+    @deprecated(deprecatedMFCMessage, "Chisel 3.6")
     def Zero(range: IntervalRange): Interval = Lit(0, range)
 
     /** Make an interval from this BigInt, the BigInt is treated as bits
@@ -2369,6 +2410,7 @@ package experimental {
       * @param binaryPoint
       * @return
       */
+    @deprecated(deprecatedMFCMessage, "Chisel 3.6")
     def fromBigInt(value: BigInt, width: Width = Width(), binaryPoint: BinaryPoint = 0.BP): Interval = {
       Interval.Lit(value, Width(), binaryPoint)
     }
@@ -2376,6 +2418,7 @@ package experimental {
     /** Create an Interval literal with inferred width from Double.
       * Use PrivateObject to force users to specify width and binaryPoint by name
       */
+    @deprecated(deprecatedMFCMessage, "Chisel 3.6")
     def fromDouble(
       value:       Double,
       dummy:       PrivateType = PrivateObject,
@@ -2392,6 +2435,7 @@ package experimental {
     /** Create an Interval literal with inferred width from Double.
       * Use PrivateObject to force users to specify width and binaryPoint by name
       */
+    @deprecated(deprecatedMFCMessage, "Chisel 3.6")
     def fromBigDecimal(
       value:       Double,
       dummy:       PrivateType = PrivateObject,
@@ -2446,6 +2490,7 @@ package experimental {
       * @param range use to figure low number
       * @return
       */
+    @deprecated(deprecatedMFCMessage, "Chisel 3.6")
     def getSmallestLegalLit(range: IntervalRange): Option[Interval] = {
       val bp = range.binaryPoint
       range.lowerBound match {
@@ -2465,6 +2510,7 @@ package experimental {
       * @param range use to figure low number
       * @return
       */
+    @deprecated(deprecatedMFCMessage, "Chisel 3.6")
     def getLargestLegalLit(range: IntervalRange): Option[Interval] = {
       val bp = range.binaryPoint
       range.upperBound match {
@@ -2484,46 +2530,60 @@ package experimental {
       *   val y = 7.5.I(4.BP)
       * }}}
       */
+    @deprecated(deprecatedMFCMessage, "Chisel 3.6")
     object Implicits {
+      @deprecated(deprecatedMFCMessage, "Chisel 3.6")
       implicit class fromBigIntToLiteralInterval(bigInt: BigInt) {
+        @deprecated(deprecatedMFCMessage, "Chisel 3.6")
         def I: Interval = {
           Interval.Lit(bigInt, width = Width(), 0.BP)
         }
 
+        @deprecated(deprecatedMFCMessage, "Chisel 3.6")
         def I(binaryPoint: BinaryPoint): Interval = {
           Interval.Lit(bigInt, width = Width(), binaryPoint = binaryPoint)
         }
 
+        @deprecated(deprecatedMFCMessage, "Chisel 3.6")
         def I(width: Width, binaryPoint: BinaryPoint): Interval = {
           Interval.Lit(bigInt, width, binaryPoint)
         }
 
+        @deprecated(deprecatedMFCMessage, "Chisel 3.6")
         def I(range: IntervalRange): Interval = {
           Interval.Lit(bigInt, range)
         }
       }
 
+      @deprecated(deprecatedMFCMessage, "Chisel 3.6")
       implicit class fromIntToLiteralInterval(int: Int) extends fromBigIntToLiteralInterval(int)
+      @deprecated(deprecatedMFCMessage, "Chisel 3.6")
       implicit class fromLongToLiteralInterval(long: Long) extends fromBigIntToLiteralInterval(long)
 
+      @deprecated(deprecatedMFCMessage, "Chisel 3.6")
       implicit class fromBigDecimalToLiteralInterval(bigDecimal: BigDecimal) {
+        @deprecated(deprecatedMFCMessage, "Chisel 3.6")
         def I: Interval = {
           Interval.Lit(Interval.toBigInt(bigDecimal, 0.BP), width = Width(), 0.BP)
         }
 
+        @deprecated(deprecatedMFCMessage, "Chisel 3.6")
         def I(binaryPoint: BinaryPoint): Interval = {
           Interval.Lit(Interval.toBigInt(bigDecimal, binaryPoint), width = Width(), binaryPoint = binaryPoint)
         }
 
+        @deprecated(deprecatedMFCMessage, "Chisel 3.6")
         def I(width: Width, binaryPoint: BinaryPoint): Interval = {
           Interval.Lit(Interval.toBigInt(bigDecimal, binaryPoint), width, binaryPoint)
         }
 
+        @deprecated(deprecatedMFCMessage, "Chisel 3.6")
         def I(range: IntervalRange): Interval = {
           Interval.Lit(Interval.toBigInt(bigDecimal, range.binaryPoint), range)
         }
       }
 
+      @deprecated(deprecatedMFCMessage, "Chisel 3.6")
       implicit class fromDoubleToLiteralInterval(double: Double)
           extends fromBigDecimalToLiteralInterval(BigDecimal(double))
     }

--- a/core/src/main/scala/chisel3/Bits.scala
+++ b/core/src/main/scala/chisel3/Bits.scala
@@ -1310,12 +1310,15 @@ package experimental {
   /** Chisel types that have binary points support retrieving
     * literal values as `Double` or `BigDecimal`
     */
+  @deprecated(deprecatedMFCMessage, "Chisel 3.6")
   trait HasBinaryPoint { self: Bits =>
+    @deprecated(deprecatedMFCMessage, "Chisel 3.6")
     def binaryPoint: BinaryPoint
 
     /** Return the [[Double]] value of this instance if it is a Literal
       * @note this method may throw an exception if the literal value won't fit in a Double
       */
+    @deprecated(deprecatedMFCMessage, "Chisel 3.6")
     def litToDoubleOption: Option[Double] = {
       litOption match {
         case Some(bigInt: BigInt) =>
@@ -1326,11 +1329,13 @@ package experimental {
 
     /** Return the double value of this instance assuming it is a literal (convenience method)
       */
+    @deprecated(deprecatedMFCMessage, "Chisel 3.6")
     def litToDouble: Double = litToDoubleOption.get
 
     /** Return the [[BigDecimal]] value of this instance if it is a Literal
       * @note this method may throw an exception if the literal value won't fit in a BigDecimal
       */
+    @deprecated(deprecatedMFCMessage, "Chisel 3.6")
     def litToBigDecimalOption: Option[BigDecimal] = {
       litOption match {
         case Some(bigInt: BigInt) =>
@@ -1342,6 +1347,7 @@ package experimental {
     /** Return the [[BigDecimal]] value of this instance assuming it is a literal (convenience method)
       * @return
       */
+    @deprecated(deprecatedMFCMessage, "Chisel 3.6")
     def litToBigDecimal: BigDecimal = litToBigDecimalOption.get
   }
 
@@ -1359,6 +1365,7 @@ package experimental {
     * @define expandingWidth @note The width of the returned $coll is `width of this` + `1`.
     * @define constantWidth  @note The width of the returned $coll is unchanged, i.e., `width of this`.
     */
+  @deprecated(deprecatedMFCMessage, "Chisel 3.6")
   sealed class FixedPoint private (width: Width, val binaryPoint: BinaryPoint)
       extends Bits(width)
       with Num[FixedPoint]
@@ -1724,19 +1731,23 @@ package experimental {
     * Factory and convenience methods for the FixedPoint class
     * IMPORTANT: The API provided here is experimental and may change in the future.
     */
+  @deprecated(deprecatedMFCMessage, "Chisel 3.6")
   object FixedPoint extends NumObject {
 
     import FixedPoint.Implicits._
 
     /** Create an FixedPoint type with inferred width. */
+    @deprecated(deprecatedMFCMessage, "Chisel 3.6")
     def apply(): FixedPoint = apply(Width(), BinaryPoint())
 
     /** Create an FixedPoint type or port with fixed width. */
+    @deprecated(deprecatedMFCMessage, "Chisel 3.6")
     def apply(width: Width, binaryPoint: BinaryPoint): FixedPoint = new FixedPoint(width, binaryPoint)
 
     /** Create an FixedPoint literal with inferred width from BigInt.
       * Use PrivateObject to force users to specify width and binaryPoint by name
       */
+    @deprecated(deprecatedMFCMessage, "Chisel 3.6")
     def fromBigInt(value: BigInt, width: Width, binaryPoint: BinaryPoint): FixedPoint = {
       apply(value, width, binaryPoint)
     }
@@ -1744,6 +1755,7 @@ package experimental {
     /** Create an FixedPoint literal with inferred width from BigInt.
       * Use PrivateObject to force users to specify width and binaryPoint by name
       */
+    @deprecated(deprecatedMFCMessage, "Chisel 3.6")
     def fromBigInt(value: BigInt, binaryPoint: BinaryPoint = 0.BP): FixedPoint = {
       apply(value, Width(), binaryPoint)
     }
@@ -1751,6 +1763,7 @@ package experimental {
     /** Create an FixedPoint literal with inferred width from BigInt.
       * Use PrivateObject to force users to specify width and binaryPoint by name
       */
+    @deprecated(deprecatedMFCMessage, "Chisel 3.6")
     def fromBigInt(value: BigInt, width: Int, binaryPoint: Int): FixedPoint =
       if (width == -1) {
         apply(value, Width(), BinaryPoint(binaryPoint))
@@ -1761,6 +1774,7 @@ package experimental {
     /** Create an FixedPoint literal with inferred width from Double.
       * Use PrivateObject to force users to specify width and binaryPoint by name
       */
+    @deprecated(deprecatedMFCMessage, "Chisel 3.6")
     def fromDouble(value: Double, width: Width, binaryPoint: BinaryPoint): FixedPoint = {
       fromBigInt(
         toBigInt(value, binaryPoint.get),
@@ -1772,6 +1786,7 @@ package experimental {
     /** Create an FixedPoint literal with inferred width from BigDecimal.
       * Use PrivateObject to force users to specify width and binaryPoint by name
       */
+    @deprecated(deprecatedMFCMessage, "Chisel 3.6")
     def fromBigDecimal(value: BigDecimal, width: Width, binaryPoint: BinaryPoint): FixedPoint = {
       fromBigInt(
         toBigInt(value, binaryPoint.get),
@@ -1781,6 +1796,7 @@ package experimental {
     }
 
     /** Create an FixedPoint port with specified width and binary position. */
+    @deprecated(deprecatedMFCMessage, "Chisel 3.6")
     def apply(value: BigInt, width: Width, binaryPoint: BinaryPoint): FixedPoint = {
       val lit = FPLit(value, width, binaryPoint)
       val newLiteral = new FixedPoint(lit.width, lit.binaryPoint)
@@ -1788,23 +1804,30 @@ package experimental {
       lit.bindLitArg(newLiteral)
     }
 
+    @deprecated(deprecatedMFCMessage, "Chisel 3.6")
     object Implicits {
 
+      @deprecated(deprecatedMFCMessage, "Chisel 3.6")
       implicit class fromDoubleToLiteral(double: Double) {
+        @deprecated(deprecatedMFCMessage, "Chisel 3.6")
         def F(binaryPoint: BinaryPoint): FixedPoint = {
           FixedPoint.fromDouble(double, Width(), binaryPoint)
         }
 
+        @deprecated(deprecatedMFCMessage, "Chisel 3.6")
         def F(width: Width, binaryPoint: BinaryPoint): FixedPoint = {
           FixedPoint.fromDouble(double, width, binaryPoint)
         }
       }
 
+      @deprecated(deprecatedMFCMessage, "Chisel 3.6")
       implicit class fromBigDecimalToLiteral(bigDecimal: BigDecimal) {
+        @deprecated(deprecatedMFCMessage, "Chisel 3.6")
         def F(binaryPoint: BinaryPoint): FixedPoint = {
           FixedPoint.fromBigDecimal(bigDecimal, Width(), binaryPoint)
         }
 
+        @deprecated(deprecatedMFCMessage, "Chisel 3.6")
         def F(width: Width, binaryPoint: BinaryPoint): FixedPoint = {
           FixedPoint.fromBigDecimal(bigDecimal, width, binaryPoint)
         }

--- a/core/src/main/scala/chisel3/package.scala
+++ b/core/src/main/scala/chisel3/package.scala
@@ -358,4 +358,7 @@ package object chisel3 {
   // Connection exceptions.
   case class BiConnectException(message: String) extends ChiselException(message)
   case class MonoConnectException(message: String) extends ChiselException(message)
+
+  final val deprecatedMFCMessage =
+    "this feature will not be supported as part of the migration to the MLIR-based FIRRTL Compiler (MFC). For more information about this migration, please see the Chisel ROADMAP.md."
 }


### PR DESCRIPTION
Deprecate Fixed Point types and Interval types.

This is the first of several PRs that are implementing the [Chisel Roadmap](https://github.com/chipsalliance/chisel3/blob/master/ROADMAP.md) plan to migrate to the MLIR-based FIRRTL Compiler. For more information, please see the referenced roadmap.