### PR TITLE
Deprecate EnumAnnotations

### DIFF
--- a/core/src/main/scala/chisel3/StrongEnum.scala
+++ b/core/src/main/scala/chisel3/StrongEnum.scala
@@ -13,6 +13,7 @@ import chisel3.internal.sourceinfo._
 import chisel3.internal.{throwException, Binding, Builder, ChildBinding, ConstrainedBinding, InstanceId}
 import firrtl.annotations._
 
+@deprecated(deprecatedMFCMessage, "Chisel 3.6")
 object EnumAnnotations {
 
   /** An annotation for strong enum instances that are ''not'' inside of Vecs
@@ -20,10 +21,12 @@ object EnumAnnotations {
     * @param target the enum instance being annotated
     * @param enumTypeName the name of the enum's type (e.g. ''"mypackage.MyEnum"'')
     */
+  @deprecated(deprecatedMFCMessage, "Chisel 3.6")
   case class EnumComponentAnnotation(target: Named, enumTypeName: String) extends SingleTargetAnnotation[Named] {
     def duplicate(n: Named): EnumComponentAnnotation = this.copy(target = n)
   }
 
+  @deprecated(deprecatedMFCMessage, "Chisel 3.6")
   case class EnumComponentChiselAnnotation(target: InstanceId, enumTypeName: String) extends ChiselAnnotation {
     def toFirrtl: EnumComponentAnnotation = EnumComponentAnnotation(target.toNamed, enumTypeName)
   }
@@ -48,11 +51,13 @@ object EnumAnnotations {
     * @param typeName the name of the enum's type (e.g. ''"mypackage.MyEnum"'')
     * @param fields a list of all chains of elements leading from the Vec instance to its inner enum fields.
     */
+  @deprecated(deprecatedMFCMessage, "Chisel 3.6")
   case class EnumVecAnnotation(target: Named, typeName: String, fields: Seq[Seq[String]])
       extends SingleTargetAnnotation[Named] {
     def duplicate(n: Named): EnumVecAnnotation = this.copy(target = n)
   }
 
+  @deprecated(deprecatedMFCMessage, "Chisel 3.6")
   case class EnumVecChiselAnnotation(target: InstanceId, typeName: String, fields: Seq[Seq[String]])
       extends ChiselAnnotation {
     override def toFirrtl: EnumVecAnnotation = EnumVecAnnotation(target.toNamed, typeName, fields)
@@ -63,8 +68,10 @@ object EnumAnnotations {
     * @param typeName the name of the enum's type (e.g. ''"mypackage.MyEnum"'')
     * @param definition a map describing which integer values correspond to which enum names
     */
+  @deprecated(deprecatedMFCMessage, "Chisel 3.6")
   case class EnumDefAnnotation(typeName: String, definition: Map[String, BigInt]) extends NoTargetAnnotation
 
+  @deprecated(deprecatedMFCMessage, "Chisel 3.6")
   case class EnumDefChiselAnnotation(typeName: String, definition: Map[String, BigInt]) extends ChiselAnnotation {
     override def toFirrtl: Annotation = EnumDefAnnotation(typeName, definition)
   }


### PR DESCRIPTION
Deprecate EnumAnnotations as these are not plan-of-record for the MLIR-based FIRRTL Compiler migration.