### PR TITLE
Added extension to work with users on 2.12.10 (and other 2.12 versions)

### DIFF
--- a/plugin/src/main/scala/chisel3/internal/plugin/DeprecateSFCComponent.scala
+++ b/plugin/src/main/scala/chisel3/internal/plugin/DeprecateSFCComponent.scala
@@ -48,9 +48,9 @@ class DeprecateSFCComponent(val global: Global, arguments: ChiselPluginArguments
       }
     }
     implicit final class GlobalCompat(
-        self: DeprecateSFCComponent.this.global.type) {
+      self: DeprecateSFCComponent.this.global.type) {
 
-      // Added in Scala 2.13.2 for configurable warnings                                                                                                                                                        
+      // Added in Scala 2.13.2 for configurable warnings
       object runReporting {
         def warning(pos: Position, msg: String, cat: Any, site: Symbol): Unit =
           reporter.warning(pos, msg)

--- a/plugin/src/main/scala/chisel3/internal/plugin/DeprecateSFCComponent.scala
+++ b/plugin/src/main/scala/chisel3/internal/plugin/DeprecateSFCComponent.scala
@@ -47,6 +47,15 @@ class DeprecateSFCComponent(val global: Global, arguments: ChiselPluginArguments
         Reporting.WarningCategory
       }
     }
+    implicit final class GlobalCompat(
+        self: DeprecateSFCComponent.this.global.type) {
+
+      // Added in Scala 2.13.2 for configurable warnings                                                                                                                                                        
+      object runReporting {
+        def warning(pos: Position, msg: String, cat: Any, site: Symbol): Unit =
+          reporter.warning(pos, msg)
+      }
+    }
 
     @tailrec private def isRootFirrtl(tree: Tree): Boolean = tree match {
       case Ident(name) if name.toString == "firrtl" => true


### PR DESCRIPTION
For users using Scala 2.12.10 (and other versions), this enables defaulting to the old warning mechanism in the plugin. @jackkoenig tried it out by publishLocal on 2.12.8 and showing it compiles with chisel-template project.

### Contributor Checklist

- [N/A] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [N/A] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [N/A] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
- bug fix           
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->


### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
