### PR TITLE
Support zero-width integer literals.

### DIFF
--- a/core/src/main/scala/chisel3/Bits.scala
+++ b/core/src/main/scala/chisel3/Bits.scala
@@ -109,6 +109,7 @@ sealed abstract class Bits(private[chisel3] val width: Width) extends Element wi
       requireIsHardware(this, "bits to be indexed")
 
       widthOption match {
+        case Some(w) if w == 0 => Builder.error(s"Cannot extract from zero-width")
         case Some(w) if x >= w => Builder.error(s"High index $x is out of range [0, ${w - 1}]")
         case _                 =>
       }
@@ -190,6 +191,7 @@ sealed abstract class Bits(private[chisel3] val width: Width) extends Element wi
       requireIsHardware(this, "bits to be sliced")
 
       widthOption match {
+        case Some(w) if w == 0 => Builder.error(s"Cannot extract from zero-width")
         case Some(w) if y >= w => Builder.error(s"High and low indices $x and $y are both out of range [0, ${w - 1}]")
         case Some(w) if x >= w => Builder.error(s"High index $x is out of range [0, ${w - 1}]")
         case _                 =>

--- a/core/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -135,7 +135,7 @@ case class ILit(n: BigInt) extends Arg {
 
 case class ULit(n: BigInt, w: Width) extends LitArg(n, w) {
   def name:     String = "UInt" + width + "(\"h0" + num.toString(16) + "\")"
-  def minWidth: Int = 1.max(n.bitLength)
+  def minWidth: Int = (if (w.known) 0 else 1).max(n.bitLength)
 
   def cloneWithWidth(newWidth: Width): this.type = {
     ULit(n, newWidth).asInstanceOf[this.type]
@@ -149,7 +149,7 @@ case class SLit(n: BigInt, w: Width) extends LitArg(n, w) {
     val unsigned = if (n < 0) (BigInt(1) << width.get) + n else n
     s"asSInt(${ULit(unsigned, width).name})"
   }
-  def minWidth: Int = 1 + n.bitLength
+  def minWidth: Int = (if (w.known) 0 else 1) + n.bitLength
 
   def cloneWithWidth(newWidth: Width): this.type = {
     SLit(n, newWidth).asInstanceOf[this.type]

--- a/src/test/scala/chiselTests/ChiselSpec.scala
+++ b/src/test/scala/chiselTests/ChiselSpec.scala
@@ -68,8 +68,9 @@ trait ChiselRunners extends Assertions with BackendCompilationUtilities {
       // Sanity check that firrtl doesn't change the width
       x := 0.U.asTypeOf(chiselTypeOf(x))
       val (_, done) = chisel3.util.Counter(true.B, 2)
+      val ones = if (expected == 0) 0.U(0.W) else -1.S(expected.W).asUInt
       when(done) {
-        chisel3.assert(~(x.asUInt) === -1.S(expected.W).asUInt)
+        chisel3.assert(~(x.asUInt) === ones)
         stop()
       }
     })
@@ -81,8 +82,9 @@ trait ChiselRunners extends Assertions with BackendCompilationUtilities {
       assert(!x.isWidthKnown, s"Asserting that width should be inferred yet width is known to Chisel!")
       x := 0.U.asTypeOf(chiselTypeOf(x))
       val (_, done) = chisel3.util.Counter(true.B, 2)
+      val ones = if (expected == 0) 0.U(0.W) else -1.S(expected.W).asUInt
       when(done) {
-        chisel3.assert(~(x.asUInt) === -1.S(expected.W).asUInt)
+        chisel3.assert(~(x.asUInt) === ones)
         stop()
       }
     })

--- a/src/test/scala/chiselTests/ChiselSpec.scala
+++ b/src/test/scala/chiselTests/ChiselSpec.scala
@@ -66,7 +66,7 @@ trait ChiselRunners extends Assertions with BackendCompilationUtilities {
       val x = gen
       assert(x.getWidth === expected)
       // Sanity check that firrtl doesn't change the width
-      x := 0.U.asTypeOf(chiselTypeOf(x))
+      x := 0.U(0.W).asTypeOf(chiselTypeOf(x))
       val (_, done) = chisel3.util.Counter(true.B, 2)
       val ones = if (expected == 0) 0.U(0.W) else -1.S(expected.W).asUInt
       when(done) {
@@ -80,7 +80,7 @@ trait ChiselRunners extends Assertions with BackendCompilationUtilities {
     assertTesterPasses(new BasicTester {
       val x = gen
       assert(!x.isWidthKnown, s"Asserting that width should be inferred yet width is known to Chisel!")
-      x := 0.U.asTypeOf(chiselTypeOf(x))
+      x := 0.U(0.W).asTypeOf(chiselTypeOf(x))
       val (_, done) = chisel3.util.Counter(true.B, 2)
       val ones = if (expected == 0) 0.U(0.W) else -1.S(expected.W).asUInt
       when(done) {

--- a/src/test/scala/chiselTests/OneHotMuxSpec.scala
+++ b/src/test/scala/chiselTests/OneHotMuxSpec.scala
@@ -43,12 +43,8 @@ class OneHotMuxSpec extends AnyFreeSpec with Matchers with ChiselRunners {
   "UIntToOH with output width greater than 2^(input width)" in {
     assertTesterPasses(new UIntToOHTester)
   }
-  "UIntToOH should not accept width of zero (until zero-width wires are fixed" in {
-    intercept[IllegalArgumentException] {
-      assertTesterPasses(new BasicTester {
-        val out = UIntToOH(0.U, 0)
-      })
-    }
+  "UIntToOH should accept width of zero" in {
+    assertTesterPasses(new ZeroWidthOHTester)
   }
 
 }
@@ -314,5 +310,11 @@ class UIntToOHTester extends BasicTester {
   require(out2.getWidth == 1)
   assert(out2 === 1.U)
 
+  stop()
+}
+
+class ZeroWidthOHTester extends BasicTester {
+  val out = UIntToOH(0.U, 0)
+  assert(out === 0.U(0.W))
   stop()
 }

--- a/src/test/scala/chiselTests/SIntOps.scala
+++ b/src/test/scala/chiselTests/SIntOps.scala
@@ -98,6 +98,19 @@ class SIntLitExtractTester extends BasicTester {
   stop()
 }
 
+class SIntLitZeroWidthTester extends BasicTester {
+  assert(-0.S(0.W) === 0.S)
+  assert(~0.S(0.W) === 0.S)
+  assert(0.S(0.W) + 0.S(0.W) === 0.S)
+  assert(5.S * 0.S(0.W) === 0.S)
+  assert(0.S(0.W) / 5.S === 0.S)
+  assert(0.S(0.W).head(0) === 0.U)
+  assert(0.S(0.W).tail(0) === 0.U)
+  assert(0.S(0.W).pad(1) === 0.S)
+  assert(-0.S(0.W)(0, 0) === "b0".U)
+  stop()
+}
+
 class SIntOpsSpec extends ChiselPropSpec with Utils {
 
   property("SIntOps should elaborate") {
@@ -114,6 +127,10 @@ class SIntOpsSpec extends ChiselPropSpec with Utils {
 
   property("Bit extraction on literals should work for all non-negative indices") {
     assertTesterPasses(new SIntLitExtractTester)
+  }
+
+  property("Basic arithmetic with zero-width literals should return correct result (0)") {
+    assertTesterPasses(new SIntLitZeroWidthTester)
   }
 
   // We use WireDefault with 2 arguments because of
@@ -143,6 +160,12 @@ class SIntOpsSpec extends ChiselPropSpec with Utils {
     }
     assertKnownWidth(5) {
       val x = WireDefault(SInt(4.W), DontCare)
+      val y = WireDefault(SInt(8.W), DontCare)
+      val op = x / y
+      WireDefault(chiselTypeOf(op), op)
+    }
+    assertKnownWidth(1) {
+      val x = WireDefault(SInt(0.W), DontCare)
       val y = WireDefault(SInt(8.W), DontCare)
       val op = x / y
       WireDefault(chiselTypeOf(op), op)

--- a/src/test/scala/chiselTests/SIntOps.scala
+++ b/src/test/scala/chiselTests/SIntOps.scala
@@ -129,7 +129,7 @@ class SIntOpsSpec extends ChiselPropSpec with Utils {
     assertTesterPasses(new SIntLitExtractTester)
   }
 
-  property("Basic arithmetic with zero-width literals should return correct result (0)") {
+  property("Basic arithmetic and bit operations with zero-width literals should return correct result (0)") {
     assertTesterPasses(new SIntLitZeroWidthTester)
   }
 

--- a/src/test/scala/chiselTests/UIntOps.scala
+++ b/src/test/scala/chiselTests/UIntOps.scala
@@ -107,6 +107,14 @@ class BadBoolConversion extends Module {
   io.b := io.u.asBool
 }
 
+class ZeroWidthBoolConversion extends Module {
+  val io = IO(new Bundle {
+    val u = Input(UInt(0.W))
+    val b = Output(Bool())
+  })
+  io.b := io.u.asBool
+}
+
 class NegativeShift(t: => Bits) extends Module {
   val io = IO(new Bundle {})
   Reg(t) >> -1
@@ -182,6 +190,7 @@ class UIntLitExtractTester extends BasicTester {
   assert("b101010".U(6.W)(100) === false.B)
   assert("b101010".U(6.W)(3, 0) === "b1010".U)
   assert("b101010".U(6.W)(9, 0) === "b0000101010".U)
+  assert("b0".U(0.W)(0, 0) === "b0".U)
   stop()
 }
 
@@ -192,6 +201,10 @@ class UIntOpsSpec extends ChiselPropSpec with Matchers with Utils {
 
   property("Bools can be created from 1 bit UInts") {
     ChiselStage.elaborate(new GoodBoolConversion)
+  }
+
+  property("Bools cannot be created from 0 bit UInts") {
+    a[Exception] should be thrownBy extractCause[Exception] { ChiselStage.elaborate(new ZeroWidthBoolConversion) }
   }
 
   property("Bools cannot be created from >1 bit UInts") {

--- a/src/test/scala/chiselTests/UIntOps.scala
+++ b/src/test/scala/chiselTests/UIntOps.scala
@@ -287,7 +287,7 @@ class UIntOpsSpec extends ChiselPropSpec with Matchers with Utils {
     assertTesterPasses(new UIntLitExtractTester)
   }
 
-  property("Basic arithmetic with zero-width literals should return correct result (0)") {
+  property("Basic arithmetic and bit operations with zero-width literals should return correct result (0)") {
     assertTesterPasses(new UIntLitZeroWidthTester)
   }
 

--- a/src/test/scala/chiselTests/WidthSpec.scala
+++ b/src/test/scala/chiselTests/WidthSpec.scala
@@ -98,18 +98,18 @@ abstract class WireRegWidthSpecImpl extends ChiselFlatSpec {
     }
   }
 
-  it should "infer width as 1-bit if the template type has no width and is initialized to zero-width literal" in {
-    assertInferredWidth(1) {
+  it should "infer width as zero if the template type has no width and is initialized to zero-width literal" in {
+    assertInferredWidth(0) {
       val w = builder(UInt())
       w := 0.U(0.W)
       w
     }
-    assertInferredWidth(1) {
+    assertInferredWidth(0) {
       val w = builder(new ZeroWidthBundle)
       w := ZeroWidthBundle.intoWire()
       w.y
     }
-    assertInferredWidth(1) {
+    assertInferredWidth(0) {
       val w = builder(Vec(1, UInt()))
       w(0) := 0.U(0.W)
       w(0)

--- a/src/test/scala/chiselTests/WidthSpec.scala
+++ b/src/test/scala/chiselTests/WidthSpec.scala
@@ -17,15 +17,30 @@ object SimpleBundle {
   }
 }
 
+class ZeroWidthBundle extends Bundle {
+  val x = UInt(0.W)
+  val y = UInt()
+}
+object ZeroWidthBundle {
+  def intoWire(): ZeroWidthBundle = {
+    val w = Wire(new ZeroWidthBundle)
+    w.x := 0.U(0.W)
+    w.y := 0.U(0.W)
+    w
+  }
+}
+
 class WidthSpec extends ChiselFlatSpec {
   "Literals without specified widths" should "get the minimum legal width" in {
     "hdeadbeef".U.getWidth should be(32)
     "h_dead_beef".U.getWidth should be(32)
     "h0a".U.getWidth should be(4)
     "h1a".U.getWidth should be(5)
-    "h0".U.getWidth should be(1)
+    "h0".U.getWidth should be(1) // no literal is zero-width unless explicitly requested.
     1.U.getWidth should be(1)
     1.S.getWidth should be(2)
+    0.U.getWidth should be(1)
+    0.S.getWidth should be(1)
   }
 }
 
@@ -50,6 +65,21 @@ abstract class WireRegWidthSpecImpl extends ChiselFlatSpec {
     }
   }
 
+  it should "set the width to zero if the template type is set to zero-width" in {
+    assertKnownWidth(0) {
+      builder(UInt(0.W))
+    }
+    assertKnownWidth(0) {
+      val w = builder(new ZeroWidthBundle)
+      w := ZeroWidthBundle.intoWire()
+      w.x
+    }
+    assertKnownWidth(0) {
+      val x = builder(Vec(1, UInt(0.W)))
+      x(0)
+    }
+  }
+
   it should "infer the width if the template type has no width" in {
     assertInferredWidth(4) {
       val w = builder(UInt())
@@ -64,6 +94,24 @@ abstract class WireRegWidthSpecImpl extends ChiselFlatSpec {
     assertInferredWidth(4) {
       val w = builder(Vec(1, UInt()))
       w(0) := 0.U(4.W)
+      w(0)
+    }
+  }
+
+  it should "infer width as 1-bit if the template type has no width and is initialized to zero-width literal" in {
+    assertInferredWidth(1) {
+      val w = builder(UInt())
+      w := 0.U(0.W)
+      w
+    }
+    assertInferredWidth(1) {
+      val w = builder(new ZeroWidthBundle)
+      w := ZeroWidthBundle.intoWire()
+      w.y
+    }
+    assertInferredWidth(1) {
+      val w = builder(Vec(1, UInt()))
+      w(0) := 0.U(0.W)
       w(0)
     }
   }
@@ -89,12 +137,21 @@ abstract class WireDefaultRegInitSpecImpl extends ChiselFlatSpec {
     assertKnownWidth(4) {
       builder1(3.U(4.W))
     }
+    assertKnownWidth(0) {
+      builder1(0.U(0.W))
+    }
   }
 
   it should "NOT set width if passed a literal without a forced width" in {
     assertInferredWidth(4) {
       val w = builder1(3.U)
       w := 3.U(4.W)
+      w
+    }
+
+    assertInferredWidth(1) {
+      val w = builder1(0.U)
+      w := 0.U(0.W)
       w
     }
   }


### PR DESCRIPTION
These are in the FIRRTL language specification now and supported by both SFC + MFC.

If integer literal width is specified, support zero-width (`0.U(0.W)`), otherwise at least 1-bit (`0.U`), for compatibility with existing code.

Modified `assertKnownWidth`/`assertInferredWidth` to allow checking for width of zero, avoid attempting to use `-1S(0.W)`.  Used these to check basic zero-width behavior of wires/regs being initialized with zero-width integer literals.

Add a few tests to ensure zero-width literals and a few operations/constructs work as expected, and that their behavior is preserved.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [ ] Did you state the API impact?
- [ ] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
- new feature/API

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
- Squash: The PR will be squashed and merged
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes

Add support for zero-width integer literals, which must be explicitly requested (`0.U(0.W)`), for compatibility reasons `0.U` will still be (minimum) 1-bit.

### Reviewer Checklist (only modified by reviewer)
- [x] Did you add the appropriate labels?
- [x] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [x] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
