### PR TITLE
Improve Record.bind and Detect Records with unstable elements

### DIFF
--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -28,7 +28,8 @@ sealed abstract class Aggregate extends Data {
     binding = target
 
     val resolvedDirection = SpecifiedDirection.fromParent(parentDirection, specifiedDirection)
-    val duplicates = getElements.groupBy(identity).collect { case (x, elts) if elts.size > 1 => x }
+    // TODO micro-optimize this, there's no reason to construct the Seq and resulting Map and Seqs
+    val duplicates = elementsIterator.toSeq.groupBy(identity).collect { case (x, elts) if elts.size > 1 => x }
     if (!duplicates.isEmpty) {
       this match {
         case b: Record =>
@@ -54,12 +55,12 @@ sealed abstract class Aggregate extends Data {
           )
       }
     }
-    for (child <- getElements) {
+    for (child <- elementsIterator) {
       child.bind(ChildBinding(this), resolvedDirection)
     }
 
     // Check that children obey the directionality rules.
-    val childDirections = getElements.map(_.direction).toSet - ActualDirection.Empty
+    val childDirections = elementsIterator.map(_.direction).toSet - ActualDirection.Empty
     direction = ActualDirection.fromChildren(childDirections, resolvedDirection) match {
       case Some(dir) => dir
       case None =>
@@ -102,7 +103,10 @@ sealed abstract class Aggregate extends Data {
     */
   def getElements: Seq[Data]
 
-  private[chisel3] def width: Width = getElements.map(_.width).foldLeft(0.W)(_ + _)
+  /** Similar to [[getElements]] but allows for more optimized use */
+  private[chisel3] def elementsIterator: Iterator[Data]
+
+  private[chisel3] def width: Width = elementsIterator.map(_.width).foldLeft(0.W)(_ + _)
 
   private[chisel3] def legacyConnect(that: Data)(implicit sourceInfo: SourceInfo): Unit = {
     // If the source is a DontCare, generate a DefInvalid for the sink,
@@ -223,7 +227,7 @@ sealed class Vec[T <: Data] private[chisel3] (gen: => T, val length: Int) extend
 
     val resolvedDirection = SpecifiedDirection.fromParent(parentDirection, specifiedDirection)
     sample_element.bind(SampleElementBinding(this), resolvedDirection)
-    for (child <- getElements) { // assume that all children are the same
+    for (child <- elementsIterator) { // assume that all children are the same
       child.bind(ChildBinding(this), resolvedDirection)
     }
 
@@ -344,8 +348,9 @@ sealed class Vec[T <: Data] private[chisel3] (gen: => T, val length: Int) extend
     new Vec(gen.cloneTypeFull, length).asInstanceOf[this.type]
   }
 
-  override def getElements: Seq[Data] =
-    (0 until length).map(apply(_))
+  override def getElements: Seq[Data] = self
+
+  override def elementsIterator: Iterator[Data] = self.iterator
 
   /** Default "pretty-print" implementation
     * Analogous to printing a Seq
@@ -1127,9 +1132,11 @@ abstract class Record(private[chisel3] implicit val compileOptions: CompileOptio
     case _ => false
   }
 
-  private[chisel3] final def allElements: Seq[Element] = elements.toIndexedSeq.flatMap(_._2.allElements)
+  private[chisel3] final def allElements: Seq[Element] = elementsIterator.flatMap(_.allElements).toIndexedSeq
 
-  override def getElements: Seq[Data] = elements.toIndexedSeq.map(_._2)
+  override def getElements: Seq[Data] = elementsIterator.toIndexedSeq
+
+  override def elementsIterator: Iterator[Data] = elements.iterator.map(_._2)
 
   // Helper because Bundle elements are reversed before printing
   private[chisel3] def toPrintableHelper(elts: Seq[(String, Data)]): Printable = {

--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -23,55 +23,6 @@ class AliasedAggregateFieldException(message: String) extends ChiselException(me
   * of) other Data objects.
   */
 sealed abstract class Aggregate extends Data {
-  private[chisel3] override def bind(target: Binding, parentDirection: SpecifiedDirection): Unit = {
-    _parent.foreach(_.addId(this))
-    binding = target
-
-    val resolvedDirection = SpecifiedDirection.fromParent(parentDirection, specifiedDirection)
-    // TODO micro-optimize this, there's no reason to construct the Seq and resulting Map and Seqs
-    val duplicates = elementsIterator.toSeq.groupBy(identity).collect { case (x, elts) if elts.size > 1 => x }
-    if (!duplicates.isEmpty) {
-      this match {
-        case b: Record =>
-          // show groups of names of fields with duplicate id's
-          // The sorts make the displayed order of fields deterministic and matching the order of occurrence in the Bundle.
-          // It's a bit convoluted but happens rarely and makes the error message easier to understand
-          val dupNames = duplicates.toSeq
-            .sortBy(_._id)
-            .map { duplicate =>
-              b.elements.collect { case x if x._2._id == duplicate._id => x }.toSeq
-                .sortBy(_._2._id)
-                .map(_._1)
-                .reverse
-                .mkString("(", ",", ")")
-            }
-            .mkString(",")
-          throw new AliasedAggregateFieldException(
-            s"${b.className} contains aliased fields named ${dupNames}"
-          )
-        case _ =>
-          throw new AliasedAggregateFieldException(
-            s"Aggregate ${this.getClass} contains aliased fields $duplicates ${duplicates.mkString(",")}"
-          )
-      }
-    }
-    for (child <- elementsIterator) {
-      child.bind(ChildBinding(this), resolvedDirection)
-    }
-
-    // Check that children obey the directionality rules.
-    val childDirections = elementsIterator.map(_.direction).toSet - ActualDirection.Empty
-    direction = ActualDirection.fromChildren(childDirections, resolvedDirection) match {
-      case Some(dir) => dir
-      case None =>
-        val resolvedDirection = SpecifiedDirection.fromParent(parentDirection, specifiedDirection)
-        resolvedDirection match {
-          case SpecifiedDirection.Unspecified => ActualDirection.Bidirectional(ActualDirection.Default)
-          case SpecifiedDirection.Flip        => ActualDirection.Bidirectional(ActualDirection.Flipped)
-          case _                              => ActualDirection.Bidirectional(ActualDirection.Default)
-        }
-    }
-  }
 
   /** Return an Aggregate's literal value if it is a literal, None otherwise.
     * If any element of the aggregate is not a literal with a defined width, the result isn't a literal.
@@ -961,7 +912,46 @@ abstract class Record(private[chisel3] implicit val compileOptions: CompileOptio
   }
 
   private[chisel3] override def bind(target: Binding, parentDirection: SpecifiedDirection): Unit = {
-    super.bind(target, parentDirection)
+    _parent.foreach(_.addId(this))
+    binding = target
+
+    val resolvedDirection = SpecifiedDirection.fromParent(parentDirection, specifiedDirection)
+    // TODO micro-optimize this, there's no reason to construct the Seq and resulting Map and Seqs
+    val duplicates = elementsIterator.toSeq.groupBy(identity).collect { case (x, elts) if elts.size > 1 => x }
+    if (!duplicates.isEmpty) {
+      // show groups of names of fields with duplicate id's
+      // The sorts make the displayed order of fields deterministic and matching the order of occurrence in the Bundle.
+      // It's a bit convoluted but happens rarely and makes the error message easier to understand
+      val dupNames = duplicates.toSeq
+        .sortBy(_._id)
+        .map { duplicate =>
+          this.elements.collect { case x if x._2._id == duplicate._id => x }.toSeq
+            .sortBy(_._2._id)
+            .map(_._1)
+            .reverse
+            .mkString("(", ",", ")")
+        }
+        .mkString(",")
+      throw new AliasedAggregateFieldException(
+        s"${this.className} contains aliased fields named ${dupNames}"
+      )
+    }
+    for (child <- elementsIterator) {
+      child.bind(ChildBinding(this), resolvedDirection)
+    }
+
+    // Check that children obey the directionality rules.
+    val childDirections = elementsIterator.map(_.direction).toSet - ActualDirection.Empty
+    direction = ActualDirection.fromChildren(childDirections, resolvedDirection) match {
+      case Some(dir) => dir
+      case None =>
+        val resolvedDirection = SpecifiedDirection.fromParent(parentDirection, specifiedDirection)
+        resolvedDirection match {
+          case SpecifiedDirection.Unspecified => ActualDirection.Bidirectional(ActualDirection.Default)
+          case SpecifiedDirection.Flip        => ActualDirection.Bidirectional(ActualDirection.Flipped)
+          case _                              => ActualDirection.Bidirectional(ActualDirection.Default)
+        }
+    }
     setElementRefs()
   }
 

--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -951,7 +951,12 @@ abstract class Record(private[chisel3] implicit val compileOptions: CompileOptio
 
     checkForAndReportDuplicates()
 
-    for (child <- elementsIterator) {
+    for ((child, sameChild) <- this.elementsIterator.zip(this.elementsIterator)) {
+      if (child != sameChild) {
+        throwException(
+          s"${this.className} does not return the same objects when calling .elements multiple times. Did you make it a def by mistake?"
+        )
+      }
       child.bind(ChildBinding(this), resolvedDirection)
     }
 

--- a/core/src/main/scala/chisel3/Data.scala
+++ b/core/src/main/scala/chisel3/Data.scala
@@ -355,7 +355,7 @@ private[chisel3] object getRecursiveFields {
         _ ++ _
       }
     case data: Vec[_] =>
-      data.getElements.zipWithIndex.map {
+      data.elementsIterator.zipWithIndex.map {
         case (fieldData, fieldIndex) =>
           getRecursiveFields(fieldData, path = s"$path($fieldIndex)")
       }.fold(Seq(data -> path)) {
@@ -373,7 +373,7 @@ private[chisel3] object getRecursiveFields {
         }
     case data: Vec[_] =>
       LazyList(data -> path) ++
-        data.getElements.view.zipWithIndex.flatMap {
+        data.elementsIterator.zipWithIndex.flatMap {
           case (fieldData, fieldIndex) =>
             getRecursiveFields(fieldData, path = s"$path($fieldIndex)")
         }
@@ -400,8 +400,8 @@ private[chisel3] object getMatchedFields {
           _ ++ _
         }
     case (x: Vec[_], y: Vec[_]) =>
-      (x.getElements
-        .zip(y.getElements))
+      (x.elementsIterator
+        .zip(y.elementsIterator))
         .map {
           case (xElt, yElt) =>
             getMatchedFields(xElt, yElt)
@@ -458,7 +458,7 @@ abstract class Data extends HasId with NamedComponent with SourceInfoDoc {
   @deprecated("pending removal once all instances replaced", "chisel3")
   private[chisel3] def flatten: IndexedSeq[Element] = {
     this match {
-      case elt: Aggregate => elt.getElements.toIndexedSeq.flatMap { _.flatten }
+      case elt: Aggregate => elt.elementsIterator.toIndexedSeq.flatMap { _.flatten }
       case elt: Element   => IndexedSeq(elt)
       case elt => throwException(s"Cannot flatten type ${elt.getClass}")
     }
@@ -751,7 +751,7 @@ abstract class Data extends HasId with NamedComponent with SourceInfoDoc {
       data match {
         case _:   Element =>
         case agg: Aggregate =>
-          agg.getElements.foreach(rec)
+          agg.elementsIterator.foreach(rec)
       }
     }
     rec(this)
@@ -933,8 +933,8 @@ object Data {
           if (thiz.length != that.length) {
             throwException(s"Cannot compare Vecs $thiz and $that: Vec sizes differ")
           } else {
-            thiz.getElements
-              .zip(that.getElements)
+            thiz.elementsIterator
+              .zip(that.elementsIterator)
               .map { case (thisData, thatData) => thisData === thatData }
               .reduce(_ && _)
           }

--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -540,9 +540,9 @@ package experimental {
               case SpecifiedDirection.Unspecified | SpecifiedDirection.Flip =>
                 data match {
                   case record: Record =>
-                    record.getElements.foreach(assignCompatDir(_))
+                    record.elementsIterator.foreach(assignCompatDir(_))
                   case vec: Vec[_] =>
-                    vec.getElements.foreach(assignCompatDir(_))
+                    vec.elementsIterator.foreach(assignCompatDir(_))
                 }
               case SpecifiedDirection.Input | SpecifiedDirection.Output =>
               // forced assign, nothing to do

--- a/core/src/main/scala/chisel3/experimental/Trace.scala
+++ b/core/src/main/scala/chisel3/experimental/Trace.scala
@@ -35,7 +35,7 @@ object Trace {
         annotate(new ChiselAnnotation {
           def toFirrtl: Annotation = TraceAnnotation(aggregate.toAbsoluteTarget, aggregate.toAbsoluteTarget)
         })
-        aggregate.getElements.foreach(traceName)
+        aggregate.elementsIterator.foreach(traceName)
       case element: Element =>
         annotate(new ChiselAnnotation {
           def toFirrtl: Annotation = TraceAnnotation(element.toAbsoluteTarget, element.toAbsoluteTarget)

--- a/src/main/scala/chisel3/aop/Select.scala
+++ b/src/main/scala/chisel3/aop/Select.scala
@@ -25,7 +25,7 @@ object Select {
     * @param d Component to find leafs if aggregate typed. Intermediate fields/indicies are not included
     */
   def getLeafs(d: Data): Seq[Data] = d match {
-    case r: Record => r.getElements.flatMap(getLeafs)
+    case r: Record => r.elementsIterator.flatMap(getLeafs).toSeq
     case v: Vec[_] => v.getElements.flatMap(getLeafs)
     case other => Seq(other)
   }
@@ -35,7 +35,7 @@ object Select {
     * @param d Component to find leafs if aggregate typed. Intermediate fields/indicies ARE included
     */
   def getIntermediateAndLeafs(d: Data): Seq[Data] = d match {
-    case r: Record => r +: r.getElements.flatMap(getIntermediateAndLeafs)
+    case r: Record => r +: r.elementsIterator.flatMap(getIntermediateAndLeafs).toSeq
     case v: Vec[_] => v +: v.getElements.flatMap(getIntermediateAndLeafs)
     case other => Seq(other)
   }

--- a/src/test/scala/chiselTests/RecordSpec.scala
+++ b/src/test/scala/chiselTests/RecordSpec.scala
@@ -324,4 +324,17 @@ class RecordSpec extends ChiselFlatSpec with RecordSpecUtils with Utils {
   "CustomBundle" should "check the types" in {
     ChiselStage.elaborate { new RecordTypeTester }
   }
+
+  "Record with unstable elements" should "error" in {
+    class MyRecord extends Record {
+      def elements = SeqMap("a" -> UInt(8.W))
+      override def cloneType: this.type = (new MyRecord).asInstanceOf[this.type]
+    }
+    val e = the[ChiselException] thrownBy {
+      ChiselStage.elaborate(new Module {
+        val io = IO(Input(new MyRecord))
+      })
+    }
+    e.getMessage should include("does not return the same objects when calling .elements multiple times")
+  }
 }


### PR DESCRIPTION
This is a slightly omnibus PR but it was motivated by a bug discovered by @azidar.
If you create a `Record` with `def elements` (and those elements are not referring to vals in the `Record`), you get a `None.get` during binding. In debugging and fixing this issue, I noticed several things that I decided to fix in this PR. Please see the separate commits as they are technically each different things but all chain together well.

1. I added `Aggregates.elementsIterator` and micro-optimized a few functions. This should prevent lots of eager `Seq` constructions.
2. I realized `Aggregate.bind` is only called by `Records` so I moved it into `Record`. This is just a clean up
3. I extracted some logic from `Record.bind` and micro-optimized it.
4. I added a check for the original bug 😇 

For the time being, I did not make the new `Aggregate.elementsIterator` public, but we could consider doing so.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
 - bug fix  
 - performance improvement 
 - code cleanup      


#### API Impact

No impact, just better error messages for some invalid Records

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

   - Rebase (merge commit please!)

#### Release Notes

Micro-optimize some Aggregate internals. Detect and error on Records whose `.elements` return different objects on each call.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
