### PR TITLE
Unify BaseModule.IO and chisel3.experimental.IO into chisel3.IO

### DIFF
--- a/core/src/main/scala/chisel3/IO.scala
+++ b/core/src/main/scala/chisel3/IO.scala
@@ -1,0 +1,46 @@
+package chisel3
+
+import chisel3.internal.requireIsChiselType // Fix ambiguous import
+import chisel3.internal.Builder
+import chisel3.internal.sourceinfo.SourceInfo
+
+object IO {
+
+  /** Constructs a port for the current Module
+    *
+    * This must wrap the datatype used to set the io field of any Module.
+    * i.e. All concrete modules must have defined io in this form:
+    * [lazy] val io[: io type] = IO(...[: io type])
+    *
+    * Items in [] are optional.
+    *
+    * The granted iodef must be a chisel type and not be bound to hardware.
+    *
+    * Also registers a Data as a port, also performing bindings. Cannot be called once ports are
+    * requested (so that all calls to ports will return the same information).
+    * Internal API.
+    */
+  def apply[T <: Data](iodef: => T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T = {
+    val module = Module.currentModule.get // Impossible to fail
+    require(!module.isClosed, "Can't add more ports after module close")
+    val prevId = Builder.idGen.value
+    val data = iodef // evaluate once (passed by name)
+    requireIsChiselType(data, "io type")
+
+    // Clone the IO so we preserve immutability of data types
+    // Note: we don't clone if the data is fresh (to avoid unnecessary clones)
+    val iodefClone =
+      if (!data.mustClone(prevId)) data
+      else
+        try {
+          data.cloneTypeFull
+        } catch {
+          // For now this is going to be just a deprecation so we don't suddenly break everyone's code
+          case e: AutoClonetypeException =>
+            Builder.deprecated(e.getMessage, Some(s"${data.getClass}"))
+            data
+        }
+    module.bindIoInPlace(iodefClone)
+    iodefClone
+  }
+}

--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -200,47 +200,10 @@ abstract class Module(implicit moduleCompileOptions: CompileOptions) extends Raw
 }
 
 package experimental {
-
-  import chisel3.internal.requireIsChiselType // Fix ambiguous import
-
   object IO {
-
-    /** Constructs a port for the current Module
-      *
-      * This must wrap the datatype used to set the io field of any Module.
-      * i.e. All concrete modules must have defined io in this form:
-      * [lazy] val io[: io type] = IO(...[: io type])
-      *
-      * Items in [] are optional.
-      *
-      * The granted iodef must be a chisel type and not be bound to hardware.
-      *
-      * Also registers a Data as a port, also performing bindings. Cannot be called once ports are
-      * requested (so that all calls to ports will return the same information).
-      * Internal API.
-      */
+    @deprecated("chisel3.experimental.IO is deprecated, use chisel3.IO instead", "Chisel 3.5")
     def apply[T <: Data](iodef: => T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T = {
-      val module = Module.currentModule.get // Impossible to fail
-      require(!module.isClosed, "Can't add more ports after module close")
-      val prevId = Builder.idGen.value
-      val data = iodef // evaluate once (passed by name)
-      requireIsChiselType(data, "io type")
-
-      // Clone the IO so we preserve immutability of data types
-      // Note: we don't clone if the data is fresh (to avoid unnecessary clones)
-      val iodefClone =
-        if (!data.mustClone(prevId)) data
-        else
-          try {
-            data.cloneTypeFull
-          } catch {
-            // For now this is going to be just a deprecation so we don't suddenly break everyone's code
-            case e: AutoClonetypeException =>
-              Builder.deprecated(e.getMessage, Some(s"${data.getClass}"))
-              data
-          }
-      module.bindIoInPlace(iodefClone)
-      iodefClone
+      chisel3.IO.apply(iodef)
     }
   }
 }
@@ -599,7 +562,7 @@ package experimental {
       * are problematic.
       */
     protected def IO[T <: Data](iodef: => T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T = {
-      chisel3.experimental.IO.apply(iodef)
+      chisel3.IO.apply(iodef)
     }
 
     //

--- a/core/src/main/scala/chisel3/experimental/package.scala
+++ b/core/src/main/scala/chisel3/experimental/package.scala
@@ -72,7 +72,7 @@ package object experimental {
     val ports: Seq[Data] =
       gen.elements.toSeq.reverse.map {
         case (name, data) =>
-          val p = IO(coerceDirection(chiselTypeClone(data).asInstanceOf[Data]))
+          val p = chisel3.IO(coerceDirection(chiselTypeClone(data).asInstanceOf[Data]))
           p.suggestName(name)
           p
 


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
   - code refactoring          
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->
`chisel3.experimental.IO` will be deprecated and replaced by `chisel3.IO`

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->
N/A

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
  - Squash: The PR will be squashed and merged (choose this if you have no preference. 
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
The `IO` from `chisel3.experimental.IO` been deprecated in favor of `chisel3.IO`.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
