### PR TITLE
Add versionScheme (PVP) to SBT publish settings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,6 +37,7 @@ lazy val commonSettings = Seq(
 )
 
 lazy val publishSettings = Seq(
+  versionScheme := Some("pvp"),
   publishMavenStyle := true,
   Test / publishArtifact := false,
   pomIncludeRepository := { x => false },


### PR DESCRIPTION
This allows build tools to warn users about possiblity binary incompatibilty issues when using dependencies that rely on binary incompatible versions of Chisel.

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

- infrastructure

#### API Impact

No impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

  - Squash

#### Release Notes

Chisel now publishes with `versionScheme` in the POM which should allow build tools (SBT and Mill) to warn users when library dependencies rely on binary incompatible versions of Chisel.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
