### PR TITLE
Improve performance of ChiselEnum annotations

### DIFF
--- a/core/src/main/scala/chisel3/StrongEnum.scala
+++ b/core/src/main/scala/chisel3/StrongEnum.scala
@@ -240,11 +240,13 @@ abstract class EnumType(private[chisel3] val factory: EnumFactory, selfAnnotatin
       case None    => EnumComponentChiselAnnotation(this, enumTypeName)
     }
 
-    if (!Builder.annotations.contains(anno)) {
+    if (!Builder.enumAnnos.contains(anno)) {
+      Builder.enumAnnos += anno
       annotate(anno)
     }
 
-    if (!Builder.annotations.contains(factory.globalAnnotation)) {
+    if (!Builder.enumAnnos.contains(factory.globalAnnotation)) {
+      Builder.enumAnnos += factory.globalAnnotation
       annotate(factory.globalAnnotation)
     }
   }

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -451,6 +451,10 @@ private[chisel3] class DynamicContext(
   val newAnnotations = ArrayBuffer[ChiselMultiAnnotation]()
   var currentModule: Option[BaseModule] = None
 
+  // Enum annotations are added every time a StrongEnum is bound
+  // To keep the number down, we keep them unique in the annotations
+  val enumAnnos = mutable.HashSet[ChiselAnnotation]()
+
   /** Contains a mapping from a elaborated module to their aspect
     * Set by [[ModuleAspect]]
     */
@@ -518,6 +522,8 @@ private[chisel3] object Builder extends LazyLogging {
   def globalNamespace: Namespace = dynamicContext.globalNamespace
   def components:      ArrayBuffer[Component] = dynamicContext.components
   def annotations:     ArrayBuffer[ChiselAnnotation] = dynamicContext.annotations
+
+  def enumAnnos: mutable.HashSet[ChiselAnnotation] = dynamicContext.enumAnnos
 
   // TODO : Unify this with annotations in the future - done this way for backward compatability
   def newAnnotations: ArrayBuffer[ChiselMultiAnnotation] = dynamicContext.newAnnotations


### PR DESCRIPTION
ChiselEnums check if they should create annotations every time an instance of them is bound. Because so many annotations would be created, they check to see if an equivalent annotation has already been added to the annotations. Previously, this used a linear search of the annotations, now it uses a HashSet.

I noticed this inefficiency glancing at a Flamegraph of a very large design. In that case, just eyeballing where this is obviously showing up, it's at least 18% of the runtime. As with all things that are fundamentally `O(n*m)`, the benefits from this change will be greatest in large designs with lots of annotations (`n`) and lots of `ChiselEnum`s (`m`).

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

  - performance improvement

#### API Impact

No impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

 - Squash

#### Release Notes

Improve performance of ChiselEnum

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [x] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
