### PR TITLE
Optimize _ids

### DIFF
--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -184,7 +184,7 @@ sealed class Vec[T <: Data] private[chisel3] (gen: => T, val length: Int) extend
   }
 
   private[chisel3] override def bind(target: Binding, parentDirection: SpecifiedDirection): Unit = {
-    _parent.foreach(_.addId(this))
+    this.maybeAddToParentIds(target)
     binding = target
 
     val resolvedDirection = SpecifiedDirection.fromParent(parentDirection, specifiedDirection)
@@ -987,7 +987,7 @@ abstract class Record(private[chisel3] implicit val compileOptions: CompileOptio
   }
 
   private[chisel3] override def bind(target: Binding, parentDirection: SpecifiedDirection): Unit = {
-    _parent.foreach(_.addId(this))
+    this.maybeAddToParentIds(target)
     binding = target
 
     val resolvedDirection = SpecifiedDirection.fromParent(parentDirection, specifiedDirection)

--- a/core/src/main/scala/chisel3/Data.scala
+++ b/core/src/main/scala/chisel3/Data.scala
@@ -450,6 +450,14 @@ abstract class Data extends HasId with NamedComponent with SourceInfoDoc {
     */
   private[chisel3] def bind(target: Binding, parentDirection: SpecifiedDirection = SpecifiedDirection.Unspecified): Unit
 
+  /** Adds this `Data` to its parents _ids if it should be added */
+  private[chisel3] def maybeAddToParentIds(target: Binding): Unit = {
+    // ConstrainedBinding means the thing actually corresponds to a Module, no need to add to _ids otherwise
+    if (target.isInstanceOf[ConstrainedBinding]) {
+      _parent.foreach(_.addId(this))
+    }
+  }
+
   // Both _direction and _resolvedUserDirection are saved versions of computed variables (for
   // efficiency, avoid expensive recomputation of frequent operations).
   // Both are only valid after binding is set.

--- a/core/src/main/scala/chisel3/Element.scala
+++ b/core/src/main/scala/chisel3/Element.scala
@@ -18,7 +18,7 @@ abstract class Element extends Data {
   def name:                               String = getRef.name
 
   private[chisel3] override def bind(target: Binding, parentDirection: SpecifiedDirection): Unit = {
-    _parent.foreach(_.addId(this))
+    this.maybeAddToParentIds(target)
     binding = target
     val resolvedDirection = SpecifiedDirection.fromParent(parentDirection, specifiedDirection)
     direction = ActualDirection.fromSpecified(resolvedDirection)

--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -331,9 +331,9 @@ package experimental {
         _ids.maxBy(_._id)._id
     }
 
-    private[chisel3] def getIds = {
+    private[chisel3] def getIds: Iterable[HasId] = {
       require(_closed, "Can't get ids before module close")
-      _ids.toSeq
+      _ids
     }
 
     private val _ports = new ArrayBuffer[(Data, SourceInfo)]()

--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -326,9 +326,10 @@ package experimental {
     // Returns the last id contained within a Module
     private[chisel3] def _lastId: Long = _ids.last match {
       case mod: BaseModule => mod._lastId
-      case _ =>
-        // Ideally we could just take last._id, but Records store and thus bind their Data in reverse order
-        _ids.maxBy(_._id)._id
+      case agg: Aggregate  =>
+        // Ideally we could just take .last._id, but Records store their elements in reverse order
+        getRecursiveFields.lazily(agg, "").map(_._1._id).max
+      case other => other._id
     }
 
     private[chisel3] def getIds: Iterable[HasId] = {

--- a/core/src/main/scala/chisel3/experimental/Analog.scala
+++ b/core/src/main/scala/chisel3/experimental/Analog.scala
@@ -55,7 +55,7 @@ final class Analog private (private[chisel3] val width: Width) extends Element {
   // Define setter/getter pairing
   // Analog can only be bound to Ports and Wires (and Unbound)
   private[chisel3] override def bind(target: Binding, parentDirection: SpecifiedDirection): Unit = {
-    _parent.foreach(_.addId(this))
+    this.maybeAddToParentIds(target)
     SpecifiedDirection.fromParent(parentDirection, specifiedDirection) match {
       case SpecifiedDirection.Unspecified | SpecifiedDirection.Flip =>
       case x                                                        => throwException(s"Analog may not have explicit direction, got '$x'")

--- a/core/src/main/scala/chisel3/experimental/dataview/DataProduct.scala
+++ b/core/src/main/scala/chisel3/experimental/dataview/DataProduct.scala
@@ -68,7 +68,7 @@ object DataProduct extends LowPriorityDataProduct {
     def dataIterator(a: BaseModule, path: String): Iterator[(Data, String)] = {
       a.getIds.iterator.flatMap {
         case d: Data if d.getOptionRef.isDefined => // Using ref to decide if it's truly hardware in the module
-          Seq(d -> s"${path}.${d.instanceName}")
+          implicitly[DataProduct[Data]].dataIterator(d, s"${path}.${d.instanceName}")
         case b: BaseModule => dataIterator(b, s"$path.${b.instanceName}")
         case _ => Seq.empty
       }

--- a/src/test/scala/chiselTests/experimental/ModuleDataProductSpec.scala
+++ b/src/test/scala/chiselTests/experimental/ModuleDataProductSpec.scala
@@ -10,7 +10,7 @@ import chiselTests.ChiselFlatSpec
 object ModuleDataProductSpec {
   class MyBundle extends Bundle {
     val foo = UInt(8.W)
-    val bar = UInt(8.W)
+    val bar = Vec(1, UInt(8.W))
   }
   trait MyIntf extends BaseModule {
     val in = IO(Input(new MyBundle))
@@ -49,12 +49,15 @@ class ModuleDataProductSpec extends ChiselFlatSpec {
       m.in -> "m.in",
       m.in.foo -> "m.in.foo",
       m.in.bar -> "m.in.bar",
+      m.in.bar(0) -> "m.in.bar(0)",
       m.out -> "m.out",
       m.out.foo -> "m.out.foo",
       m.out.bar -> "m.out.bar",
+      m.out.bar(0) -> "m.out.bar(0)",
       m.r -> "m.r",
       m.r.foo -> "m.r.foo",
       m.r.bar -> "m.r.bar",
+      m.r.bar(0) -> "m.r.bar(0)",
       m.inst.in -> "m.inst.in",
       m.inst.out -> "m.inst.out"
     )
@@ -72,11 +75,13 @@ class ModuleDataProductSpec extends ChiselFlatSpec {
     val m = elaborateAndGetModule(new MyExtModuleWrapper).inst
     val expected = Seq(
       m.in -> "m.in",
-      m.in.foo -> "m.in.foo",
       m.in.bar -> "m.in.bar",
+      m.in.bar(0) -> "m.in.bar(0)",
+      m.in.foo -> "m.in.foo",
       m.out -> "m.out",
-      m.out.foo -> "m.out.foo",
-      m.out.bar -> "m.out.bar"
+      m.out.bar -> "m.out.bar",
+      m.out.bar(0) -> "m.out.bar(0)",
+      m.out.foo -> "m.out.foo"
     )
 
     val impl = implicitly[DataProduct[MyExtModule]]


### PR DESCRIPTION
Only add Data to _ids when the binding is constrained. ConstrainedBinding means that the bound Data is scoped to a module. Since _ids are used for naming of signals within a module, there is no reason to add Unconstrained Data to the _ids of the Module they were constructed during. Unconstrained Data include things like literals and children of Aggregates (which sort of are constrained to a Module but only via their parent, they are not directly named by the module).

Note that this cannot be backported because it breaks the naming of unnamed things which is deprecated in 3.5 (but still works).

I measured this for a balanced, large design and it reduced minimum memory use from ~8000 MiB to ~7500 MiB (~6.25%). It did not have a measurable impact on wall-clock performance, but does reduce total user time which does reduce overall system compute. I don't currently measure user time very scientifically, but it seems to reduce user time by ~6% which would make sense. So definitely a win.
 
### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

   - performance improvement

#### API Impact

There is a slight order change to the ordering of the `Data` in `DataProduct[BaseModule]`. This is due to the fact that `DataProduct[Data]` iterates on the elements of `Aggregates` in a slightly different order than the order those elements were added to the `_ids` of the parent `Module`. I think this is a fine tradeoff but it may be worth carefully considering the orders from `DataProduct` in case users may depend on them in the future.

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

#### Desired Merge Strategy

  - Squash

#### Release Notes

Reduce memory use of some internal data structures. Reduces memory use by ~6%. Slight change to ordering of `Data` in `DataProduct[BaseModule]`.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
