### PR TITLE
Check for Vec subaccess in NamedComponent and throw a nicer error.

### DIFF
--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -292,17 +292,21 @@ private[chisel3] trait HasId extends InstanceId {
   private def refName(c: Component): String = _ref match {
     case Some(arg) => arg.fullName(c)
     case None => {
-      val nameGuess = _computeName(None) match {
-        case Some(name) => s": '$name'"
-        case None       => ""
-      }
-      val parentGuess = _parent match {
-        case Some(ViewParent) => s", in module '${reifyParent.pathName}'"
-        case Some(p)          => s", in module '${p.pathName}'"
-        case None             => ""
-      }
-      throwException("You cannot access the .instanceName or .toTarget of non-hardware Data" + nameGuess + parentGuess)
+      throwException(
+        "You cannot access the .instanceName or .toTarget of non-hardware Data" + _nameGuess + _parentGuess
+      )
     }
+  }
+
+  private[chisel3] def _nameGuess: String = _computeName(None) match {
+    case Some(name) => s": '$name'"
+    case None       => ""
+  }
+
+  private[chisel3] def _parentGuess: String = _parent match {
+    case Some(ViewParent) => s", in module '${reifyParent.pathName}'"
+    case Some(p)          => s", in module '${p.pathName}'"
+    case None             => ""
   }
 
   // Helper for reifying views if they map to a single Target
@@ -361,11 +365,7 @@ private[chisel3] trait NamedComponent extends HasId {
     * @note Should not be called until circuit elaboration is complete
     */
   final def toNamed: ComponentName = {
-    if (isVecSubaccess())
-      throwException(
-        s"Cannot target a Vec subaccess (${this.instanceName}). " +
-          "Instead, assign it to a temporary (for example with WireInit) and target that."
-      )
+    assertValidTarget()
     ComponentName(this.instanceName, ModuleName(this.parentModName, CircuitName(this.circuitName)))
   }
 
@@ -373,11 +373,7 @@ private[chisel3] trait NamedComponent extends HasId {
     * @note Should not be called until circuit elaboration is complete
     */
   final def toTarget: ReferenceTarget = {
-    if (isVecSubaccess())
-      throwException(
-        s"Cannot target a Vec subaccess (${this.instanceName}). " +
-          "Instead, assign it to a temporary (for example with WireInit) and target that."
-      )
+    assertValidTarget()
     val name = this.instanceName
     if (!validComponentName(name)) throwException(s"Illegal component name: $name (note: literals are illegal)")
     import _root_.firrtl.annotations.{Target, TargetToken}
@@ -402,12 +398,19 @@ private[chisel3] trait NamedComponent extends HasId {
     }
   }
 
-  private def isVecSubaccess(): Boolean = {
-    getOptionRef.map {
+  private def assertValidTarget(): Unit = {
+    val isVecSubaccess = getOptionRef.map {
       case Index(_, _: ULit) => true // Vec literal indexing
       case Index(_, _: Node) => true // Vec dynamic indexing
       case _ => false
     }.getOrElse(false)
+
+    if (isVecSubaccess) {
+      throwException(
+        s"You cannot target Vec subaccess" + _nameGuess + _parentGuess +
+          ". Instead, assign it to a temporary (for example, with WireInit) and target that."
+      )
+    }
   }
 }
 

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -361,7 +361,11 @@ private[chisel3] trait NamedComponent extends HasId {
     * @note Should not be called until circuit elaboration is complete
     */
   final def toNamed: ComponentName = {
-    if (isVecSubaccess()) throwException(s"Cannot target a Vec subaccess (${this.instanceName}). Instead, assign it to a temporary (for example with WireInit) and target that.")
+    if (isVecSubaccess())
+      throwException(
+        s"Cannot target a Vec subaccess (${this.instanceName}). " +
+          "Instead, assign it to a temporary (for example with WireInit) and target that."
+      )
     ComponentName(this.instanceName, ModuleName(this.parentModName, CircuitName(this.circuitName)))
   }
 
@@ -369,7 +373,11 @@ private[chisel3] trait NamedComponent extends HasId {
     * @note Should not be called until circuit elaboration is complete
     */
   final def toTarget: ReferenceTarget = {
-    if (isVecSubaccess()) throwException(s"Cannot target a Vec subaccess (${this.instanceName}). Instead, assign it to a temporary (for example with WireInit) and target that.")
+    if (isVecSubaccess())
+      throwException(
+        s"Cannot target a Vec subaccess (${this.instanceName}). " +
+          "Instead, assign it to a temporary (for example with WireInit) and target that."
+      )
     val name = this.instanceName
     if (!validComponentName(name)) throwException(s"Illegal component name: $name (note: literals are illegal)")
     import _root_.firrtl.annotations.{Target, TargetToken}

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -293,20 +293,24 @@ private[chisel3] trait HasId extends InstanceId {
     case Some(arg) => arg.fullName(c)
     case None => {
       throwException(
-        "You cannot access the .instanceName or .toTarget of non-hardware Data" + _nameGuess + _parentGuess
+        "You cannot access the .instanceName or .toTarget of non-hardware Data" + _errorContext
       )
     }
   }
 
-  private[chisel3] def _nameGuess: String = _computeName(None) match {
-    case Some(name) => s": '$name'"
-    case None       => ""
-  }
+  private[chisel3] def _errorContext: String = {
+    val nameGuess: String = _computeName(None) match {
+      case Some(name) => s": '$name'"
+      case None       => ""
+    }
 
-  private[chisel3] def _parentGuess: String = _parent match {
-    case Some(ViewParent) => s", in module '${reifyParent.pathName}'"
-    case Some(p)          => s", in module '${p.pathName}'"
-    case None             => ""
+    val parentGuess: String = _parent match {
+      case Some(ViewParent) => s", in module '${reifyParent.pathName}'"
+      case Some(p)          => s", in module '${p.pathName}'"
+      case None             => ""
+    }
+
+    nameGuess + parentGuess
   }
 
   // Helper for reifying views if they map to a single Target
@@ -407,8 +411,8 @@ private[chisel3] trait NamedComponent extends HasId {
 
     if (isVecSubaccess) {
       throwException(
-        s"You cannot target Vec subaccess" + _nameGuess + _parentGuess +
-          ". Instead, assign it to a temporary (for example, with WireInit) and target that."
+        s"You cannot target Vec subaccess" + _errorContext +
+          ". Instead, assign it to a temporary (for example, with WireInit) and target the temporary."
       )
     }
   }

--- a/src/test/scala/chiselTests/VecToTargetSpec.scala
+++ b/src/test/scala/chiselTests/VecToTargetSpec.scala
@@ -5,49 +5,71 @@ package chiselTests
 import chisel3._
 import chisel3.stage.ChiselStage
 
-class VecToTargetSpec extends ChiselFlatSpec with Utils {
+trait VecToTargetSpecUtils {
+  class Foo extends RawModule {
+    val vec = IO(Input(Vec(4, Bool())))
+
+    // Index a Vec with a Scala literal.
+    val scalaLitIdx = 0
+    val vecScalaLitIdx = vec(scalaLitIdx)
+
+    // Index a Vec with a Chisel literal.
+    val chiselLitIdx = 0.U
+    val vecChiselLitIdx = vec(chiselLitIdx)
+
+    // Index a Vec with a node.
+    val nodeIdx = IO(Input(UInt(2.W)))
+    val vecNodeIdx = vec(nodeIdx)
+
+    // Put an otherwise un-targetable Vec subaccess into a temp.
+    val vecWithTmp = WireInit(vecNodeIdx)
+  }
+
+  var foo: Foo = null
+
+  ChiselStage.elaborate { foo = new Foo; foo }
+
+  val expectedError = "You cannot target Vec subaccess:"
+}
+
+class VecToTargetSpec extends ChiselFlatSpec with VecToTargetSpecUtils with Utils {
   "Vec subaccess with Scala literal" should "convert to ReferenceTarget" in {
-    ChiselStage.convert {
-      new Module {
-        val vec = IO(Input(Vec(4, Bool())))
-        val idx = 0
-        dontTouch(vec(idx))
-      }
-    }
+    foo.vecScalaLitIdx.toTarget
+  }
+
+  "Vec subaccess with Scala literal" should "convert to ComponentName" in {
+    foo.vecScalaLitIdx.toNamed
   }
 
   "Vec subaccess with Chisel literal" should "fail to convert to ReferenceTarget" in {
     (the[ChiselException] thrownBy extractCause[ChiselException] {
-      ChiselStage.convert {
-        new Module {
-          val vec = IO(Input(Vec(4, Bool())))
-          val idx = 0.U
-          dontTouch(vec(idx))
-        }
-      }
-    }).getMessage should include("Cannot target a Vec subaccess")
+      foo.vecChiselLitIdx.toTarget
+    }).getMessage should include(expectedError)
+  }
+
+  "Vec subaccess with Chisel literal" should "fail to convert to ComponentName" in {
+    (the[ChiselException] thrownBy extractCause[ChiselException] {
+      foo.vecChiselLitIdx.toNamed
+    }).getMessage should include(expectedError)
   }
 
   "Vec subaccess with node" should "fail to convert to ReferenceTarget" in {
     (the[ChiselException] thrownBy extractCause[ChiselException] {
-      ChiselStage.convert {
-        new Module {
-          val vec = IO(Input(Vec(4, Bool())))
-          val idx = IO(Input(UInt(4.W)))
-          dontTouch(vec(idx))
-        }
-      }
-    }).getMessage should include("Cannot target a Vec subaccess")
+      foo.vecNodeIdx.toTarget
+    }).getMessage should include(expectedError)
   }
 
-  "Vec subaccess with illegal construct" should "convert to ReferenceTarget if assigned to a temporary" in {
-    ChiselStage.convert {
-      new Module {
-        val vec = IO(Input(Vec(4, Bool())))
-        val idx = 0.U
-        val tmp = WireInit(vec(idx))
-        dontTouch(tmp)
-      }
-    }
+  "Vec subaccess with node" should "fail to convert to ComponentName" in {
+    (the[ChiselException] thrownBy extractCause[ChiselException] {
+      foo.vecNodeIdx.toNamed
+    }).getMessage should include(expectedError)
+  }
+
+  "Vec subaccess with un-targetable construct" should "convert to ReferenceTarget if assigned to a temporary" in {
+    foo.vecWithTmp.toTarget
+  }
+
+  "Vec subaccess with un-targetable construct" should "convert to ComponentName if assigned to a temporary" in {
+    foo.vecWithTmp.toNamed
   }
 }

--- a/src/test/scala/chiselTests/VecToTargetSpec.scala
+++ b/src/test/scala/chiselTests/VecToTargetSpec.scala
@@ -9,7 +9,7 @@ class VecToTargetSpec extends ChiselFlatSpec with Utils {
   "Vec subaccess with Scala literal" should "convert to ReferenceTarget" in {
     ChiselStage.convert {
       new Module {
-        val vec = IO(Input(Vec(4,Bool())))
+        val vec = IO(Input(Vec(4, Bool())))
         val idx = 0
         dontTouch(vec(idx))
       }
@@ -20,7 +20,7 @@ class VecToTargetSpec extends ChiselFlatSpec with Utils {
     (the[ChiselException] thrownBy extractCause[ChiselException] {
       ChiselStage.convert {
         new Module {
-          val vec = IO(Input(Vec(4,Bool())))
+          val vec = IO(Input(Vec(4, Bool())))
           val idx = 0.U
           dontTouch(vec(idx))
         }
@@ -32,7 +32,7 @@ class VecToTargetSpec extends ChiselFlatSpec with Utils {
     (the[ChiselException] thrownBy extractCause[ChiselException] {
       ChiselStage.convert {
         new Module {
-          val vec = IO(Input(Vec(4,Bool())))
+          val vec = IO(Input(Vec(4, Bool())))
           val idx = IO(Input(UInt(4.W)))
           dontTouch(vec(idx))
         }
@@ -43,7 +43,7 @@ class VecToTargetSpec extends ChiselFlatSpec with Utils {
   "Vec subaccess with illegal construct" should "convert to ReferenceTarget if assigned to a temporary" in {
     ChiselStage.convert {
       new Module {
-        val vec = IO(Input(Vec(4,Bool())))
+        val vec = IO(Input(Vec(4, Bool())))
         val idx = 0.U
         val tmp = WireInit(vec(idx))
         dontTouch(tmp)

--- a/src/test/scala/chiselTests/VecToTargetSpec.scala
+++ b/src/test/scala/chiselTests/VecToTargetSpec.scala
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiselTests
+
+import chisel3._
+import chisel3.stage.ChiselStage
+
+class VecToTargetSpec extends ChiselFlatSpec with Utils {
+  "Vec subaccess with Scala literal" should "convert to ReferenceTarget" in {
+    ChiselStage.convert {
+      new Module {
+        val vec = IO(Input(Vec(4,Bool())))
+        val idx = 0
+        dontTouch(vec(idx))
+      }
+    }
+  }
+
+  "Vec subaccess with Chisel literal" should "fail to convert to ReferenceTarget" in {
+    (the[ChiselException] thrownBy extractCause[ChiselException] {
+      ChiselStage.convert {
+        new Module {
+          val vec = IO(Input(Vec(4,Bool())))
+          val idx = 0.U
+          dontTouch(vec(idx))
+        }
+      }
+    }).getMessage should include("Cannot target a Vec subaccess")
+  }
+
+  "Vec subaccess with node" should "fail to convert to ReferenceTarget" in {
+    (the[ChiselException] thrownBy extractCause[ChiselException] {
+      ChiselStage.convert {
+        new Module {
+          val vec = IO(Input(Vec(4,Bool())))
+          val idx = IO(Input(UInt(4.W)))
+          dontTouch(vec(idx))
+        }
+      }
+    }).getMessage should include("Cannot target a Vec subaccess")
+  }
+
+  "Vec subaccess with illegal construct" should "convert to ReferenceTarget if assigned to a temporary" in {
+    ChiselStage.convert {
+      new Module {
+        val vec = IO(Input(Vec(4,Bool())))
+        val idx = 0.U
+        val tmp = WireInit(vec(idx))
+        dontTouch(tmp)
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
- code cleanup
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->
The only effect on the current API should be that existing usages that threw errors should now throw a more precise and helpful error.

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->
This has no impact on code generation.

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->
- Squash

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

Improved error message when targeting Vec subaccess

### Reviewer Checklist (only modified by reviewer)
- [x] Did you add the appropriate labels?
- [x] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [x] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [x] Did you do one of the following when ready to merge:
  - [x] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
