### PR TITLE
Use SourceInfo in Builder error messages when available

### DIFF
--- a/core/src/main/scala/chisel3/Bits.scala
+++ b/core/src/main/scala/chisel3/Bits.scala
@@ -438,7 +438,7 @@ sealed abstract class Bits(private[chisel3] val width: Width) extends Element wi
   /** Default print as [[Decimal]] */
   final def toPrintable: Printable = Decimal(this)
 
-  protected final def validateShiftAmount(x: Int): Int = {
+  protected final def validateShiftAmount(x: Int)(implicit sourceInfo: SourceInfo): Int = {
     if (x < 0)
       Builder.error(s"Negative shift amounts are illegal (got $x)")
     x

--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -179,7 +179,7 @@ abstract class Module(implicit moduleCompileOptions: CompileOptions) extends Raw
         case _ => // Bad! It hasn't been migrated.
           Builder.error(
             s"$desiredName is not inferring its module reset, but has not been marked `RequireSyncReset`. Please extend this trait."
-          )
+          )(UnlocatableSourceInfo)
       }
     }
     if (inferReset) Reset() else Bool()
@@ -418,14 +418,14 @@ package experimental {
               Builder.error(
                 s"""Unable to name port $port to "$name" in $this,""" +
                   s" name is already taken by another port! ${source}"
-              )
+              )(UnlocatableSourceInfo)
             }
             port.setRef(ModuleIO(this, _namespace.name(name)))
           case None =>
             Builder.error(
               s"Unable to name port $port in $this, " +
                 s"try making it a public field of the Module $source"
-            )
+            )(UnlocatableSourceInfo)
             port.setRef(ModuleIO(this, "<UNNAMED>"))
         }
       }

--- a/core/src/main/scala/chisel3/RawModule.scala
+++ b/core/src/main/scala/chisel3/RawModule.scala
@@ -53,7 +53,7 @@ abstract class RawModule(implicit moduleCompileOptions: CompileOptions) extends 
         Builder.error(
           s"Unable to name port $port in $this, " +
             s"try making it a public field of the Module $source"
-        )
+        )(UnlocatableSourceInfo)
       }
     }
   }

--- a/core/src/main/scala/chisel3/package.scala
+++ b/core/src/main/scala/chisel3/package.scala
@@ -8,7 +8,7 @@ import scala.collection.mutable
   */
 package object chisel3 {
   import internal.chiselRuntimeDeprecated
-  import internal.sourceinfo.DeprecatedSourceInfo
+  import internal.sourceinfo.{DeprecatedSourceInfo, UnlocatableSourceInfo}
   import internal.firrtl.{Port, Width}
   import internal.Builder
 
@@ -38,7 +38,8 @@ package object chisel3 {
     def B: Bool = bigint match {
       case bigint if bigint == 0 => Bool.Lit(false)
       case bigint if bigint == 1 => Bool.Lit(true)
-      case bigint                => Builder.error(s"Cannot convert $bigint to Bool, must be 0 or 1"); Bool.Lit(false)
+      case bigint =>
+        Builder.error(s"Cannot convert $bigint to Bool, must be 0 or 1")(UnlocatableSourceInfo); Bool.Lit(false)
     }
 
     /** Int to UInt conversion, recommended style for constants. */
@@ -121,7 +122,7 @@ package object chisel3 {
         case "d"       => 10
         case "o"       => 8
         case "b"       => 2
-        case _         => Builder.error(s"Invalid base $base"); 2
+        case _         => Builder.error(s"Invalid base $base")(UnlocatableSourceInfo); 2
       }
       BigInt(num.filterNot(_ == '_'), radix)
     }

--- a/core/src/main/scala/chisel3/package.scala
+++ b/core/src/main/scala/chisel3/package.scala
@@ -39,7 +39,8 @@ package object chisel3 {
       case bigint if bigint == 0 => Bool.Lit(false)
       case bigint if bigint == 1 => Bool.Lit(true)
       case bigint =>
-        Builder.error(s"Cannot convert $bigint to Bool, must be 0 or 1")(UnlocatableSourceInfo); Bool.Lit(false)
+        Builder.error(s"Cannot convert $bigint to Bool, must be 0 or 1")(UnlocatableSourceInfo)
+        Bool.Lit(false)
     }
 
     /** Int to UInt conversion, recommended style for constants. */

--- a/src/test/scala/chiselTests/stage/ChiselMainSpec.scala
+++ b/src/test/scala/chiselTests/stage/ChiselMainSpec.scala
@@ -42,6 +42,12 @@ object ChiselMainSpec {
     val w = Wire(UInt(8.W))
     w(3, -1)
   }
+
+  /** A module that triggers a Builder.error without source info */
+  class BuilderErrorNoSourceInfoModule extends RawModule {
+    val w = Wire(Bool())
+    w := BigInt(2).B
+  }
 }
 
 case class TestClassAspect()
@@ -261,19 +267,33 @@ class ChiselMainSpec extends AnyFeatureSpec with GivenWhenThen with Matchers wit
       )
     ).foreach(runStageExpectException)
   }
-  Feature("Stack trace trimming and Builder.error errors") {
-    Seq(
+  Feature("Builder.error errors with source info") {
+    runStageExpectException(
       ChiselMainExceptionTest[chisel3.internal.ChiselException](
         args = Array("-X", "low"),
         generator = Some(classOf[BuilderErrorModule]),
         message = Seq(Right("Fatal errors during hardware elaboration")),
         stdout = Seq(
           Right(
-            "ChiselMainSpec.scala:43: Invalid bit range (3,-1) in class chiselTests.stage.ChiselMainSpec$BuilderErrorModule"
+            "src/test/scala/chiselTests/stage/ChiselMainSpec.scala:43:6: Invalid bit range (3,-1)"
           )
         )
       )
-    ).foreach(runStageExpectException)
+    )
+  }
+  Feature("Stack trace trimming and Builder.error errors") {
+    runStageExpectException(
+      ChiselMainExceptionTest[chisel3.internal.ChiselException](
+        args = Array("-X", "low"),
+        generator = Some(classOf[BuilderErrorNoSourceInfoModule]),
+        message = Seq(Right("Fatal errors during hardware elaboration")),
+        stdout = Seq(
+          Right(
+            "ChiselMainSpec.scala:49: Cannot convert 2 to Bool, must be 0 or 1"
+          )
+        )
+      )
+    )
   }
 
   Feature("Specifying a custom output file") {


### PR DESCRIPTION
This updates `Builder.error` and `Builder.warning` to take an implicit `SourceInfo` argument. 

`SourceInfo` of type `SourceLine` provides error messages with relative paths to the source file of the error as opposed to just the file basename, in addition to the column of the error occurrence.

If the `SourceInfo` is of type `NoSourceInfo`, the `ErrorLog` code falls back to the old behavior of looking up the source location via stack trace.

Furthermore, the deprecated `ErrorLog.info` method has been removed and the error message generating code has been simplified, removing the `LogEntry` class hierarchy which duplicated the error message tagging code found in `ErrorLog`.

One consequence of the changes is the removal of the `in class <class-name>` suffix in errors and warnings. `SourceLine` doesn't have this information and I'm not sure how helpful it is. Note that deprecation messages did not include this suffix anyway so things are more consistent this way at least.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
- logging improvements
- code cleanup
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact
This is internal only

#### Backend Code Generation Impact
None

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
- Squash: The PR will be squashed and merged

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
