### PR TITLE
Fix lazy cloning and apply the optimization in more cases

### DIFF
--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -1219,7 +1219,9 @@ abstract class Record(private[chisel3] implicit val compileOptions: CompileOptio
     )
   }
 
-  private[chisel3] lazy val hasExternalRef: Boolean = this.elements.exists(_._2._id < _id)
+  override private[chisel3] lazy val _minId: Long = {
+    this.elementsIterator.map(_._minId).foldLeft(this._id)(_ min _)
+  }
 }
 
 /**

--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -1218,6 +1218,8 @@ abstract class Record(private[chisel3] implicit val compileOptions: CompileOptio
       s"Internal Error! This should have been implemented by the chisel3-plugin. Please file an issue against chisel3"
     )
   }
+
+  private[chisel3] lazy val hasExternalRef: Boolean = this.elements.exists(_._2._id < _id)
 }
 
 /**
@@ -1404,8 +1406,6 @@ abstract class Bundle(implicit compileOptions: CompileOptions) extends Record wi
       }
     }
   }
-
-  private[chisel3] lazy val hasExternalRef: Boolean = this.elements.exists(_._2._id < _id)
 
   override def cloneType: this.type = {
     val clone = _cloneTypeImpl.asInstanceOf[this.type]

--- a/core/src/main/scala/chisel3/Data.scala
+++ b/core/src/main/scala/chisel3/Data.scala
@@ -367,18 +367,19 @@ abstract class Data extends HasId with NamedComponent with SourceInfoDoc {
     }
   }
 
-  // must clone a data if
-  // * it has a binding
-  // * its id is older than prevId (not "freshly created")
-  // * it is a bundle with a non-fresh member (external reference)
+  // Must clone a Data if any of the following are true:
+  // * It has a binding
+  // * Its id is older than prevId (not "freshly created")
+  // * It is a Bundle or Record that contains a member older than prevId
   private[chisel3] def mustClone(prevId: Long): Boolean = {
-    if (this.hasBinding || this._id <= prevId) true
-    else
-      this match {
-        case r: Record => r.hasExternalRef
-        case _ => false
-      }
+    this.hasBinding || this._minId <= prevId
   }
+
+  /** The minimum (aka "oldest") id that is part of this Data
+    *
+    * @note This is usually just _id except for some Records and Bundles
+    */
+  private[chisel3] def _minId: Long = this._id
 
   override def autoSeed(name: String): this.type = {
     topBindingOpt match {

--- a/core/src/main/scala/chisel3/Data.scala
+++ b/core/src/main/scala/chisel3/Data.scala
@@ -375,7 +375,7 @@ abstract class Data extends HasId with NamedComponent with SourceInfoDoc {
     if (this.hasBinding || this._id <= prevId) true
     else
       this match {
-        case b: Bundle => b.hasExternalRef
+        case r: Record => r.hasExternalRef
         case _ => false
       }
   }

--- a/src/test/scala/chiselTests/AutoClonetypeSpec.scala
+++ b/src/test/scala/chiselTests/AutoClonetypeSpec.scala
@@ -256,7 +256,10 @@ class AutoClonetypeSpec extends ChiselFlatSpec with Utils {
 
       elaborate {
         new Module {
-          val io = IO(Output(new BadBundle(UInt(8.W), 1)))
+          // This needs to be constructed before the call to Output, otherwise it won't be cloned
+          // thanks to lazy cloning
+          val gen = new BadBundle(UInt(8.W), 1)
+          val io = IO(Output(gen))
           io.a := 0.U
         }
       }

--- a/src/test/scala/chiselTests/LazyCloneSpec.scala
+++ b/src/test/scala/chiselTests/LazyCloneSpec.scala
@@ -119,4 +119,29 @@ class LazyCloneSpec extends ChiselFlatSpec {
     ChiselStage.elaborate(new MyModule)
     Counter.count should be(2L)
   }
+
+  it should "not clone Vecs (but Vecs always clone their gen 1 + size times)" in {
+    Counter.count = 0L
+    class MyModule extends RawModule {
+      val in = IO(Input(Vec(2, new Foo)))
+      val out = IO(Output(Vec(2, new Foo)))
+      out := in
+    }
+    ChiselStage.elaborate(new MyModule)
+    // Each Vec has 3 clones of Foo + the original Foo, then the Vec isn't cloned
+    Counter.count should be(8L)
+  }
+
+  it should "not clone Vecs even with external refs (but Vecs always clone their gen 1 + size times)" in {
+    Counter.count = 0L
+    class MyModule extends RawModule {
+      val gen = new Foo
+      val in = IO(Input(Vec(2, gen)))
+      val out = IO(Output(Vec(2, gen)))
+      out := in
+    }
+    ChiselStage.elaborate(new MyModule)
+    // Each Vec has 3 clones of Foo + the original Foo, then the Vec isn't cloned
+    Counter.count should be(7L)
+  }
 }


### PR DESCRIPTION
Follow on to https://github.com/chipsalliance/chisel3/pull/2919. Fixes a couple of minor bugs and enhances the implementation from https://github.com/chipsalliance/chisel3/pull/2611.

This fixes 2 bugs:
* Lazy clone checking for external references must include Records
* Lazy clone checking for Records must be recursive.

The simple fix for the 2nd bug has a large negative impact on the utility of the lazy cloning, so this also tweaked the implementation to require more storage per Record, but identify more cases where cloning is not necessary.

Also see the description for the PR changing the lazy cloning algorithm:

Change mustClone calculation to use _minId

Previously it used a calculation of whether a given Record (or Bundle)
contained an "external reference", defined as any element with an _id
less than the _id of the Record. This does not work for certain cases
because it is not recursive and a child Record could itself contain an
external reference. Changing the calculation to be recursive negates
much of the benefit because many cases that should not need to clone end
up cloning.

The new algorithm instead uses a notion of "minimum id" for a Data. For
most Data, this is just _id, but for Records, it is the minimum id of
any of its children (recursively). This does replace the previous 1-byte
memoized field with an 8-byte field, but this algorithm works better and
should result in more savings from lazy cloning.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [NA] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

  - bug fix     
  - performance improvement  

#### API Impact

No impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit.
 
#### Release Notes

Fix bugs where some Records and nested Bundles may not be cloned when they should be resulting in confusing errors downstream. Also increase the number of cases where cloning can be avoided.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
