### PR TITLE
FlatIOSpec: make sure the Analog test is using FlatIO

### DIFF
--- a/src/test/scala/chiselTests/experimental/FlatIOSpec.scala
+++ b/src/test/scala/chiselTests/experimental/FlatIOSpec.scala
@@ -55,9 +55,11 @@ class FlatIOSpec extends ChiselFlatSpec {
       val bar = Analog(8.W)
     }
     class MyModule extends RawModule {
-      val in = IO(Flipped(new MyBundle))
-      val out = IO(new MyBundle)
-      out <> in
+      val io = FlatIO(new Bundle {
+        val in = Flipped(new MyBundle)
+        val out = new MyBundle
+      })
+      io.out <> io.in
     }
     val chirrtl = emitChirrtl(new MyModule)
     chirrtl should include("out.foo <= in.foo")


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
   - bug fix                           
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->
No impact, test code only.

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->
No impact, test code only.

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
   - Squash: The PR will be squashed and merged (choose this if you have no preference. 
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

Fix the FlatIOSpec test case for Analog (previously it was not actually using FlatIO).

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
