### PR TITLE
Remove Misleading comments from CompatibilityInteroperabilitySpec.scala

### DIFF
--- a/src/test/scala/chiselTests/CompatibilityInteroperabilitySpec.scala
+++ b/src/test/scala/chiselTests/CompatibilityInteroperabilitySpec.scala
@@ -488,8 +488,6 @@ class CompatibilityInteroperabilitySpec extends ChiselFlatSpec {
 
   "A chisel3.Bundle with only unspecified directions" should "work with D/I" in {
 
-    // This test is NOT expected to work on 3.5.x, it should throw an error in the IO construction.
-
     object Chisel3 {
       import chisel3._
       import chisel3.experimental.hierarchy.{instantiable, public, Instance}
@@ -517,8 +515,6 @@ class CompatibilityInteroperabilitySpec extends ChiselFlatSpec {
   }
 
   "A chisel3.Bundle with mixed Specified and Unspecified directions" should "work with D/I" in {
-
-    // This test is NOT expected to work on 3.5.x, it should throw an error in the IO construction.
 
     object Chisel3 {
       import chisel3._
@@ -548,8 +544,6 @@ class CompatibilityInteroperabilitySpec extends ChiselFlatSpec {
 
   "A chisel3.Bundle with only unspecified vec direction" should "work with D/I" in {
 
-    // This test is NOT expected to work on 3.5.x, it should throw an error in the IO construction
-
     object Chisel3 {
       import chisel3._
       import chisel3.experimental.hierarchy.{instantiable, public, Instance}
@@ -577,8 +571,6 @@ class CompatibilityInteroperabilitySpec extends ChiselFlatSpec {
   }
 
   "A chisel3.Bundle with only unspecified vec direction within an unspecified direction parent Bundle" should "work with D/I" in {
-
-    // This test is NOT expected to work in 3.5.x, it should throw an error in the IO construction.
 
     object Chisel3 {
       import chisel3._
@@ -613,8 +605,6 @@ class CompatibilityInteroperabilitySpec extends ChiselFlatSpec {
 
   "A undirectioned Chisel.Bundle used in a MixedVec " should "bulk connect in import chisel3._ code correctly" in {
 
-    // This test is NOT expected to work on 3.5.x, it should throw an error in the IO construction.
-
     object Compat {
 
       import Chisel._
@@ -647,8 +637,6 @@ class CompatibilityInteroperabilitySpec extends ChiselFlatSpec {
   }
 
   "A undirectioned Chisel.Bundle with Records with undirectioned and directioned fields " should "work" in {
-
-    // This test should fail on 3.5.x
 
     object Compat {
 


### PR DESCRIPTION
### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [ ] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [ ] Did you state the API impact?
- [ ] Did you specify the code generation impact?
- [ ] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!-- - bug fix                            -->
<!--   - performance improvement            -->
   - documentation    
<!--   - code refactoring                   -->
  - code cleanup        
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
- Squash: The PR will be squashed and merged (choose this if you have no preference. 
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

Fix misleading comments about tests that dont' pass on 3.5.x because they actually do pass (for 3.5.5)

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
