### PR TITLE
[mill] Restore defaultVersions for release automation

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -8,9 +8,23 @@ import mill.contrib.buildinfo.BuildInfo
 
 object chisel3 extends mill.Cross[chisel3CrossModule]("2.13.10", "2.12.17")
 
+// The following stanza is searched for and used when preparing releases.
+// Please retain it.
+// Provide a managed dependency on X if -DXVersion="" is supplied on the command line.
+val defaultVersions = Map(
+  "firrtl" -> "1.6-SNAPSHOT",
+  "treadle" -> "1.6-SNAPSHOT"
+)
+
+def getVersion(dep: String, org: String = "edu.berkeley.cs") = {
+  val version = sys.env.getOrElse(dep + "Version", defaultVersions(dep))
+  ivy"$org::$dep:$version"
+}
+// Do not remove the above logic, it is needed by the release automation
+
 object v {
-  val firrtl = ivy"edu.berkeley.cs::firrtl:1.6-SNAPSHOT"
-  val treadle = ivy"edu.berkeley.cs::treadle:1.6-SNAPSHOT"
+  val firrtl = getVersion("firrtl")
+  val treadle = getVersion("treadle")
   val chiseltest = ivy"edu.berkeley.cs::chiseltest:0.6-SNAPSHOT"
   val scalatest = ivy"org.scalatest::scalatest:3.2.12"
   val scalacheck = ivy"org.scalatestplus::scalacheck-1-14:3.2.2.0"


### PR DESCRIPTION
The release automation uses regex to find these `defaultVersions` maps and they need to be consistent between `build.sbt` and `build.sc`. We can revisit this logic after the release of 3.6 but I'd rather wait till we collapse the many repositories before attempting any large changes to the release flow.

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [NA] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

  - bug fix   


#### API Impact

No impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

  - Squash


#### Release Notes


### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
