### PR TITLE
fullModulePorts + Opaque Types Fix and Test

### DIFF
--- a/core/src/main/scala/chisel3/Data.scala
+++ b/core/src/main/scala/chisel3/Data.scala
@@ -258,8 +258,13 @@ package experimental {
     def fullModulePorts(target: BaseModule): Seq[(String, Data)] = {
       def getPortNames(name: String, data: Data): Seq[(String, Data)] = Seq(name -> data) ++ (data match {
         case _: Element => Seq()
-        case r: Record  => r.elements.toSeq.flatMap { case (eltName, elt) => getPortNames(s"${name}_${eltName}", elt) }
-        case v: Vec[_]  => v.zipWithIndex.flatMap { case (elt, index) => getPortNames(s"${name}_${index}", elt) }
+        case r: Record =>
+          r.elements.toSeq.flatMap {
+            case (eltName, elt) =>
+              if (r._isOpaqueType) { getPortNames(s"${name}", elt) }
+              else { getPortNames(s"${name}_${eltName}", elt) }
+          }
+        case v: Vec[_] => v.zipWithIndex.flatMap { case (elt, index) => getPortNames(s"${name}_${index}", elt) }
       })
       modulePorts(target).flatMap {
         case (name, data) =>

--- a/src/test/scala/chiselTests/RecordSpec.scala
+++ b/src/test/scala/chiselTests/RecordSpec.scala
@@ -285,6 +285,26 @@ class RecordSpec extends ChiselFlatSpec with RecordSpecUtils with Utils {
     testStrings.foreach(x => assert(x == "~NestedRecordModule|InnerModule>io.foo"))
   }
 
+  they should "work correctly with DataMirror in nested OpaqueType Records" in {
+    var mod: NestedRecordModule = null
+    ChiselStage.elaborate { mod = new NestedRecordModule; mod }
+    val ports = chisel3.experimental.DataMirror.fullModulePorts(mod.inst)
+    val expectedPorts = Seq(
+      ("clock", mod.inst.clock),
+      ("reset", mod.inst.reset),
+      ("io", mod.inst.io),
+      ("io_bar", mod.inst.io.bar),
+      ("io_bar", mod.inst.io.bar.k),
+      ("io_bar", mod.inst.io.bar.k.k),
+      ("io_bar", mod.inst.io.bar.k.k.elements.head._2),
+      ("io_foo", mod.inst.io.foo),
+      ("io_foo", mod.inst.io.foo.k),
+      ("io_foo", mod.inst.io.foo.k.k),
+      ("io_foo", mod.inst.io.foo.k.k.elements.head._2)
+    )
+    ports shouldBe expectedPorts
+  }
+
   they should "work correctly when connecting nested OpaqueType elements" in {
     val nestedRecordChirrtl = ChiselStage.emitChirrtl { new NestedRecordModule }
     nestedRecordChirrtl should include("input in : UInt<8>")


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
   - bug fix                  
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

Fixes https://github.com/chipsalliance/chisel3/issues/2844, corrects the string IO names from fullModulePorts.

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

Unless verilog was being generated by reflecting upon DataMirror.fullModulePorts returned values, no changes to emitted verilog.

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
 - Squash: The PR will be squashed and merged (choose this if you have no preference.
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
