### PR TITLE
Fix bug where Flipped did not properly flip

### DIFF
--- a/core/src/main/scala/chisel3/Data.scala
+++ b/core/src/main/scala/chisel3/Data.scala
@@ -66,7 +66,7 @@ object SpecifiedDirection {
       requireIsChiselType(data)
     }
     val out = if (!data.mustClone(prevId)) data else data.cloneType.asInstanceOf[T]
-    out.specifiedDirection = dir(out)
+    out.specifiedDirection = dir(data) // Must use original data, specified direction of clone is cleared
     out
   }
 

--- a/src/test/scala/chiselTests/Direction.scala
+++ b/src/test/scala/chiselTests/Direction.scala
@@ -133,6 +133,31 @@ class DirectionSpec extends ChiselPropSpec with Matchers with Utils {
 
   import chisel3.experimental.{DataMirror, Direction}
 
+  property("Flipped should flip the specified direction of a Bundle") {
+    class MyBundle extends Bundle {
+      val out = Output(UInt(8.W))
+      val in = Input(UInt(8.W))
+    }
+    class Top extends Module {
+      val foo = IO(Flipped(new MyBundle))
+      // Where I come from, referential transparency is a good thing
+      val fooType = chiselTypeOf(foo)
+      val fizz = IO(Flipped(fooType))
+      val buzz = IO(Flipped(chiselTypeOf(foo)))
+
+      DataMirror.specifiedDirectionOf(foo) should be(SpecifiedDirection.Flip)
+      DataMirror.specifiedDirectionOf(fizz) should be(SpecifiedDirection.Unspecified)
+      DataMirror.specifiedDirectionOf(buzz) should be(SpecifiedDirection.Unspecified)
+      DataMirror.directionOf(foo) should be(Direction.Bidirectional(Direction.Flipped))
+      DataMirror.directionOf(fizz) should be(Direction.Bidirectional(Direction.Default))
+      DataMirror.directionOf(buzz) should be(Direction.Bidirectional(Direction.Default))
+    }
+    val chirrtl = ChiselStage.emitChirrtl(new Top)
+    chirrtl should include("input foo")
+    chirrtl should include("output fizz")
+    chirrtl should include("output buzz")
+  }
+
   property("Directions should be preserved through cloning and binding of Bundles") {
     ChiselStage.elaborate(new Module {
       class MyBundle extends Bundle {


### PR DESCRIPTION
In cases when Flipped needs to clone, it was using the specified direction of the clone. Since cloneType does not propagate specifiedDirection, it was essentially always flipping an unspecified direction even if the direction had been specified.

This bug was introduced by the optimizations in https://github.com/chipsalliance/chisel3/pull/2611 so it only applies to 3.6.

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

 - bug fix

#### API Impact

No impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

- Squash

#### Release Notes

Fix bug where `Flipped` would not actually flip when the argument is assigned to a val before being passed to `Flipped`.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
