### PR TITLE
Make PriorityMux stack safe

### DIFF
--- a/core/src/main/scala/chisel3/SeqUtils.scala
+++ b/core/src/main/scala/chisel3/SeqUtils.scala
@@ -64,7 +64,10 @@ private[chisel3] object SeqUtils {
     if (in.size == 1) {
       in.head._2
     } else {
-      Mux(in.head._1, in.head._2, priorityMux(in.tail))
+      val r = in.view.reverse
+      r.tail.foldLeft(r.head._2) {
+        case (alt, (sel, elt)) => Mux(sel, elt, alt)
+      }
     }
   }
 

--- a/src/test/scala/chiselTests/util/PipeSpec.scala
+++ b/src/test/scala/chiselTests/util/PipeSpec.scala
@@ -1,6 +1,6 @@
-package chiselTests.util
-
 // SPDX-License-Identifier: Apache-2.0
+
+package chiselTests.util
 
 import chisel3._
 import chisel3.util.{Pipe, Valid}

--- a/src/test/scala/chiselTests/util/PriorityMuxSpec.scala
+++ b/src/test/scala/chiselTests/util/PriorityMuxSpec.scala
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiselTests.util
+
+import chisel3._
+import chisel3.util.{is, switch, Counter, PriorityMux}
+import chisel3.testers.BasicTester
+import chisel3.stage.ChiselStage.emitChirrtl
+
+import chiselTests.ChiselFlatSpec
+
+class PriorityMuxTester extends BasicTester {
+
+  val sel = Wire(UInt(3.W))
+  sel := 0.U // default
+
+  val elts = Seq(5.U, 6.U, 7.U)
+  val muxed = PriorityMux(sel, elts)
+
+  // Priority is given to lowest order bit
+  val tests = Seq(
+    1.U -> elts(0),
+    2.U -> elts(1),
+    3.U -> elts(0),
+    4.U -> elts(2),
+    5.U -> elts(0),
+    6.U -> elts(1),
+    7.U -> elts(0)
+  )
+  val (cycle, done) = Counter(0 until tests.size + 1)
+
+  for (((in, out), idx) <- tests.zipWithIndex) {
+    when(cycle === idx.U) {
+      sel := in
+      assert(muxed === out)
+    }
+  }
+
+  when(done) {
+    stop()
+  }
+}
+
+class PriorityMuxSpec extends ChiselFlatSpec {
+  behavior.of("PriorityMux")
+
+  it should "be functionally correct" in {
+    assertTesterPasses(new PriorityMuxTester)
+  }
+
+  it should "be stack safe" in {
+    emitChirrtl(new RawModule {
+      val n = 1 << 15
+      val in = IO(Input(Vec(n, UInt(8.W))))
+      val sel = IO(Input(UInt(n.W)))
+      val out = IO(Output(UInt(8.W)))
+      out := PriorityMux(sel, in)
+    })
+  }
+}


### PR DESCRIPTION
It used to be implemented with recursion, now it's implemented with a stack safe reverse and foldLeft.

Also there were no tests for PriorityMux so I added one which helps prove the change is functionally correct.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

  - performance improvement  

#### API Impact

No impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

 - Squash

#### Release Notes

`PriorityMux` is now stack-safe and will not require users to increase their JVM's stack size when called with large inputs.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
