### PR TITLE
Clarify mismatched width error message

### DIFF
--- a/core/src/main/scala/chisel3/connectable/Connection.scala
+++ b/core/src/main/scala/chisel3/connectable/Connection.scala
@@ -194,8 +194,11 @@ private[chisel3] object Connection {
         // Base Case 3: early exit if operator requires matching widths, but they aren't the same
         case (consumerAlignment: NonEmptyAlignment, producerAlignment: NonEmptyAlignment)
             if (consumerAlignment
-              .mismatchedWidths(producerAlignment, connectionOp)) && (connectionOp.noMismatchedWidths) =>
-          errors = (s"mismatched widths of ${consumerAlignment.member} and ${producerAlignment.member}") +: errors
+              .truncationRequired(producerAlignment, connectionOp)
+              .nonEmpty) && (connectionOp.noMismatchedWidths) =>
+          val mustBeTruncated = consumerAlignment.truncationRequired(producerAlignment, connectionOp).get
+          errors =
+            (s"mismatched widths of ${consumerAlignment.member} and ${producerAlignment.member} might require truncation of $mustBeTruncated") +: errors
 
         // Base Case 3: operator error on dangling/unconnected fields
         case (consumer: NonEmptyAlignment, _: EmptyAlignment) =>


### PR DESCRIPTION
Minor change to enable a clearer mismatched widths error message.

### Contributor Checklist

- [N/A] Did you add Scaladoc to every public function/method?
- [N/A] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [N/A] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [N/A] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
   - code cleanup 
<!--   - backend code generation            -->
<!--   - new feature/API                    -->


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
 - Squash: The PR will be squashed and merged (choose this if you have no preference.
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->


### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [x] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [x] Did you review?
- [x] Did you check whether all relevant Contributor checkboxes have been checked?
- [x] Did you do one of the following when ready to merge:
  - [x] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
