### PR TITLE
Change tests to use import circt.stage.ChiselStage

### DIFF
--- a/src/main/scala/circt/stage/ChiselStage.scala
+++ b/src/main/scala/circt/stage/ChiselStage.scala
@@ -4,11 +4,8 @@ package circt.stage
 
 import chisel3.RawModule
 import chisel3.stage.{ChiselGeneratorAnnotation, NoRunFirrtlCompilerAnnotation}
-
-import firrtl.{AnnotationSeq, EmittedVerilogCircuitAnnotation}
 import firrtl.options.{Dependency, Phase, PhaseManager, Shell, Stage, StageMain}
-import firrtl.options.Viewer.view
-import firrtl.stage.{Forms, RunFirrtlTransformAnnotation}
+import firrtl.{AnnotationSeq, EmittedVerilogCircuitAnnotation}
 
 /** Entry point for running Chisel with the CIRCT compiler.
   *
@@ -50,6 +47,14 @@ object ChiselStage {
   /** Elaborate a Chisel circuit into a CHIRRTL string */
   def emitCHIRRTL(gen: => RawModule): String = chisel3.stage.ChiselStage.emitChirrtl(gen)
 
+  /** Return a CHIRRTL circuit for a Chisel module
+    *
+    * @param gen a call-by-name Chisel module
+    */
+  def convert(gen: => RawModule): firrtl.ir.Circuit = {
+    chisel3.stage.ChiselStage.convert(gen)
+  }
+
   /** A phase shared by all the CIRCT backends */
   private def phase = new PhaseManager(
     Seq(
@@ -90,8 +95,9 @@ object ChiselStage {
     .get
 
   /** Compile a Chisel circuit to SystemVerilog
-    * @param gen a call-by-name Chisel module
-    * @param args additional command line arguments to pass to Chisel
+    *
+    * @param gen         a call-by-name Chisel module
+    * @param args        additional command line arguments to pass to Chisel
     * @param firtoolOpts additional [[circt.stage.FirtoolOption]] to pass to firtool
     * @return a string containing the Verilog output
     */
@@ -114,8 +120,9 @@ object ChiselStage {
       .value
 
   /** Compile a Chisel circuit to SystemVerilog with file output
-    * @param gen a call-by-name Chisel module
-    * @param args additional command line arguments to pass to Chisel
+    *
+    * @param gen         a call-by-name Chisel module
+    * @param args        additional command line arguments to pass to Chisel
     * @param firtoolOpts additional command line options to pass to firtool
     * @return a string containing the Verilog output
     */
@@ -129,6 +136,16 @@ object ChiselStage {
       chiselArgs,
       Seq(ChiselGeneratorAnnotation(() => gen)) ++ firtoolOpts.map(FirtoolOption(_))
     )
+  }
+
+  /** Return a Chisel circuit for a Chisel module
+    *
+    * @param gen a call-by-name Chisel module
+    */
+  def elaborate(
+    gen: => RawModule
+  ): chisel3.internal.firrtl.Circuit = {
+    chisel3.stage.ChiselStage.elaborate(gen)
   }
 }
 

--- a/src/test/scala/chisel3/testers/TestUtils.scala
+++ b/src/test/scala/chisel3/testers/TestUtils.scala
@@ -2,10 +2,7 @@
 
 package chisel3.testers
 
-import TesterDriver.Backend
-import chisel3.{Bundle, RawModule}
-import chisel3.internal.firrtl.Circuit
-import chisel3.stage.ChiselStage
+import chisel3.testers.TesterDriver.Backend
 import firrtl.AnnotationSeq
 
 object TestUtils {

--- a/src/test/scala/chiselTests/AnalogSpec.scala
+++ b/src/test/scala/chiselTests/AnalogSpec.scala
@@ -3,7 +3,7 @@
 package chiselTests
 
 import chisel3._
-import chisel3.stage.ChiselStage
+import circt.stage.ChiselStage
 import chisel3.util._
 import chisel3.testers.{BasicTester, TesterDriver}
 import chisel3.experimental.{attach, Analog, BaseModule}

--- a/src/test/scala/chiselTests/Assert.scala
+++ b/src/test/scala/chiselTests/Assert.scala
@@ -3,7 +3,7 @@
 package chiselTests
 
 import chisel3._
-import chisel3.stage.ChiselStage
+import circt.stage.ChiselStage
 import chisel3.testers.BasicTester
 import chisel3.util._
 
@@ -178,7 +178,7 @@ class AssertSpec extends ChiselFlatSpec with Utils {
     assertTesterPasses { new FormattedAssertTester }
   }
   they should "allow printf-style format strings in Assumes" in {
-    val chirrtl = ChiselStage.emitChirrtl(new PrintableAssumeTester)
+    val chirrtl = ChiselStage.emitCHIRRTL(new PrintableAssumeTester)
     chirrtl should include(
       """assume(w === 255.U, cf\"Assumption failed, Wire w =/= $w%%%%x\")\n", w)"""
     )

--- a/src/test/scala/chiselTests/AsyncResetSpec.scala
+++ b/src/test/scala/chiselTests/AsyncResetSpec.scala
@@ -3,7 +3,7 @@
 package chiselTests
 
 import chisel3._
-import chisel3.stage.ChiselStage
+import circt.stage.ChiselStage
 import chisel3.util.{Counter, Queue}
 import chisel3.testers.BasicTester
 import firrtl.checks.CheckResets.NonLiteralAsyncResetValueException

--- a/src/test/scala/chiselTests/AutoClonetypeSpec.scala
+++ b/src/test/scala/chiselTests/AutoClonetypeSpec.scala
@@ -3,10 +3,10 @@
 package chiselTests
 
 import chisel3._
-import chisel3.testers.TestUtils
-import chisel3.util.QueueIO
-import chisel3.stage.ChiselStage.elaborate
 import chisel3.experimental.AutoCloneType
+import chisel3.util.QueueIO
+import circt.stage.ChiselStage.elaborate
+
 import scala.collection.immutable.ListMap
 
 class BundleWithIntArg(val i: Int) extends Bundle {

--- a/src/test/scala/chiselTests/AutoNestedCloneSpec.scala
+++ b/src/test/scala/chiselTests/AutoNestedCloneSpec.scala
@@ -2,8 +2,7 @@
 
 package chiselTests
 import chisel3._
-import chisel3.testers.TestUtils
-import chisel3.stage.ChiselStage.elaborate
+import circt.stage.ChiselStage.elaborate
 import org.scalatest.matchers.should.Matchers
 
 class BundleWithAnonymousInner(val w: Int) extends Bundle {

--- a/src/test/scala/chiselTests/BetterNamingTests.scala
+++ b/src/test/scala/chiselTests/BetterNamingTests.scala
@@ -3,7 +3,7 @@
 package chiselTests
 
 import chisel3._
-import chisel3.stage.ChiselStage
+import circt.stage.ChiselStage
 import chisel3.util._
 
 import scala.collection.mutable
@@ -98,8 +98,8 @@ class BetterNamingTests extends ChiselFlatSpec {
       }
       WireDefault(3.U)
     }
-    val withLits = ChiselStage.emitChirrtl(new MyModule(true))
-    val noLits = ChiselStage.emitChirrtl(new MyModule(false))
+    val withLits = ChiselStage.emitCHIRRTL(new MyModule(true))
+    val noLits = ChiselStage.emitCHIRRTL(new MyModule(false))
     withLits should equal(noLits)
   }
 }

--- a/src/test/scala/chiselTests/BlackBox.scala
+++ b/src/test/scala/chiselTests/BlackBox.scala
@@ -4,9 +4,9 @@ package chiselTests
 
 import chisel3._
 import chisel3.experimental._
-import chisel3.stage.ChiselStage
 import chisel3.testers.{BasicTester, TesterDriver}
 import chisel3.util._
+import circt.stage.ChiselStage
 
 class BlackBoxInverter extends BlackBox {
   val io = IO(new Bundle() {

--- a/src/test/scala/chiselTests/BulkConnectSpec.scala
+++ b/src/test/scala/chiselTests/BulkConnectSpec.scala
@@ -2,14 +2,14 @@ package chiselTests
 
 import chisel3._
 import chisel3.util.Decoupled
-import chisel3.stage.ChiselStage
+import circt.stage.ChiselStage
 import chisel3.testers.BasicTester
 
 import scala.annotation.nowarn
 
 class BulkConnectSpec extends ChiselPropSpec {
   property("Chisel connects should emit FIRRTL bulk connects when possible") {
-    val chirrtl = ChiselStage.emitChirrtl(new Module {
+    val chirrtl = ChiselStage.emitCHIRRTL(new Module {
       val io = IO(new Bundle {
         val inMono = Input(Vec(4, UInt(8.W)))
         val outMono = Output(Vec(4, UInt(8.W)))
@@ -44,7 +44,7 @@ class BulkConnectSpec extends ChiselPropSpec {
       val buzz = if (child) new BundleChild else new BundleParent
     }
 
-    val chirrtl = ChiselStage.emitChirrtl(new Module {
+    val chirrtl = ChiselStage.emitCHIRRTL(new Module {
       // Checking MonoConnect
       val in = IO(Input(new MyBundle(true)))
       val out = IO(Output(new MyBundle(false)))
@@ -69,7 +69,7 @@ class BulkConnectSpec extends ChiselPropSpec {
   }
 
   property("Chisel connects should not emit FIRRTL bulk connects between differing FIRRTL types") {
-    val chirrtl = ChiselStage.emitChirrtl(new Module {
+    val chirrtl = ChiselStage.emitCHIRRTL(new Module {
       val in = IO(Flipped(new Bundle {
         val foo = Flipped(new Bundle {
           val bar = Input(UInt(8.W))
@@ -91,7 +91,7 @@ class BulkConnectSpec extends ChiselPropSpec {
   }
 
   property("Chisel connects should not emit a FIRRTL bulk connect for a bidirectional MonoConnect") {
-    val chirrtl = ChiselStage.emitChirrtl(new Module {
+    val chirrtl = ChiselStage.emitCHIRRTL(new Module {
       val enq = IO(Flipped(Decoupled(UInt(8.W))))
       val deq = IO(Decoupled(UInt(8.W)))
 
@@ -116,7 +116,7 @@ class BulkConnectSpec extends ChiselPropSpec {
       val I: Bool = Input(Bool())
     }
 
-    val chirrtl = ChiselStage.emitChirrtl(new Module {
+    val chirrtl = ChiselStage.emitCHIRRTL(new Module {
       val io: MyBundle = IO(Flipped(new MyBundle))
 
       val bb = Module(new BlackBox {
@@ -131,7 +131,7 @@ class BulkConnectSpec extends ChiselPropSpec {
   }
 
   property("MonoConnect should bulk connect undirectioned internal wires") {
-    val chirrtl = ChiselStage.emitChirrtl(new Module {
+    val chirrtl = ChiselStage.emitCHIRRTL(new Module {
       val io = IO(new Bundle {})
       val w1 = Wire(Vec(2, UInt(8.W)))
       val w2 = Wire(Vec(2, UInt(8.W)))

--- a/src/test/scala/chiselTests/BundleElementsSpec.scala
+++ b/src/test/scala/chiselTests/BundleElementsSpec.scala
@@ -3,8 +3,8 @@
 package chiselTests
 
 import chisel3._
-import chisel3.experimental.FixedPoint
-import chisel3.stage.ChiselStage
+import chisel3.experimental.{ChiselEnum, FixedPoint}
+import circt.stage.ChiselStage
 import chisel3.util.Decoupled
 import org.scalatest.exceptions.TestFailedException
 import org.scalatest.freespec.AnyFreeSpec
@@ -299,48 +299,48 @@ class BundleElementsSpec extends AnyFreeSpec with Matchers {
   }
 
   "Complex Bundle with inheritance, traits and params. DebugProblem1" in {
-    ChiselStage.emitFirrtl(new BpipIsComplexBundle)
+    ChiselStage.emitCHIRRTL(new BpipIsComplexBundle)
   }
 
   "Decoupled Bundle with inheritance" in {
-    ChiselStage.emitFirrtl(new HasDecoupledBundleByInheritance)
+    ChiselStage.emitCHIRRTL(new HasDecoupledBundleByInheritance)
   }
 
   "Simple bundle inheritance. DebugProblem3" in {
-    ChiselStage.emitFirrtl(new DebugProblem3)
+    ChiselStage.emitCHIRRTL(new DebugProblem3)
   }
 
   "Bundles containing Seq[Data] should be compile erorr. HasBadSeqBundle" in {
     intercept[ChiselException] {
-      ChiselStage.emitFirrtl(new HasBadSeqBundle)
+      ChiselStage.emitCHIRRTL(new HasBadSeqBundle)
     }
   }
 
   "IgnoreSeqInBundle allows Seq[Data] in bundle" in {
-    ChiselStage.emitFirrtl(new UsesIgnoreSeqInBundle)
+    ChiselStage.emitCHIRRTL(new UsesIgnoreSeqInBundle)
   }
 
   "Simple field ordering test." in {
-    ChiselStage.emitFirrtl(new ForFieldOrderingTest)
+    ChiselStage.emitCHIRRTL(new ForFieldOrderingTest)
   }
 
   "Val params to Bundle should be an Exception." in {
-    ChiselStage.emitFirrtl(new HasValParamsToBundle)
+    ChiselStage.emitCHIRRTL(new HasValParamsToBundle)
   }
 
   "Should handle gen params passed to superclasses" in {
-    ChiselStage.emitFirrtl(new HasGenParamsPassedToSuperclasses)
+    ChiselStage.emitCHIRRTL(new HasGenParamsPassedToSuperclasses)
   }
 
   "Aliased fields should be detected and throw an exception, because gen: Data, with no =>" in {
     intercept[AliasedAggregateFieldException] {
-      ChiselStage.emitFirrtl(new UsesGenFiedldsInSuperClass)
+      ChiselStage.emitCHIRRTL(new UsesGenFiedldsInSuperClass)
     }
   }
 
   "Error when bundle fields are hardware, such as literal values. HasHardwareFieldsInBundle" in {
     val e = intercept[ExpectedChiselTypeException] {
-      ChiselStage.emitFirrtl(new HasHardwareFieldsInBundle)
+      ChiselStage.emitCHIRRTL(new HasHardwareFieldsInBundle)
     }
     e.getMessage should include(
       "Bundle: BpipBadBundleWithHardware contains hardware fields: bpipWithHardwareBad: UInt<16>(244)"
@@ -348,7 +348,7 @@ class BundleElementsSpec extends AnyFreeSpec with Matchers {
   }
 
   "Aliased fields not created when using gen: => Data" in {
-    ChiselStage.emitFirrtl(new UsesBundleWithGeneratorField)
+    ChiselStage.emitCHIRRTL(new UsesBundleWithGeneratorField)
   }
 
   class OptionBundle(val hasIn: Boolean) extends Bundle {
@@ -369,7 +369,7 @@ class BundleElementsSpec extends AnyFreeSpec with Matchers {
   }
 
   "plugin should work with Bundles with Option fields" in {
-    ChiselStage.emitFirrtl(new UsesBundleWithOptionFields)
+    ChiselStage.emitCHIRRTL(new UsesBundleWithOptionFields)
   }
 
   "plugin should work with enums in bundles" in {
@@ -377,7 +377,7 @@ class BundleElementsSpec extends AnyFreeSpec with Matchers {
       val s0, s1, s2 = Value
     }
 
-    ChiselStage.emitFirrtl(new Module {
+    ChiselStage.emitCHIRRTL(new Module {
       val out = IO(Output(new Bundle {
         val a = UInt(8.W)
         val b = Bool()
@@ -390,7 +390,7 @@ class BundleElementsSpec extends AnyFreeSpec with Matchers {
   "plugin will NOT see fields that are Data but declared in some way as Any" in {
     //This is not incompatible with chisel not using the plugin, but this code is considered bad practice
 
-    ChiselStage.emitFirrtl(new Module {
+    ChiselStage.emitCHIRRTL(new Module {
       val out = IO(Output(new Bundle {
         val a = UInt(8.W)
         val b: Any = Bool()
@@ -411,7 +411,7 @@ class BundleElementsSpec extends AnyFreeSpec with Matchers {
 
     def checkAssertion(checks: (BundleAB => (String, Data))*)(expectedMessage: String): Unit = {
       intercept[AssertionError] {
-        ChiselStage.emitFirrtl(new Module {
+        ChiselStage.emitCHIRRTL(new Module {
           val out = IO(new BundleAB)
           assertElementsMatchExpected(out)(checks: _*)
         })
@@ -443,7 +443,7 @@ class BundleElementsSpec extends AnyFreeSpec with Matchers {
   }
 
   "plugin should error correctly when bundles contain only a Option field" in {
-    ChiselStage.emitFirrtl(new Module {
+    ChiselStage.emitCHIRRTL(new Module {
       val io = IO(new Bundle {
         val foo = Input(UInt(8.W))
         val x = new Bundle {
@@ -489,7 +489,7 @@ class BundleElementsSpec extends AnyFreeSpec with Matchers {
       )
     }
 
-    ChiselStage.emitFirrtl(new ALU(ALUConfig(10, mul = true, b = false)))
+    ChiselStage.emitCHIRRTL(new ALU(ALUConfig(10, mul = true, b = false)))
   }
 
   "TraceSpec test, different version found in TraceSpec.scala" in {
@@ -528,7 +528,7 @@ class BundleElementsSpec extends AnyFreeSpec with Matchers {
       val s0, s1, s2 = Value
     }
 
-    ChiselStage.emitFirrtl(new Module1)
+    ChiselStage.emitCHIRRTL(new Module1)
   }
 }
 /* Checks that the elements method of a bundle matches the testers idea of what the bundle field names and their

--- a/src/test/scala/chiselTests/BundleLiteralSpec.scala
+++ b/src/test/scala/chiselTests/BundleLiteralSpec.scala
@@ -3,7 +3,7 @@
 package chiselTests
 
 import chisel3._
-import chisel3.stage.ChiselStage
+import circt.stage.ChiselStage
 import chisel3.testers.BasicTester
 import chisel3.experimental.BundleLiterals._
 import chisel3.experimental.VecLiterals.AddVecLiteralConstructor

--- a/src/test/scala/chiselTests/BundleSpec.scala
+++ b/src/test/scala/chiselTests/BundleSpec.scala
@@ -3,9 +3,8 @@
 package chiselTests
 
 import chisel3._
-import chisel3.util.Decoupled
-import chisel3.stage.ChiselStage
 import chisel3.testers.BasicTester
+import circt.stage.ChiselStage
 
 trait BundleSpecUtils {
   class BundleFooBar extends Bundle {

--- a/src/test/scala/chiselTests/Clock.scala
+++ b/src/test/scala/chiselTests/Clock.scala
@@ -3,8 +3,8 @@
 package chiselTests
 
 import chisel3._
-import chisel3.stage.ChiselStage
 import chisel3.testers.BasicTester
+import circt.stage.ChiselStage
 
 class ClockAsUIntTester extends BasicTester {
   assert(true.B.asClock.asUInt === 1.U)
@@ -30,7 +30,7 @@ class ClockSpec extends ChiselPropSpec {
   }
 
   property("Should be able to use withClock in a module with no reset") {
-    val circuit = ChiselStage.emitChirrtl(new WithClockAndNoReset)
+    val circuit = ChiselStage.emitCHIRRTL(new WithClockAndNoReset)
     circuit.contains("reg a : UInt<1>, clock2") should be(true)
   }
 }

--- a/src/test/scala/chiselTests/CloneModuleSpec.scala
+++ b/src/test/scala/chiselTests/CloneModuleSpec.scala
@@ -3,7 +3,7 @@
 package chiselTests
 
 import chisel3._
-import chisel3.stage.ChiselStage
+import circt.stage.ChiselStage
 import chisel3.util.{log2Ceil, Decoupled, DeqIO, EnqIO, Queue, QueueIO}
 import chisel3.experimental.{CloneModuleAsRecord, IO}
 import chisel3.testers.BasicTester

--- a/src/test/scala/chiselTests/CompatibilityInteroperabilitySpec.scala
+++ b/src/test/scala/chiselTests/CompatibilityInteroperabilitySpec.scala
@@ -3,7 +3,7 @@
 package chiselTests
 
 import scala.collection.immutable.ListMap
-import chisel3.stage.ChiselStage.emitChirrtl
+import circt.stage.ChiselStage.emitCHIRRTL
 
 import scala.annotation.nowarn
 
@@ -701,7 +701,7 @@ class CompatibilityInteroperabilitySpec extends ChiselFlatSpec {
         foo.io <> mirror.io
       }
     }
-    val chirrtl = emitChirrtl(new Chisel3.Top)
+    val chirrtl = emitCHIRRTL(new Chisel3.Top)
     chirrtl should include("foo.io.bar <= mirror.bar")
     chirrtl should include("mirror.foo <= foo.io.foo")
     chirrtl should include("foo.io.quz.q.bits <- mirror.quz.q.bits")
@@ -727,10 +727,10 @@ class CompatibilityInteroperabilitySpec extends ChiselFlatSpec {
         out <> in
       }
     }
-    val chirrtl0 = emitChirrtl(new Chisel3.MyModule(true))
+    val chirrtl0 = emitCHIRRTL(new Chisel3.MyModule(true))
     chirrtl0 shouldNot include("<=")
     chirrtl0 should include("out <- in")
-    val chirrtl1 = emitChirrtl(new Chisel3.MyModule(true))
+    val chirrtl1 = emitCHIRRTL(new Chisel3.MyModule(true))
     chirrtl1 shouldNot include("<=")
     chirrtl1 should include("out <- in")
   }
@@ -756,10 +756,10 @@ class CompatibilityInteroperabilitySpec extends ChiselFlatSpec {
         out <> in
       }
     }
-    val chirrtl0 = emitChirrtl(new Chisel3.MyModule(true))
+    val chirrtl0 = emitCHIRRTL(new Chisel3.MyModule(true))
     chirrtl0 shouldNot include("<=")
     chirrtl0 should include("out <- in")
-    val chirrtl1 = emitChirrtl(new Chisel3.MyModule(true))
+    val chirrtl1 = emitCHIRRTL(new Chisel3.MyModule(true))
     chirrtl1 shouldNot include("<=")
     chirrtl1 should include("out <- in")
   }
@@ -785,10 +785,10 @@ class CompatibilityInteroperabilitySpec extends ChiselFlatSpec {
         out <> in
       }
     }
-    val chirrtl0 = emitChirrtl(new Chisel3.MyModule(true))
+    val chirrtl0 = emitCHIRRTL(new Chisel3.MyModule(true))
     chirrtl0 shouldNot include("<=")
     chirrtl0 should include("out <- in")
-    val chirrtl1 = emitChirrtl(new Chisel3.MyModule(true))
+    val chirrtl1 = emitCHIRRTL(new Chisel3.MyModule(true))
     chirrtl1 shouldNot include("<=")
     chirrtl1 should include("out <- in")
   }
@@ -814,10 +814,10 @@ class CompatibilityInteroperabilitySpec extends ChiselFlatSpec {
         out <> in
       }
     }
-    val chirrtl0 = emitChirrtl(new Chisel3.MyModule(true))
+    val chirrtl0 = emitCHIRRTL(new Chisel3.MyModule(true))
     chirrtl0 should include("out <= in")
     chirrtl0 shouldNot include("out <- in")
-    val chirrtl1 = emitChirrtl(new Chisel3.MyModule(true))
+    val chirrtl1 = emitCHIRRTL(new Chisel3.MyModule(true))
     chirrtl1 should include("out <= in")
     chirrtl1 shouldNot include("out <- in")
   }

--- a/src/test/scala/chiselTests/CompatibilitySpec.scala
+++ b/src/test/scala/chiselTests/CompatibilitySpec.scala
@@ -2,7 +2,7 @@
 
 package chiselTests
 
-import chisel3.stage.ChiselStage
+import circt.stage.ChiselStage
 import chisel3.testers.BasicTester
 
 import org.scalacheck.Gen
@@ -565,7 +565,7 @@ class CompatibilitySpec extends ChiselFlatSpec with ScalaCheckDrivenPropertyChec
       val io = IO(new MyRecord)
       io.bar := io.foo
     }
-    val verilog = ChiselStage.emitVerilog(new Foo)
+    val verilog = ChiselStage.emitSystemVerilog(new Foo)
     // Check that the names are correct (and that the FIRRTL is valid)
     verilog should include("assign io_out_0 = io_in_0;")
   }
@@ -579,7 +579,7 @@ class CompatibilitySpec extends ChiselFlatSpec with ScalaCheckDrivenPropertyChec
       io.suggestName("potato")
       io.bar := io.foo
     }
-    val verilog = ChiselStage.emitVerilog(new MyModule)
+    val verilog = ChiselStage.emitSystemVerilog(new MyModule)
     verilog should include("input  [7:0] io_foo")
     verilog should include("output [7:0] io_bar")
   }
@@ -593,7 +593,7 @@ class CompatibilitySpec extends ChiselFlatSpec with ScalaCheckDrivenPropertyChec
       val wire = Wire(init = io.foo)
       io.bar := wire
     }
-    val verilog = ChiselStage.emitVerilog(new MyModule)
+    val verilog = ChiselStage.emitSystemVerilog(new MyModule)
     verilog should include("input  [7:0] io_foo")
     verilog should include("output [7:0] io_bar")
   }
@@ -635,7 +635,7 @@ class CompatibilitySpec extends ChiselFlatSpec with ScalaCheckDrivenPropertyChec
       io.out := inst.io.out
     }
 
-    val chirrtl = ChiselStage.emitChirrtl(new ExtModuleInvalidatedTester)
+    val chirrtl = ChiselStage.emitCHIRRTL(new ExtModuleInvalidatedTester)
     chirrtl should include("inst.in is invalid")
     chirrtl should include("inst.out is invalid")
   }

--- a/src/test/scala/chiselTests/CompileOptionsTest.scala
+++ b/src/test/scala/chiselTests/CompileOptionsTest.scala
@@ -4,7 +4,7 @@ package chiselTests
 
 import chisel3._
 import chisel3.CompileOptions._
-import chisel3.stage.ChiselStage
+import circt.stage.ChiselStage
 
 import scala.annotation.nowarn
 

--- a/src/test/scala/chiselTests/ConnectSpec.scala
+++ b/src/test/scala/chiselTests/ConnectSpec.scala
@@ -2,12 +2,10 @@
 
 package chiselTests
 
-import org.scalatest._
-
 import chisel3._
 import chisel3.experimental.{Analog, FixedPoint}
-import chisel3.stage.ChiselStage
 import chisel3.testers.BasicTester
+import circt.stage.ChiselStage
 
 abstract class CrossCheck extends Bundle {
   val in:  Data

--- a/src/test/scala/chiselTests/DataEqualitySpec.scala
+++ b/src/test/scala/chiselTests/DataEqualitySpec.scala
@@ -3,8 +3,8 @@ package chiselTests
 import chisel3._
 import chisel3.experimental.VecLiterals._
 import chisel3.experimental.BundleLiterals._
-import chisel3.experimental.{Analog, ChiselRange, FixedPoint, Interval}
-import chisel3.stage.ChiselStage
+import chisel3.experimental.{Analog, ChiselEnum, ChiselRange, FixedPoint, Interval}
+import circt.stage.ChiselStage
 import chisel3.testers.BasicTester
 import chisel3.util.Valid
 
@@ -238,11 +238,11 @@ class DataEqualitySpec extends ChiselFlatSpec with Utils {
     }
 
     // Compare the verilog generated from both test cases and verify that they both are equal to true
-    val verilog1 = ChiselStage.emitVerilog(
+    val verilog1 = ChiselStage.emitSystemVerilog(
       new EqualityModule(Valid(UInt(8.W)).Lit(_.bits -> 123.U), Valid(UInt(8.W)).Lit(_.bits -> 123.U))
     )
     val verilog2 =
-      ChiselStage.emitVerilog(new EqualityModule(WireInit(UInt(8.W), DontCare), WireInit(UInt(8.W), DontCare)))
+      ChiselStage.emitSystemVerilog(new EqualityModule(WireInit(UInt(8.W), DontCare), WireInit(UInt(8.W), DontCare)))
 
     verilog1 should include("assign out = 1'h1;")
     verilog2 should include("assign out = 1'h1;")

--- a/src/test/scala/chiselTests/DataPrint.scala
+++ b/src/test/scala/chiselTests/DataPrint.scala
@@ -7,7 +7,7 @@ import org.scalatest._
 import chisel3._
 import chisel3.experimental.FixedPoint
 import chisel3.experimental.BundleLiterals._
-import chisel3.stage.ChiselStage
+import circt.stage.ChiselStage
 import org.scalatest.matchers.should.Matchers
 
 class DataPrintSpec extends ChiselFlatSpec with Matchers {

--- a/src/test/scala/chiselTests/DecoupledSpec.scala
+++ b/src/test/scala/chiselTests/DecoupledSpec.scala
@@ -3,7 +3,7 @@
 package chiselTests
 
 import chisel3._
-import chisel3.stage.ChiselStage
+import circt.stage.ChiselStage
 import chisel3.util.Decoupled
 
 class DecoupledSpec extends ChiselFlatSpec {
@@ -20,7 +20,7 @@ class DecoupledSpec extends ChiselFlatSpec {
 
   "Decoupled.map" should "apply a function to a wrapped Data" in {
     val chirrtl = ChiselStage
-      .emitChirrtl(new Module {
+      .emitCHIRRTL(new Module {
         val enq = IO(Flipped(Decoupled(UInt(8.W))))
         val deq = IO(Decoupled(UInt(8.W)))
         deq <> enq.map(_ + 1.U)
@@ -57,7 +57,7 @@ class DecoupledSpec extends ChiselFlatSpec {
     }
 
     val chirrtl = ChiselStage
-      .emitChirrtl(new Module {
+      .emitCHIRRTL(new Module {
         val enq = IO(Flipped(Decoupled(new TestBundle)))
         val deq = IO(Decoupled(new TestBundle))
         deq <> enq.map(func)
@@ -91,7 +91,7 @@ class DecoupledSpec extends ChiselFlatSpec {
     }
 
     val chirrtl = ChiselStage
-      .emitChirrtl(new Module {
+      .emitCHIRRTL(new Module {
         val enq = IO(Flipped(Decoupled(new TestBundle)))
         val deq = IO(Decoupled(UInt(8.W)))
         deq <> enq.map(bundle => bundle.foo & bundle.bar)

--- a/src/test/scala/chiselTests/Direction.scala
+++ b/src/test/scala/chiselTests/Direction.scala
@@ -5,7 +5,7 @@ package chiselTests
 import org.scalatest._
 import chisel3._
 import chisel3.experimental.OpaqueType
-import chisel3.stage.ChiselStage
+import circt.stage.ChiselStage
 import org.scalatest.matchers.should.Matchers
 
 import scala.collection.immutable.SeqMap
@@ -152,7 +152,7 @@ class DirectionSpec extends ChiselPropSpec with Matchers with Utils {
       DataMirror.directionOf(fizz) should be(Direction.Bidirectional(Direction.Default))
       DataMirror.directionOf(buzz) should be(Direction.Bidirectional(Direction.Default))
     }
-    val chirrtl = ChiselStage.emitChirrtl(new Top)
+    val chirrtl = ChiselStage.emitCHIRRTL(new Top)
     chirrtl should include("input foo")
     chirrtl should include("output fizz")
     chirrtl should include("output buzz")
@@ -268,7 +268,7 @@ class DirectionSpec extends ChiselPropSpec with Matchers with Utils {
       assert(DataMirror.directionOf(flippedVecFlipped(index).b) == Direction.Output)
     }
 
-    val emitted: String = ChiselStage.emitChirrtl(new MyModule)
+    val emitted: String = ChiselStage.emitCHIRRTL(new MyModule)
     val firrtl:  String = ChiselStage.convert(new MyModule).serialize
 
     // Check that emitted directions are correct.
@@ -337,7 +337,7 @@ class DirectionSpec extends ChiselPropSpec with Matchers with Utils {
       assert(DataMirror.directionOf(vecOutputFlipped(index).b) == Direction.Output)
     }
 
-    val emitted: String = ChiselStage.emitChirrtl(new MyModule)
+    val emitted: String = ChiselStage.emitCHIRRTL(new MyModule)
     val firrtl:  String = ChiselStage.convert(new MyModule).serialize
 
     // Check that emitted directions are correct.
@@ -368,7 +368,7 @@ class DirectionSpec extends ChiselPropSpec with Matchers with Utils {
       outgoing <> incoming
     }
 
-    val emitted: String = ChiselStage.emitChirrtl(new MyModule)
+    val emitted: String = ChiselStage.emitCHIRRTL(new MyModule)
 
     // Check that emitted directions are correct.
     assert(emitted.contains("input incoming : { bits : UInt<3>, valid : UInt<1>, flip ready : UInt<1>}"))
@@ -395,7 +395,7 @@ class DirectionSpec extends ChiselPropSpec with Matchers with Utils {
       io.monitor.ready := io.driver.ready
     }
 
-    val emitted: String = ChiselStage.emitChirrtl(new MyModule)
+    val emitted: String = ChiselStage.emitCHIRRTL(new MyModule)
 
     assert(
       emitted.contains(
@@ -423,7 +423,7 @@ class DirectionSpec extends ChiselPropSpec with Matchers with Utils {
       val sink = IO(Input(Vec(1, new Decoupled())))
     }
 
-    val emitted: String = ChiselStage.emitChirrtl(new MyModule)
+    val emitted: String = ChiselStage.emitCHIRRTL(new MyModule)
 
     assert(
       emitted.contains(
@@ -457,7 +457,7 @@ class DirectionSpec extends ChiselPropSpec with Matchers with Utils {
       val w = Wire(new MyOpaqueType())
     }
 
-    val emitted: String = ChiselStage.emitChirrtl(new MyModule)
+    val emitted: String = ChiselStage.emitCHIRRTL(new MyModule)
 
     assert(
       emitted.contains(

--- a/src/test/scala/chiselTests/DontTouchSpec.scala
+++ b/src/test/scala/chiselTests/DontTouchSpec.scala
@@ -3,7 +3,7 @@
 package chiselTests
 
 import chisel3._
-import chisel3.stage.ChiselStage
+import circt.stage.ChiselStage
 
 class HasDeadCodeChild(withDontTouch: Boolean) extends Module {
   val io = IO(new Bundle {

--- a/src/test/scala/chiselTests/EnableShiftRegister.scala
+++ b/src/test/scala/chiselTests/EnableShiftRegister.scala
@@ -2,7 +2,7 @@
 
 package chiselTests
 import chisel3._
-import chisel3.stage.ChiselStage
+import circt.stage.ChiselStage
 
 class EnableShiftRegister extends Module {
   val io = IO(new Bundle {

--- a/src/test/scala/chiselTests/ExtModule.scala
+++ b/src/test/scala/chiselTests/ExtModule.scala
@@ -4,7 +4,7 @@ package chiselTests
 
 import chisel3._
 import chisel3.experimental._
-import chisel3.stage.ChiselStage
+import circt.stage.ChiselStage
 import chisel3.testers.{BasicTester, TesterDriver}
 
 // Avoid collisions with regular BlackBox tests by putting ExtModule blackboxes
@@ -117,20 +117,20 @@ class ExtModuleSpec extends ChiselFlatSpec {
   behavior.of("ExtModule")
 
   it should "work with .suggestName (aka it should not require reflection for naming)" in {
-    val chirrtl = ChiselStage.emitChirrtl(new ExtModuleWithSuggestNameTester)
+    val chirrtl = ChiselStage.emitCHIRRTL(new ExtModuleWithSuggestNameTester)
     chirrtl should include("input foo : UInt<8>")
     chirrtl should include("inst.foo <= in")
   }
 
   it should "work with FlatIO" in {
-    val chirrtl = ChiselStage.emitChirrtl(new ExtModuleWithFlatIOTester)
+    val chirrtl = ChiselStage.emitCHIRRTL(new ExtModuleWithFlatIOTester)
     chirrtl should include("io.out <= inst.out")
     chirrtl should include("inst.in <= io.in")
     chirrtl shouldNot include("badIO")
   }
 
   it should "not have invalidated ports in a chisel3._ context" in {
-    val chirrtl = ChiselStage.emitChirrtl(new ExtModuleInvalidatedTester)
+    val chirrtl = ChiselStage.emitCHIRRTL(new ExtModuleInvalidatedTester)
     chirrtl shouldNot include("inst.in is invalid")
     chirrtl shouldNot include("inst.out is invalid")
   }

--- a/src/test/scala/chiselTests/FixedPointSpec.scala
+++ b/src/test/scala/chiselTests/FixedPointSpec.scala
@@ -5,9 +5,8 @@ package chiselTests
 import chisel3._
 import chisel3.experimental.FixedPoint
 import chisel3.internal.firrtl.{BinaryPoint, Width}
-import chisel3.stage.ChiselStage
 import chisel3.testers.BasicTester
-import org.scalatest._
+import circt.stage.ChiselStage
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 

--- a/src/test/scala/chiselTests/GCD.scala
+++ b/src/test/scala/chiselTests/GCD.scala
@@ -3,8 +3,8 @@
 package chiselTests
 
 import chisel3._
-import chisel3.stage.ChiselStage
 import chisel3.testers.BasicTester
+import circt.stage.ChiselStage
 
 class GCD extends Module {
   val io = IO(new Bundle {

--- a/src/test/scala/chiselTests/IOCompatibility.scala
+++ b/src/test/scala/chiselTests/IOCompatibility.scala
@@ -3,8 +3,7 @@
 package chiselTests
 
 import chisel3._
-import chisel3.stage.ChiselStage
-import org.scalatest._
+import circt.stage.ChiselStage
 import org.scalatest.matchers.should.Matchers
 
 class IOCSimpleIO extends Bundle {

--- a/src/test/scala/chiselTests/IllegalRefSpec.scala
+++ b/src/test/scala/chiselTests/IllegalRefSpec.scala
@@ -3,7 +3,7 @@
 package chiselTests
 
 import chisel3._
-import chisel3.stage.ChiselStage
+import circt.stage.ChiselStage
 
 object IllegalRefSpec {
   class IllegalRefInner extends RawModule {

--- a/src/test/scala/chiselTests/InstanceNameSpec.scala
+++ b/src/test/scala/chiselTests/InstanceNameSpec.scala
@@ -3,7 +3,7 @@
 package chiselTests
 
 import chisel3._
-import chisel3.stage.ChiselStage
+import circt.stage.ChiselStage
 import chisel3.util.Queue
 
 import chisel3.internal.ChiselException

--- a/src/test/scala/chiselTests/LazyCloneSpec.scala
+++ b/src/test/scala/chiselTests/LazyCloneSpec.scala
@@ -4,8 +4,7 @@ package chiselTests
 
 import chisel3._
 import chisel3.experimental.AutoCloneType
-import chisel3.stage.ChiselStage
-
+import circt.stage.ChiselStage
 import collection.immutable.VectorMap
 
 class LazyCloneSpec extends ChiselFlatSpec {

--- a/src/test/scala/chiselTests/LiteralExtractorSpec.scala
+++ b/src/test/scala/chiselTests/LiteralExtractorSpec.scala
@@ -3,10 +3,11 @@
 package chiselTests
 
 import chisel3._
-import chisel3.experimental._
 import chisel3.experimental.BundleLiterals._
-import chisel3.stage.ChiselStage
+import chisel3.experimental._
 import chisel3.testers.BasicTester
+import circt.stage.ChiselStage
+
 import scala.collection.immutable.ListMap
 
 class LiteralExtractorSpec extends ChiselFlatSpec {

--- a/src/test/scala/chiselTests/LiteralToTargetSpec.scala
+++ b/src/test/scala/chiselTests/LiteralToTargetSpec.scala
@@ -3,9 +3,7 @@
 package chiselTests
 
 import chisel3._
-import chisel3.stage.ChiselStage
-
-import org.scalatest._
+import circt.stage.ChiselStage
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 

--- a/src/test/scala/chiselTests/Mem.scala
+++ b/src/test/scala/chiselTests/Mem.scala
@@ -3,9 +3,9 @@
 package chiselTests
 
 import chisel3._
-import chisel3.stage.ChiselStage
-import chisel3.util._
 import chisel3.testers.BasicTester
+import chisel3.util._
+import circt.stage.ChiselStage
 
 class MemVecTester extends BasicTester {
   val mem = Mem(2, Vec(2, UInt(8.W)))
@@ -235,7 +235,6 @@ class MemorySpec extends ChiselPropSpec {
   }
 
   property("memories in modules without implicit clock should compile without warning or error") {
-    val stage = new ChiselStage
-    stage.emitVerilog(new TrueDualPortMemory(4, 32))
+    ChiselStage.emitCHIRRTL(new TrueDualPortMemory(4, 32))
   }
 }

--- a/src/test/scala/chiselTests/MemorySearch.scala
+++ b/src/test/scala/chiselTests/MemorySearch.scala
@@ -3,7 +3,7 @@
 package chiselTests
 
 import chisel3._
-import chisel3.stage.ChiselStage
+import circt.stage.ChiselStage
 
 class MemorySearch extends Module {
   val io = IO(new Bundle {

--- a/src/test/scala/chiselTests/MixedVecSpec.scala
+++ b/src/test/scala/chiselTests/MixedVecSpec.scala
@@ -293,7 +293,7 @@ class MixedVecSpec extends ChiselPropSpec with Utils {
       io.outMono := (io.inMono: Data)
       io.outBi <> io.inBi
     })
-    chirrtl should include("io.outMono <= io.inMono @")
-    chirrtl should include("io.outBi <= io.inBi @")
+    chirrtl should include("io.outMono <= io.inMono")
+    chirrtl should include("io.outBi <= io.inBi")
   }
 }

--- a/src/test/scala/chiselTests/MixedVecSpec.scala
+++ b/src/test/scala/chiselTests/MixedVecSpec.scala
@@ -3,9 +3,9 @@
 package chiselTests
 
 import chisel3._
-import chisel3.stage.ChiselStage
 import chisel3.testers.BasicTester
 import chisel3.util._
+import circt.stage.ChiselStage
 import org.scalacheck.Shrink
 
 class MixedVecAssignTester(w: Int, values: List[Int]) extends BasicTester {
@@ -282,7 +282,7 @@ class MixedVecSpec extends ChiselPropSpec with Utils {
   }
 
   property("MixedVec connections should emit FIRRTL bulk connects when possible") {
-    val chirrtl = ChiselStage.emitChirrtl(new Module {
+    val chirrtl = ChiselStage.emitCHIRRTL(new Module {
       val io = IO(new Bundle {
         val inMono = Input(MixedVec(Seq(UInt(8.W), UInt(16.W), UInt(4.W), UInt(7.W))))
         val outMono = Output(MixedVec(Seq(UInt(8.W), UInt(16.W), UInt(4.W), UInt(7.W))))
@@ -293,7 +293,7 @@ class MixedVecSpec extends ChiselPropSpec with Utils {
       io.outMono := (io.inMono: Data)
       io.outBi <> io.inBi
     })
-    chirrtl should include("io.outMono <= io.inMono @[src/test/scala/chiselTests/MixedVecSpec.scala")
-    chirrtl should include("io.outBi <= io.inBi @[src/test/scala/chiselTests/MixedVecSpec.scala")
+    chirrtl should include("io.outMono <= io.inMono @")
+    chirrtl should include("io.outBi <= io.inBi @")
   }
 }

--- a/src/test/scala/chiselTests/ModuleExplicitResetSpec.scala
+++ b/src/test/scala/chiselTests/ModuleExplicitResetSpec.scala
@@ -2,7 +2,7 @@
 
 package chiselTests
 
-import chisel3.stage.ChiselStage
+import circt.stage.ChiselStage
 
 import scala.annotation.nowarn
 

--- a/src/test/scala/chiselTests/MultiAssign.scala
+++ b/src/test/scala/chiselTests/MultiAssign.scala
@@ -4,8 +4,8 @@ package chiselTests
 
 import chisel3._
 import chisel3.testers.BasicTester
-import chisel3.stage.ChiselStage
 import chisel3.util._
+import circt.stage.ChiselStage
 
 class LastAssignTester() extends BasicTester {
   val countOnClockCycles = true.B

--- a/src/test/scala/chiselTests/MultiClockSpec.scala
+++ b/src/test/scala/chiselTests/MultiClockSpec.scala
@@ -5,7 +5,7 @@ package chiselTests
 import chisel3._
 import chisel3.util.Counter
 import chisel3.testers.{BasicTester, TesterDriver}
-import chisel3.stage.ChiselStage
+import circt.stage.ChiselStage
 
 /** Multi-clock test of a Reg using a different clock via withClock */
 class ClockDividerTest extends BasicTester {

--- a/src/test/scala/chiselTests/MuxSpec.scala
+++ b/src/test/scala/chiselTests/MuxSpec.scala
@@ -3,9 +3,9 @@
 package chiselTests
 
 import chisel3._
-import chisel3.stage.ChiselStage
-import chisel3.util.{log2Ceil, MuxLookup}
 import chisel3.testers.BasicTester
+import chisel3.util.{log2Ceil, MuxLookup}
+import circt.stage.ChiselStage
 
 class MuxTester extends BasicTester {
   assert(Mux(0.B, 1.U, 2.U) === 2.U)
@@ -45,27 +45,27 @@ class MuxLookupExhaustiveSpec extends ChiselPropSpec {
 
   val incomplete = () => Seq(0.U -> 1.U, 1.U -> 2.U, 2.U -> 3.U)
   property("The default value should not be optimized away for an incomplete MuxLookup") {
-    ChiselStage.emitChirrtl(new MuxLookupWrapper(keyWidth, default, incomplete)) should include(firrtlLit)
+    ChiselStage.emitCHIRRTL(new MuxLookupWrapper(keyWidth, default, incomplete)) should include(firrtlLit)
   }
 
   val exhaustive = () => (3.U -> 0.U) +: incomplete()
   property("The default value should be optimized away for an exhaustive MuxLookup") {
-    (ChiselStage.emitChirrtl(new MuxLookupWrapper(keyWidth, default, exhaustive)) should not).include(firrtlLit)
+    (ChiselStage.emitCHIRRTL(new MuxLookupWrapper(keyWidth, default, exhaustive)) should not).include(firrtlLit)
   }
 
   val overlap = () => (4096.U -> 0.U) +: incomplete()
   property("The default value should not be optimized away for a MuxLookup with 2^{keyWidth} non-distinct mappings") {
-    ChiselStage.emitChirrtl(new MuxLookupWrapper(keyWidth, default, overlap)) should include(firrtlLit)
+    ChiselStage.emitCHIRRTL(new MuxLookupWrapper(keyWidth, default, overlap)) should include(firrtlLit)
   }
 
   val nonLiteral = () => { val foo = Wire(UInt()); (foo -> 1.U) +: incomplete() }
   property("The default value should not be optimized away for a MuxLookup with a non-literal") {
-    ChiselStage.emitChirrtl(new MuxLookupWrapper(keyWidth, default, nonLiteral)) should include(firrtlLit)
+    ChiselStage.emitCHIRRTL(new MuxLookupWrapper(keyWidth, default, nonLiteral)) should include(firrtlLit)
   }
 
   val nonLiteralStillFull = () => { val foo = Wire(UInt()); (foo -> 1.U) +: exhaustive() }
   property("The default value should be optimized away for a MuxLookup with a non-literal that is still full") {
-    (ChiselStage.emitChirrtl(new MuxLookupWrapper(keyWidth, default, nonLiteralStillFull)) should not)
+    (ChiselStage.emitCHIRRTL(new MuxLookupWrapper(keyWidth, default, nonLiteralStillFull)) should not)
       .include(firrtlLit)
   }
 

--- a/src/test/scala/chiselTests/OptionBundle.scala
+++ b/src/test/scala/chiselTests/OptionBundle.scala
@@ -3,8 +3,8 @@
 package chiselTests
 
 import chisel3._
-import chisel3.stage.ChiselStage
 import chisel3.testers.BasicTester
+import circt.stage.ChiselStage
 
 class OptionBundle(val hasIn: Boolean) extends Bundle {
   val in = if (hasIn) {

--- a/src/test/scala/chiselTests/Padding.scala
+++ b/src/test/scala/chiselTests/Padding.scala
@@ -3,7 +3,7 @@
 package chiselTests
 
 import chisel3._
-import chisel3.stage.ChiselStage
+import circt.stage.ChiselStage
 
 class Padder extends Module {
   val io = IO(new Bundle {

--- a/src/test/scala/chiselTests/Printf.scala
+++ b/src/test/scala/chiselTests/Printf.scala
@@ -4,7 +4,7 @@ package chiselTests
 
 import chisel3._
 import chisel3.testers.BasicTester
-import chisel3.stage.ChiselStage
+import circt.stage.ChiselStage
 
 class SinglePrintfTester() extends BasicTester {
   val x = 254.U

--- a/src/test/scala/chiselTests/QueueSpec.scala
+++ b/src/test/scala/chiselTests/QueueSpec.scala
@@ -2,14 +2,12 @@
 
 package chiselTests
 
-import org.scalacheck._
-
 import chisel3._
 import chisel3.testers.BasicTester
 import chisel3.util._
 import chisel3.util.random.LFSR
-
-import chisel3.stage.ChiselStage
+import circt.stage.ChiselStage
+import org.scalacheck._
 
 class ThingsPassThroughTester(
   elements:       Seq[Int],
@@ -304,7 +302,7 @@ class QueueSpec extends ChiselPropSpec {
       out <> bar
     }
 
-    val chirrtl = ChiselStage.emitChirrtl(new HasTwoQueues)
+    val chirrtl = ChiselStage.emitCHIRRTL(new HasTwoQueues)
     chirrtl should include("inst foo_q of Queue")
     chirrtl should include("inst bar_q of Queue")
   }

--- a/src/test/scala/chiselTests/RawModuleSpec.scala
+++ b/src/test/scala/chiselTests/RawModuleSpec.scala
@@ -3,8 +3,8 @@
 package chiselTests
 
 import chisel3._
-import chisel3.stage.ChiselStage
 import chisel3.testers.BasicTester
+import circt.stage.ChiselStage
 
 class UnclockedPlusOne extends RawModule {
   val in = IO(Input(UInt(32.W)))

--- a/src/test/scala/chiselTests/RebindingSpec.scala
+++ b/src/test/scala/chiselTests/RebindingSpec.scala
@@ -3,7 +3,7 @@
 package chiselTests
 
 import chisel3._
-import chisel3.stage.ChiselStage
+import circt.stage.ChiselStage
 
 class RebindingSpec extends ChiselFlatSpec with Utils {
   "Rebinding a literal" should "fail" in {

--- a/src/test/scala/chiselTests/RecordSpec.scala
+++ b/src/test/scala/chiselTests/RecordSpec.scala
@@ -3,11 +3,11 @@
 package chiselTests
 
 import chisel3._
-import chisel3.stage.ChiselStage
+import chisel3.experimental.OpaqueType
+import chisel3.reflect.DataMirror
 import chisel3.testers.BasicTester
 import chisel3.util.{Counter, Queue}
-import chisel3.reflect.DataMirror
-import chisel3.experimental.OpaqueType
+import circt.stage.ChiselStage
 
 import scala.collection.immutable.SeqMap
 
@@ -241,11 +241,11 @@ class RecordSpec extends ChiselFlatSpec with RecordSpecUtils with Utils {
   }
 
   they should "emit FIRRTL bulk connects when possible" in {
-    val chirrtl = (new ChiselStage).emitChirrtl(
+    val chirrtl = ChiselStage.emitCHIRRTL(
       gen = new ConnectionTestModule(fooBarType, fooBarType)
     )
-    chirrtl should include("io.outMono <= io.inMono @[src/test/scala/chiselTests/RecordSpec.scala")
-    chirrtl should include("io.outBi <= io.inBi @[src/test/scala/chiselTests/RecordSpec.scala")
+    chirrtl should include("io.outMono <= io.inMono @")
+    chirrtl should include("io.outBi <= io.inBi @")
   }
 
   they should "not allow aliased fields" in {
@@ -266,7 +266,7 @@ class RecordSpec extends ChiselFlatSpec with RecordSpecUtils with Utils {
   }
 
   they should "support OpaqueType for maps with single unnamed elements" in {
-    val singleElementChirrtl = ChiselStage.emitChirrtl { new SingleElementRecordModule }
+    val singleElementChirrtl = ChiselStage.emitCHIRRTL { new SingleElementRecordModule }
     singleElementChirrtl should include("input in1 : UInt<8>")
     singleElementChirrtl should include("input in2 : UInt<8>")
     singleElementChirrtl should include("add(in1, in2)")
@@ -307,7 +307,7 @@ class RecordSpec extends ChiselFlatSpec with RecordSpecUtils with Utils {
   }
 
   they should "work correctly when connecting nested OpaqueType elements" in {
-    val nestedRecordChirrtl = ChiselStage.emitChirrtl { new NestedRecordModule }
+    val nestedRecordChirrtl = ChiselStage.emitCHIRRTL { new NestedRecordModule }
     nestedRecordChirrtl should include("input in : UInt<8>")
     nestedRecordChirrtl should include("output out : UInt<8>")
     nestedRecordChirrtl should include("inst.io.foo <= in")
@@ -329,7 +329,7 @@ class RecordSpec extends ChiselFlatSpec with RecordSpecUtils with Utils {
   }
 
   they should "work correctly when an OpaqueType overrides the def as false" in {
-    val chirrtl = ChiselStage.emitChirrtl(new NotActuallyOpaqueTypeModule)
+    val chirrtl = ChiselStage.emitCHIRRTL(new NotActuallyOpaqueTypeModule)
     chirrtl should include("input in : { y : UInt<8>, x : UInt<8>}")
     chirrtl should include("output out : { y : UInt<8>, x : UInt<8>}")
     chirrtl should include("out <= in")
@@ -344,7 +344,7 @@ class RecordSpec extends ChiselFlatSpec with RecordSpecUtils with Utils {
       out0 := in0
       out1 := in1
     }
-    val chirrtl = ChiselStage.emitChirrtl(new MyModule)
+    val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
     chirrtl should include("input in0 : { underlying : UInt<8>}")
     chirrtl should include("input in1 : UInt<8>")
   }

--- a/src/test/scala/chiselTests/Reg.scala
+++ b/src/test/scala/chiselTests/Reg.scala
@@ -3,10 +3,10 @@
 package chiselTests
 
 import chisel3._
-import chisel3.util._
 import chisel3.reflect.DataMirror
-import chisel3.stage.ChiselStage
 import chisel3.testers.BasicTester
+import chisel3.util._
+import circt.stage.ChiselStage
 import org.scalacheck.Gen
 
 class RegSpec extends ChiselFlatSpec {

--- a/src/test/scala/chiselTests/ResetSpec.scala
+++ b/src/test/scala/chiselTests/ResetSpec.scala
@@ -3,9 +3,7 @@
 package chiselTests
 
 import chisel3._
-import chisel3.stage.ChiselStage
-import chisel3.util.{Counter, Queue}
-import chisel3.testers.BasicTester
+import circt.stage.ChiselStage
 
 class ResetAgnosticModule extends RawModule {
   val clk = IO(Input(Clock()))
@@ -44,7 +42,7 @@ class ResetSpec extends ChiselFlatSpec with Utils {
   }
 
   it should "be able to drive Bool" in {
-    ChiselStage.emitVerilog(new RawModule {
+    ChiselStage.emitSystemVerilog(new RawModule {
       val in = IO(Input(Bool()))
       val out = IO(Output(Bool()))
       val w = Wire(Reset())
@@ -54,7 +52,7 @@ class ResetSpec extends ChiselFlatSpec with Utils {
   }
 
   it should "be able to drive AsyncReset" in {
-    ChiselStage.emitVerilog(new RawModule {
+    ChiselStage.emitSystemVerilog(new RawModule {
       val in = IO(Input(AsyncReset()))
       val out = IO(Output(AsyncReset()))
       val w = Wire(Reset())
@@ -92,14 +90,14 @@ class ResetSpec extends ChiselFlatSpec with Utils {
   behavior.of("Users")
 
   they should "be able to force implicit reset to be synchronous" in {
-    val fir = ChiselStage.emitChirrtl(new Module with RequireSyncReset {
+    val fir = ChiselStage.emitCHIRRTL(new Module with RequireSyncReset {
       reset shouldBe a[Bool]
     })
     fir should include("input reset : UInt<1>")
   }
 
   they should "be able to force implicit reset to be asynchronous" in {
-    val fir = ChiselStage.emitChirrtl(new Module with RequireAsyncReset {
+    val fir = ChiselStage.emitCHIRRTL(new Module with RequireAsyncReset {
       reset shouldBe an[AsyncReset]
     })
     fir should include("input reset : AsyncReset")

--- a/src/test/scala/chiselTests/Risc.scala
+++ b/src/test/scala/chiselTests/Risc.scala
@@ -3,8 +3,8 @@
 package chiselTests
 
 import chisel3._
-import chisel3.stage.ChiselStage
 import chisel3.util._
+import circt.stage.ChiselStage
 
 class Risc extends Module {
   val io = IO(new Bundle {

--- a/src/test/scala/chiselTests/SIntOps.scala
+++ b/src/test/scala/chiselTests/SIntOps.scala
@@ -3,8 +3,8 @@
 package chiselTests
 
 import chisel3._
-import chisel3.stage.ChiselStage
 import chisel3.testers.BasicTester
+import circt.stage.ChiselStage
 
 class SIntOps extends Module {
   val io = IO(new Bundle {

--- a/src/test/scala/chiselTests/Stack.scala
+++ b/src/test/scala/chiselTests/Stack.scala
@@ -3,8 +3,8 @@
 package chiselTests
 
 import chisel3._
-import chisel3.stage.ChiselStage
 import chisel3.util._
+import circt.stage.ChiselStage
 
 class ChiselStack(val depth: Int) extends Module {
   val io = IO(new Bundle {

--- a/src/test/scala/chiselTests/SwitchSpec.scala
+++ b/src/test/scala/chiselTests/SwitchSpec.scala
@@ -3,8 +3,8 @@
 package chiselTests
 
 import chisel3._
-import chisel3.stage.ChiselStage
 import chisel3.util.{is, switch}
+import circt.stage.ChiselStage
 
 class SwitchSpec extends ChiselFlatSpec with Utils {
   "switch" should "require literal conditions" in {
@@ -33,7 +33,7 @@ class SwitchSpec extends ChiselFlatSpec with Utils {
     }
   }
   it should "provide useful source locators" in {
-    val chirrtl = ChiselStage.emitChirrtl(new Module {
+    val chirrtl = ChiselStage.emitCHIRRTL(new Module {
       val io = IO(new Bundle {
         val in = Input(UInt(2.W))
         val out = Output(UInt(2.W))

--- a/src/test/scala/chiselTests/ToTargetSpec.scala
+++ b/src/test/scala/chiselTests/ToTargetSpec.scala
@@ -3,9 +3,8 @@
 package chiselTests
 
 import chisel3._
-import chisel3.stage.ChiselStage
-import chisel3.util.Queue
 import chisel3.internal.ChiselException
+import circt.stage.ChiselStage
 
 class ToTargetSpec extends ChiselFlatSpec with Utils {
 

--- a/src/test/scala/chiselTests/UIntOps.scala
+++ b/src/test/scala/chiselTests/UIntOps.scala
@@ -3,10 +3,9 @@
 package chiselTests
 
 import chisel3._
-import org.scalatest._
-import chisel3.stage.ChiselStage
 import chisel3.testers.BasicTester
 import chisel3.util._
+import circt.stage.ChiselStage
 import org.scalacheck.Shrink
 import org.scalatest.matchers.should.Matchers
 

--- a/src/test/scala/chiselTests/Vec.scala
+++ b/src/test/scala/chiselTests/Vec.scala
@@ -2,13 +2,12 @@
 
 package chiselTests
 
-import org.scalacheck._
-
 import chisel3._
-import chisel3.stage.ChiselStage
 import chisel3.testers.{BasicTester, TesterDriver}
 import chisel3.util._
-import org.scalacheck.Shrink
+import circt.stage.ChiselStage
+import org.scalacheck._
+
 import scala.annotation.tailrec
 
 class LitTesterMod(vecSize: Int) extends Module {
@@ -534,7 +533,7 @@ class VecSpec extends ChiselPropSpec with Utils {
       override def cloneType = (new EmptyRecord).asInstanceOf[this.type]
     }
     for (gen <- List(new EmptyBundle, new EmptyRecord)) {
-      val chirrtl = ChiselStage.emitChirrtl(new MyModule(gen))
+      val chirrtl = ChiselStage.emitCHIRRTL(new MyModule(gen))
       chirrtl should include("input in : { }")
       chirrtl should include("reg reg : { }[4]")
     }

--- a/src/test/scala/chiselTests/VecLiteralSpec.scala
+++ b/src/test/scala/chiselTests/VecLiteralSpec.scala
@@ -5,10 +5,11 @@ package chiselTests
 import chisel3._
 import chisel3.experimental.BundleLiterals.AddBundleLiteralConstructor
 import chisel3.experimental.VecLiterals._
-import chisel3.experimental.{FixedPoint, VecLiteralException}
-import chisel3.stage.ChiselStage
+import chisel3.experimental.{ChiselEnum, FixedPoint, VecLiteralException}
 import chisel3.testers.BasicTester
 import chisel3.util.Counter
+import circt.stage.ChiselStage
+
 import scala.language.reflectiveCalls
 
 class VecLiteralSpec extends ChiselFreeSpec with Utils {
@@ -76,7 +77,7 @@ class VecLiteralSpec extends ChiselFreeSpec with Utils {
   }
 
   "Vec literals should work when used to initialize a reg of vec" in {
-    val firrtl = (new ChiselStage).emitFirrtl(new HasVecInit, args = Array("--full-stacktrace"))
+    val firrtl = ChiselStage.emitCHIRRTL(new HasVecInit)
     firrtl should include("""_y_WIRE[0] <= UInt<8>("hab")""")
     firrtl should include("""_y_WIRE[1] <= UInt<8>("hcd")""")
     firrtl should include("""_y_WIRE[2] <= UInt<8>("hef")""")
@@ -91,7 +92,7 @@ class VecLiteralSpec extends ChiselFreeSpec with Utils {
   }
 
   "Vec literals should work when used to partially initialize a reg of vec" in {
-    val firrtl = (new ChiselStage).emitFirrtl(new HasPartialVecInit, args = Array("--full-stacktrace"))
+    val firrtl = ChiselStage.emitCHIRRTL(new HasPartialVecInit)
     firrtl should include("""_y_WIRE[0] <= UInt<8>("hab")""")
     firrtl should include("""_y_WIRE[1] is invalid""")
     firrtl should include("""_y_WIRE[2] <= UInt<8>("hef")""")
@@ -114,7 +115,7 @@ class VecLiteralSpec extends ChiselFreeSpec with Utils {
   }
 
   "Vec literals should only init specified fields when used to partially initialize a reg of vec" in {
-    println(ChiselStage.emitFirrtl(new ResetRegWithPartialVecLiteral))
+    println(ChiselStage.emitCHIRRTL(new ResetRegWithPartialVecLiteral))
     assertTesterPasses(new BasicTester {
       val m = Module(new ResetRegWithPartialVecLiteral)
       val (counter, wrapped) = Counter(true.B, 8)
@@ -444,7 +445,7 @@ class VecLiteralSpec extends ChiselFreeSpec with Utils {
       out := bundle
     }
 
-    val firrtl = (new chisel3.stage.ChiselStage).emitFirrtl(new VecExample5, args = Array("--full-stacktrace"))
+    val firrtl = ChiselStage.emitCHIRRTL(new VecExample5)
     firrtl should include("""out[0] <= UInt<4>("ha")""")
     firrtl should include("""out[1] <= UInt<4>("hb")""")
   }
@@ -464,7 +465,7 @@ class VecLiteralSpec extends ChiselFreeSpec with Utils {
   }
 
   "vec literals can contain bundles and should not be bulk connected" in {
-    val chirrtl = (new chisel3.stage.ChiselStage).emitChirrtl(new VecExample, args = Array("--full-stacktrace"))
+    val chirrtl = ChiselStage.emitCHIRRTL(new VecExample)
     chirrtl should include("""out[0].bar <= UInt<5>("h16")""")
     chirrtl should include("""out[0].foo <= UInt<6>("h2a")""")
     chirrtl should include("""out[1].bar <= UInt<2>("h3")""")

--- a/src/test/scala/chiselTests/VecToTargetSpec.scala
+++ b/src/test/scala/chiselTests/VecToTargetSpec.scala
@@ -3,7 +3,7 @@
 package chiselTests
 
 import chisel3._
-import chisel3.stage.ChiselStage
+import circt.stage.ChiselStage
 
 trait VecToTargetSpecUtils extends Utils {
   this: ChiselFunSpec =>

--- a/src/test/scala/chiselTests/When.scala
+++ b/src/test/scala/chiselTests/When.scala
@@ -3,9 +3,9 @@
 package chiselTests
 
 import chisel3._
-import chisel3.stage.ChiselStage
 import chisel3.testers.BasicTester
 import chisel3.util._
+import circt.stage.ChiselStage
 
 class WhenTester() extends BasicTester {
   val cnt = Counter(4)

--- a/src/test/scala/chiselTests/WireSpec.scala
+++ b/src/test/scala/chiselTests/WireSpec.scala
@@ -30,8 +30,7 @@ class WireSpec extends ChiselFlatSpec {
     }
 
     val chirrtl = ChiselStage.emitCHIRRTL(new Dummy)
-    // This test can fail when run from IntelliJ because the source locator path can be different
-    chirrtl should include("wire wire : UInt<1> @[src/test/scala/chiselTests/WireSpec.scala")
-    chirrtl should include("wire wire2 : UInt<1> @[src/test/scala/chiselTests/WireSpec.scala")
+    chirrtl should include("wire wire : UInt<1>")
+    chirrtl should include("wire wire2 : UInt<1>")
   }
 }

--- a/src/test/scala/chiselTests/WireSpec.scala
+++ b/src/test/scala/chiselTests/WireSpec.scala
@@ -3,7 +3,7 @@
 package chiselTests
 
 import chisel3._
-import chisel3.stage.ChiselStage
+import circt.stage.ChiselStage
 
 class WireSpec extends ChiselFlatSpec {
   "WireDefault.apply" should "work" in {
@@ -29,7 +29,8 @@ class WireSpec extends ChiselFlatSpec {
       out := in & wire & wire2
     }
 
-    val chirrtl = ChiselStage.emitChirrtl(new Dummy)
+    val chirrtl = ChiselStage.emitCHIRRTL(new Dummy)
+    // This test can fail when run from IntelliJ because the source locator path can be different
     chirrtl should include("wire wire : UInt<1> @[src/test/scala/chiselTests/WireSpec.scala")
     chirrtl should include("wire wire2 : UInt<1> @[src/test/scala/chiselTests/WireSpec.scala")
   }

--- a/src/test/scala/chiselTests/experimental/DataMirrorSpec.scala
+++ b/src/test/scala/chiselTests/experimental/DataMirrorSpec.scala
@@ -3,10 +3,9 @@
 package chiselTests.experimental
 
 import chisel3._
-import chisel3.util.Valid
-import chisel3.stage.ChiselStage
 import chisel3.reflect.DataMirror
 import chiselTests.ChiselFlatSpec
+import circt.stage.ChiselStage
 
 object DataMirrorSpec {
   import org.scalatest.matchers.should.Matchers._

--- a/src/test/scala/chiselTests/experimental/DataView.scala
+++ b/src/test/scala/chiselTests/experimental/DataView.scala
@@ -2,14 +2,14 @@
 
 package chiselTests.experimental
 
-import chiselTests.ChiselFlatSpec
 import chisel3._
-import chisel3.experimental.dataview._
 import chisel3.experimental.conversions._
-import chisel3.reflect.DataMirror.internal.chiselTypeClone
+import chisel3.experimental.dataview._
 import chisel3.experimental.{Analog, HWTuple2}
-import chisel3.stage.ChiselStage
+import chisel3.reflect.DataMirror.internal.chiselTypeClone
 import chisel3.util.{Decoupled, DecoupledIO}
+import chiselTests.ChiselFlatSpec
+import circt.stage.ChiselStage
 
 object SimpleBundleDataView {
   class BundleA(val w: Int) extends Bundle {
@@ -63,7 +63,7 @@ class DataViewSpec extends ChiselFlatSpec {
       val out = IO(Output(new BundleB(8)))
       out := in.viewAs[BundleB]
     }
-    val chirrtl = ChiselStage.emitChirrtl(new MyModule)
+    val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
     chirrtl should include("out.bar <= in.foo")
   }
 
@@ -74,7 +74,7 @@ class DataViewSpec extends ChiselFlatSpec {
       val out = IO(Output(new BundleB(8)))
       out.viewAs[BundleA] := in
     }
-    val chirrtl = ChiselStage.emitChirrtl(new MyModule)
+    val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
     chirrtl should include("out.bar <= in.foo")
   }
 
@@ -86,7 +86,7 @@ class DataViewSpec extends ChiselFlatSpec {
       foo := in.viewAs[UInt]
       bar.viewAs[UInt] := in
     }
-    val chirrtl = ChiselStage.emitChirrtl(new MyModule)
+    val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
     chirrtl should include("foo <= in")
     chirrtl should include("bar <= in")
   }
@@ -97,7 +97,7 @@ class DataViewSpec extends ChiselFlatSpec {
       val bar = IO(Analog(8.W))
       foo <> bar.viewAs[Analog]
     }
-    val chirrtl = ChiselStage.emitChirrtl(new MyModule)
+    val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
     chirrtl should include("attach (foo, bar)")
   }
 
@@ -112,7 +112,7 @@ class DataViewSpec extends ChiselFlatSpec {
       fizz := in.viewAs[MyBundle]
       buzz.viewAs[MyBundle] := in
     }
-    val chirrtl = ChiselStage.emitChirrtl(new MyModule)
+    val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
     chirrtl should include("fizz <= in")
     chirrtl should include("buzz <= in")
   }
@@ -125,7 +125,7 @@ class DataViewSpec extends ChiselFlatSpec {
       fizz := in.viewAs[Vec[UInt]]
       buzz.viewAs[Vec[UInt]] := in
     }
-    val chirrtl = ChiselStage.emitChirrtl(new MyModule)
+    val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
     chirrtl should include("fizz <= in")
     chirrtl should include("buzz <= in")
   }
@@ -139,7 +139,7 @@ class DataViewSpec extends ChiselFlatSpec {
       out := in.viewAs[Vec[UInt]]
       out2.viewAs[MyBundle] := in
     }
-    val chirrtl = ChiselStage.emitChirrtl(new MyModule)
+    val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
     chirrtl should include("out[0] <= in.bar")
     chirrtl should include("out[1] <= in.foo")
     chirrtl should include("out2[0] <= in.bar")
@@ -155,7 +155,7 @@ class DataViewSpec extends ChiselFlatSpec {
       deq <> enq.viewAs[FlatDecoupled]
       deq2.viewAs[DecoupledIO[FizzBuzz]] <> enq
     }
-    val chirrtl = ChiselStage.emitChirrtl(new MyModule)
+    val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
     chirrtl should include("deq.valid <= enq.valid")
     chirrtl should include("enq.ready <= deq.ready")
     chirrtl should include("deq.fizz <= enq.bits.fizz")
@@ -182,7 +182,7 @@ class DataViewSpec extends ChiselFlatSpec {
       val fooOut = IO(Output(new Foo))
       fooOut := barIn.viewAsSupertype(new Foo)
     }
-    val chirrtl = ChiselStage.emitChirrtl(new MyModule)
+    val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
     chirrtl should include("barOut.foo <= fooIn.foo")
     chirrtl should include("fooOut.foo <= barIn.foo")
   }
@@ -204,7 +204,7 @@ class DataViewSpec extends ChiselFlatSpec {
       val fooOut = IO(Output(new Foo(8)))
       fooOut := barIn.viewAs[Foo]
     }
-    val chirrtl = ChiselStage.emitChirrtl(new MyModule)
+    val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
     chirrtl should include("barOut.foo <= fooIn.foo")
     chirrtl should include("fooOut.foo <= barIn.foo")
   }
@@ -235,7 +235,7 @@ class DataViewSpec extends ChiselFlatSpec {
       io.c <> io.a.viewAsSupertype(new C)
       io.outa.viewAsSupertype(new C) <> io.inc
     }
-    val chirrtl = ChiselStage.emitChirrtl(new MyModule)
+    val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
     chirrtl should include("io.b.x <= io.a.x")
     chirrtl should include("io.c.z <= io.a.z")
     chirrtl should include("io.outa.z <= io.inc.z")
@@ -271,7 +271,7 @@ class DataViewSpec extends ChiselFlatSpec {
       io.c <> io.a.viewAsSupertype(new C)
       io.outa.viewAsSupertype(new C) <> io.inc
     }
-    val chirrtl = ChiselStage.emitChirrtl(new MyModule)
+    val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
     chirrtl should include("io.b.x <= io.a.x")
     chirrtl should include("io.c.z <= io.a.z")
     chirrtl should include("io.outa.foo <= io.inc.foo")
@@ -296,7 +296,7 @@ class DataViewSpec extends ChiselFlatSpec {
       })
       io.b <> io.a.viewAsSupertype(new B)
     }
-    a[ChiselException] should be thrownBy (ChiselStage.emitVerilog(new MyModule))
+    a[ChiselException] should be thrownBy (ChiselStage.emitSystemVerilog(new MyModule))
   }
 
   it should "support viewing structural supertypes with generated types" in {
@@ -316,7 +316,7 @@ class DataViewSpec extends ChiselFlatSpec {
       val fooOut = IO(Output(new Foo))
       fooOut <> fooIf.viewAsSupertype(new Foo)
     }
-    val chirrtl = ChiselStage.emitChirrtl(new MyModule)
+    val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
   }
 
   it should "throw a type error for structural non-supertypes with different members" in {
@@ -399,7 +399,7 @@ class DataViewSpec extends ChiselFlatSpec {
       val abCat = aBits.viewAs[UInt] ## bBits.viewAs[UInt]
       bitsCat := abCat
     }
-    val chirrtl = ChiselStage.emitChirrtl(new MyModule)
+    val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
     val expected = List(
       "node x = and(a, b.value)",
       "and <= x",
@@ -423,7 +423,7 @@ class DataViewSpec extends ChiselFlatSpec {
       val cat = barIn.viewAs[Vec[UInt]].asUInt
       fooOut := cat
     }
-    val chirrtl = ChiselStage.emitChirrtl(new MyModule)
+    val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
     chirrtl should include("node cat = cat(barIn.foo, barIn.bar)")
     chirrtl should include("fooOut <= cat")
   }
@@ -445,7 +445,7 @@ class DataViewSpec extends ChiselFlatSpec {
       y := a.viewAs[Fizz]
       z := b.viewAs[Bar].viewAs[Fizz]
     }
-    val chirrtl = ChiselStage.emitChirrtl(new MyModule)
+    val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
     chirrtl should include("y.fizz <= a.foo")
     chirrtl should include("z.fizz <= b.foo")
   }
@@ -460,7 +460,7 @@ class DataViewSpec extends ChiselFlatSpec {
       Seq(y, z) := Mux(sel, Seq(a, b).viewAs, Seq(c, d).viewAs[Vec[UInt]])
     }
     // Verilog instead of CHIRRTL because the optimizations make it much prettier
-    val verilog = ChiselStage.emitVerilog(new MyModule)
+    val verilog = ChiselStage.emitSystemVerilog(new MyModule)
     verilog should include("assign y = sel ? a : c;")
     verilog should include("assign z = sel ? b : d;")
   }
@@ -474,7 +474,7 @@ class DataViewSpec extends ChiselFlatSpec {
       Seq(x, y, z) := VecInit(a, b, c)
     }
     // Verilog instead of CHIRRTL because the optimizations make it much prettier
-    val verilog = ChiselStage.emitVerilog(new MyModule)
+    val verilog = ChiselStage.emitSystemVerilog(new MyModule)
     verilog should include("assign x = a;")
     verilog should include("assign y = b;")
     verilog should include("assign z = c;")
@@ -490,7 +490,7 @@ class DataViewSpec extends ChiselFlatSpec {
       // We could also overload `VecInit` instead of relying on the implicit conversion
       Seq((w, x), (y, z)) := VecInit[HWTuple2[UInt, UInt]]((a, b), (c, d))
     }
-    val verilog = ChiselStage.emitVerilog(new MyModule)
+    val verilog = ChiselStage.emitSystemVerilog(new MyModule)
     verilog should include("assign w = a;")
     verilog should include("assign x = b;")
     verilog should include("assign y = c;")
@@ -511,7 +511,7 @@ class DataViewSpec extends ChiselFlatSpec {
       selected := dataIn
       dataOut := selected
     }
-    val chirrtl = ChiselStage.emitChirrtl(new MyModule)
+    val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
     chirrtl should include("vec[addr] <= dataIn")
     chirrtl should include("dataOut <= vec[addr]")
   }
@@ -541,7 +541,7 @@ class DataViewSpec extends ChiselFlatSpec {
       selected := dataIn
       dataOut := selected
     }
-    val chirrtl = ChiselStage.emitChirrtl(new MyModule)
+    val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
     chirrtl should include("vec[addrReg] <= dataIn")
     chirrtl should include("dataOut <= vec[addrReg]")
   }
@@ -561,7 +561,7 @@ class DataViewSpec extends ChiselFlatSpec {
       (outA, outB) := selected
     }
     (the[InvalidViewException] thrownBy {
-      ChiselStage.emitChirrtl(new MyModule)
+      ChiselStage.emitCHIRRTL(new MyModule)
     }).getMessage should include("Dynamic indexing of Views is not yet supported")
   }
 
@@ -574,7 +574,7 @@ class DataViewSpec extends ChiselFlatSpec {
       val out = IO(Output(tpe))
       out := in.viewAs[MyBundle]
     }
-    val err = the[InvalidViewException] thrownBy (ChiselStage.emitVerilog(new MyModule))
+    val err = the[InvalidViewException] thrownBy (ChiselStage.emitSystemVerilog(new MyModule))
     err.toString should include("View field '_.foo' is missing")
   }
 
@@ -585,7 +585,7 @@ class DataViewSpec extends ChiselFlatSpec {
       val out = IO(Output(UInt(8.W)))
       out := (a, b).viewAs[UInt]
     }
-    val err = the[InvalidViewException] thrownBy (ChiselStage.emitVerilog(new MyModule))
+    val err = the[InvalidViewException] thrownBy (ChiselStage.emitSystemVerilog(new MyModule))
     err.toString should include("Target field '_._2' is missing")
   }
 
@@ -603,7 +603,7 @@ class DataViewSpec extends ChiselFlatSpec {
       val out = IO(Output(new BundleB))
       out := in.viewAs[BundleB]
     }
-    val err = the[InvalidViewException] thrownBy (ChiselStage.emitVerilog(new MyModule))
+    val err = the[InvalidViewException] thrownBy (ChiselStage.emitSystemVerilog(new MyModule))
     err.toString should include("View mapping must only contain Elements within the Target")
   }
 
@@ -622,7 +622,7 @@ class DataViewSpec extends ChiselFlatSpec {
       val out = IO(Output(new BundleB))
       out.viewAs[BundleA] := in
     }
-    val err = the[InvalidViewException] thrownBy (ChiselStage.emitVerilog(new MyModule))
+    val err = the[InvalidViewException] thrownBy (ChiselStage.emitSystemVerilog(new MyModule))
     err.toString should include("View mapping must only contain Elements within the View")
   }
 
@@ -639,7 +639,7 @@ class DataViewSpec extends ChiselFlatSpec {
       val out = IO(Output(new BundleB))
       out := in.viewAs[BundleB]
     }
-    val err = the[InvalidViewException] thrownBy ChiselStage.emitChirrtl(new MyModule)
+    val err = the[InvalidViewException] thrownBy ChiselStage.emitCHIRRTL(new MyModule)
     val expected = """View field _\.bar UInt<4> has width <4> that is incompatible with target value .+'s width <8>""".r
     (err.getMessage should fullyMatch).regex(expected)
   }
@@ -657,7 +657,7 @@ class DataViewSpec extends ChiselFlatSpec {
       val out = IO(Output(new BundleB))
       out := in.viewAs[BundleB]
     }
-    val err = the[InvalidViewException] thrownBy ChiselStage.emitChirrtl(new MyModule)
+    val err = the[InvalidViewException] thrownBy ChiselStage.emitCHIRRTL(new MyModule)
     val expected =
       """View field _\.bar UInt<4> has width <4> that is incompatible with target value .+'s width <unknown>""".r
     (err.getMessage should fullyMatch).regex(expected)
@@ -675,7 +675,7 @@ class DataViewSpec extends ChiselFlatSpec {
       fizz._2 <> DontCare
     }
 
-    val chirrtl = ChiselStage.emitChirrtl(new MyModule)
+    val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
     val expected = ('a' to 'f').map(c => s"$c is invalid")
     for (line <- expected) {
       chirrtl should include(line)
@@ -692,7 +692,7 @@ class DataViewSpec extends ChiselFlatSpec {
       val out = IO(Output(new MyBundle(UInt(8.W), UInt(8.W))))
       out := in.viewAs[MyBundle]
     }
-    val err = the[InvalidViewException] thrownBy (ChiselStage.emitVerilog(new MyModule))
+    val err = the[InvalidViewException] thrownBy (ChiselStage.emitSystemVerilog(new MyModule))
     err.toString should include("View field '_.foo' is missing")
   }
 
@@ -703,7 +703,7 @@ class DataViewSpec extends ChiselFlatSpec {
       val out = IO(Output(UInt(8.W)))
       out := (a, b).viewAs[UInt]
     }
-    val verilog = ChiselStage.emitVerilog(new MyModule)
+    val verilog = ChiselStage.emitSystemVerilog(new MyModule)
     verilog should include("assign out = b;")
   }
 }

--- a/src/test/scala/chiselTests/experimental/FlatIOSpec.scala
+++ b/src/test/scala/chiselTests/experimental/FlatIOSpec.scala
@@ -4,7 +4,7 @@ package chiselTests.experimental
 
 import chisel3._
 import chisel3.util.Valid
-import chisel3.stage.ChiselStage.emitChirrtl
+import circt.stage.ChiselStage.emitCHIRRTL
 import chisel3.experimental.{Analog, FlatIO}
 import chiselTests.ChiselFlatSpec
 
@@ -19,7 +19,7 @@ class FlatIOSpec extends ChiselFlatSpec {
       })
       io.out := io.in
     }
-    val chirrtl = emitChirrtl(new MyModule)
+    val chirrtl = emitCHIRRTL(new MyModule)
     chirrtl should include("input in : UInt<8>")
     chirrtl should include("output out : UInt<8>")
     chirrtl should include("out <= in")
@@ -31,7 +31,7 @@ class FlatIOSpec extends ChiselFlatSpec {
       val out = IO(Output(Valid(UInt(8.W))))
       out := in
     }
-    val chirrtl = emitChirrtl(new MyModule)
+    val chirrtl = emitCHIRRTL(new MyModule)
     chirrtl should include("out.bits <= bits")
     chirrtl should include("out.valid <= valid")
   }
@@ -45,7 +45,7 @@ class FlatIOSpec extends ChiselFlatSpec {
       })
       io.out(io.addr) := io.in(io.addr)
     }
-    val chirrtl = emitChirrtl(new MyModule)
+    val chirrtl = emitCHIRRTL(new MyModule)
     chirrtl should include("out[addr] <= in[addr]")
   }
 
@@ -61,7 +61,7 @@ class FlatIOSpec extends ChiselFlatSpec {
       })
       io.out <> io.in
     }
-    val chirrtl = emitChirrtl(new MyModule)
+    val chirrtl = emitCHIRRTL(new MyModule)
     chirrtl should include("out.foo <= in.foo")
     chirrtl should include("attach (out.bar, in.bar)")
   }

--- a/src/test/scala/chiselTests/experimental/ForceNames.scala
+++ b/src/test/scala/chiselTests/experimental/ForceNames.scala
@@ -121,7 +121,7 @@ class ForceNamesSpec extends ChiselFlatSpec {
     }
 
     a[ChiselException] shouldBe thrownBy {
-      chisel3.stage.ChiselStage.elaborate(new Example)
+      circt.stage.ChiselStage.elaborate(new Example)
     }
   }
 }

--- a/src/test/scala/chiselTests/experimental/ProgrammaticPortsSpec.scala
+++ b/src/test/scala/chiselTests/experimental/ProgrammaticPortsSpec.scala
@@ -4,7 +4,7 @@ package chiselTests
 package experimental
 
 import chisel3._
-import chisel3.stage.ChiselStage
+import circt.stage.ChiselStage
 
 // NOTE This is currently an experimental API and subject to change
 // Example using a private port

--- a/src/test/scala/chiselTests/experimental/Tuple.scala
+++ b/src/test/scala/chiselTests/experimental/Tuple.scala
@@ -2,10 +2,10 @@
 
 package chiselTests.experimental
 
-import chiselTests.ChiselFlatSpec
 import chisel3._
 import chisel3.experimental.conversions._
-import chisel3.stage.ChiselStage
+import chiselTests.ChiselFlatSpec
+import circt.stage.ChiselStage
 
 class TupleSpec extends ChiselFlatSpec {
 
@@ -19,7 +19,7 @@ class TupleSpec extends ChiselFlatSpec {
       (y, z) := Mux(sel, (a, b), (c, d))
     }
     // Verilog instead of CHIRRTL because the optimizations make it much prettier
-    val verilog = ChiselStage.emitVerilog(new MyModule)
+    val verilog = ChiselStage.emitSystemVerilog(new MyModule)
     verilog should include("assign y = sel ? a : c;")
     verilog should include("assign z = sel ? b : d;")
   }
@@ -30,7 +30,7 @@ class TupleSpec extends ChiselFlatSpec {
       val w, x, y, z = IO(Output(UInt(8.W)))
       ((w, x), (y, z)) := ((a, b), (c, d))
     }
-    val chirrtl = ChiselStage.emitChirrtl(new MyModule)
+    val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
     chirrtl should include("w <= a")
     chirrtl should include("x <= b")
     chirrtl should include("y <= c")
@@ -46,7 +46,7 @@ class TupleSpec extends ChiselFlatSpec {
       (v, w, x) := Mux(sel, (a, b, c), (f, g, h))
     }
     // Verilog instead of CHIRRTL because the optimizations make it much prettier
-    val verilog = ChiselStage.emitVerilog(new MyModule)
+    val verilog = ChiselStage.emitSystemVerilog(new MyModule)
     verilog should include("assign v = sel ? a : f;")
     verilog should include("assign w = sel ? b : g;")
     verilog should include("assign x = sel ? c : h;")
@@ -61,7 +61,7 @@ class TupleSpec extends ChiselFlatSpec {
       (v, w, x, y) := Mux(sel, (a, b, c, d), (f, g, h, i))
     }
     // Verilog instead of CHIRRTL because the optimizations make it much prettier
-    val verilog = ChiselStage.emitVerilog(new MyModule)
+    val verilog = ChiselStage.emitSystemVerilog(new MyModule)
     verilog should include("assign v = sel ? a : f;")
     verilog should include("assign w = sel ? b : g;")
     verilog should include("assign x = sel ? c : h;")
@@ -77,7 +77,7 @@ class TupleSpec extends ChiselFlatSpec {
       (z0, z1, z2, z3, z4) := Mux(sel, (a0, a1, a2, a3, a4), (b0, b1, b2, b3, b4))
     }
     // Verilog instead of CHIRRTL because the optimizations make it much prettier
-    val verilog = ChiselStage.emitVerilog(new MyModule)
+    val verilog = ChiselStage.emitSystemVerilog(new MyModule)
     for (i <- 0 until 5) {
       verilog should include(s"assign z$i = sel ? a$i : b$i;")
     }
@@ -92,7 +92,7 @@ class TupleSpec extends ChiselFlatSpec {
       (z0, z1, z2, z3, z4, z5) := Mux(sel, (a0, a1, a2, a3, a4, a5), (b0, b1, b2, b3, b4, b5))
     }
     // Verilog instead of CHIRRTL because the optimizations make it much prettier
-    val verilog = ChiselStage.emitVerilog(new MyModule)
+    val verilog = ChiselStage.emitSystemVerilog(new MyModule)
     for (i <- 0 until 6) {
       verilog should include(s"assign z$i = sel ? a$i : b$i;")
     }
@@ -107,7 +107,7 @@ class TupleSpec extends ChiselFlatSpec {
       (z0, z1, z2, z3, z4, z5, z6) := Mux(sel, (a0, a1, a2, a3, a4, a5, a6), (b0, b1, b2, b3, b4, b5, b6))
     }
     // Verilog instead of CHIRRTL because the optimizations make it much prettier
-    val verilog = ChiselStage.emitVerilog(new MyModule)
+    val verilog = ChiselStage.emitSystemVerilog(new MyModule)
     for (i <- 0 until 7) {
       verilog should include(s"assign z$i = sel ? a$i : b$i;")
     }
@@ -122,7 +122,7 @@ class TupleSpec extends ChiselFlatSpec {
       (z0, z1, z2, z3, z4, z5, z6, z7) := Mux(sel, (a0, a1, a2, a3, a4, a5, a6, a7), (b0, b1, b2, b3, b4, b5, b6, b7))
     }
     // Verilog instead of CHIRRTL because the optimizations make it much prettier
-    val verilog = ChiselStage.emitVerilog(new MyModule)
+    val verilog = ChiselStage.emitSystemVerilog(new MyModule)
     for (i <- 0 until 8) {
       verilog should include(s"assign z$i = sel ? a$i : b$i;")
     }
@@ -138,7 +138,7 @@ class TupleSpec extends ChiselFlatSpec {
         Mux(sel, (a0, a1, a2, a3, a4, a5, a6, a7, a8), (b0, b1, b2, b3, b4, b5, b6, b7, b8))
     }
     // Verilog instead of CHIRRTL because the optimizations make it much prettier
-    val verilog = ChiselStage.emitVerilog(new MyModule)
+    val verilog = ChiselStage.emitSystemVerilog(new MyModule)
     for (i <- 0 until 9) {
       verilog should include(s"assign z$i = sel ? a$i : b$i;")
     }
@@ -154,7 +154,7 @@ class TupleSpec extends ChiselFlatSpec {
         Mux(sel, (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9), (b0, b1, b2, b3, b4, b5, b6, b7, b8, b9))
     }
     // Verilog instead of CHIRRTL because the optimizations make it much prettier
-    val verilog = ChiselStage.emitVerilog(new MyModule)
+    val verilog = ChiselStage.emitSystemVerilog(new MyModule)
     for (i <- 0 until 10) {
       verilog should include(s"assign z$i = sel ? a$i : b$i;")
     }

--- a/src/test/scala/chiselTests/experimental/hierarchy/InstantiateSpec.scala
+++ b/src/test/scala/chiselTests/experimental/hierarchy/InstantiateSpec.scala
@@ -6,7 +6,7 @@ package experimental.hierarchy
 import chisel3._
 import chisel3.util.Valid
 import chisel3.experimental.hierarchy._
-import chisel3.stage.ChiselStage.convert
+import circt.stage.ChiselStage.convert
 
 // Note, the instantiable classes must not be inner classes because the materialized WeakTypeTags
 // will be different and they will not give the same hashCode when looking up the Definition in the

--- a/src/test/scala/chiselTests/naming/NamePluginSpec.scala
+++ b/src/test/scala/chiselTests/naming/NamePluginSpec.scala
@@ -3,10 +3,10 @@
 package chiselTests.naming
 
 import chisel3._
-import chisel3.stage.ChiselStage
 import chisel3.aop.Select
-import chisel3.experimental.{prefix, treedump}
+import chisel3.experimental.prefix
 import chiselTests.{ChiselFlatSpec, Utils}
+import circt.stage.ChiselStage
 
 class NamePluginSpec extends ChiselFlatSpec with Utils {
   implicit val minimumScalaVersion: Int = 12
@@ -81,7 +81,7 @@ class NamePluginSpec extends ChiselFlatSpec with Utils {
         val x4 = printf("foo = %d\n", foo)
       }
     }
-    val chirrtl = ChiselStage.emitChirrtl(new Test)
+    val chirrtl = ChiselStage.emitCHIRRTL(new Test)
     (chirrtl should include).regex("assert.*: x1")
     (chirrtl should include).regex("cover.*: x2")
     (chirrtl should include).regex("assume.*: x3")

--- a/src/test/scala/chiselTests/naming/PrefixSpec.scala
+++ b/src/test/scala/chiselTests/naming/PrefixSpec.scala
@@ -3,11 +3,10 @@
 package chiselTests.naming
 
 import chisel3._
-import chisel3.stage.ChiselStage
 import chisel3.aop.Select
-import chisel3.experimental.{dump, noPrefix, prefix, treedump}
+import chisel3.experimental.{noPrefix, prefix, AffectsChiselPrefix}
 import chiselTests.{ChiselPropSpec, Utils}
-import chisel3.experimental.AffectsChiselPrefix
+import circt.stage.ChiselStage
 
 class PrefixSpec extends ChiselPropSpec with Utils {
   implicit val minimumMajorVersion: Int = 12
@@ -437,7 +436,7 @@ class PrefixSpec extends ChiselPropSpec with Utils {
         }
       }
     }
-    val chirrtl = ChiselStage.emitChirrtl(new Test)
+    val chirrtl = ChiselStage.emitCHIRRTL(new Test)
     (chirrtl should include).regex("assert.*: x5")
     (chirrtl should include).regex("cover.*: x5_x2")
     (chirrtl should include).regex("assume.*: x5_x3")

--- a/src/test/scala/chiselTests/util/BitPatSpec.scala
+++ b/src/test/scala/chiselTests/util/BitPatSpec.scala
@@ -3,6 +3,7 @@
 package chiselTests.util
 
 import chisel3.util.BitPat
+import circt.stage.ChiselStage
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -29,7 +30,7 @@ class BitPatSpec extends AnyFlatSpec with Matchers {
 
   it should "throw when BitPat apply to a Hardware" in {
     intercept[java.lang.IllegalArgumentException] {
-      chisel3.stage.ChiselStage.emitChirrtl(new chisel3.Module {
+      ChiselStage.emitCHIRRTL(new chisel3.Module {
         BitPat(chisel3.Reg(chisel3.Bool()))
       })
     }

--- a/src/test/scala/chiselTests/util/BitwiseSpec.scala
+++ b/src/test/scala/chiselTests/util/BitwiseSpec.scala
@@ -1,9 +1,8 @@
 package chiselTests.util
 
 import chisel3._
-import chisel3.stage.ChiselStage
 import chisel3.util.{Fill, FillInterleaved, PopCount, Reverse}
-
+import circt.stage.ChiselStage
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -15,7 +14,7 @@ class FillInterleavedSpec extends AnyFlatSpec with Matchers {
       val out = IO(Output(UInt()))
       out := FillInterleaved(2, "b1000".U)
     }
-    val chirrtl = ChiselStage.emitChirrtl(new MyModule)
+    val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
     val cat = """cat.*BitwiseSpec\.scala""".r
     (chirrtl should include).regex(cat)
     val mux = """mux.*BitwiseSpec\.scala""".r
@@ -28,7 +27,7 @@ class FillInterleavedSpec extends AnyFlatSpec with Matchers {
       val out = IO(Output(UInt()))
       out := FillInterleaved(2, Seq(true.B, false.B, false.B, false.B))
     }
-    val chirrtl = ChiselStage.emitChirrtl(new MyModule)
+    val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
     val cat = """cat.*BitwiseSpec\.scala""".r
     (chirrtl should include).regex(cat)
     val mux = """mux.*BitwiseSpec\.scala""".r
@@ -45,7 +44,7 @@ class PopCountSpec extends AnyFlatSpec with Matchers {
       val out = IO(Output(UInt()))
       out := PopCount(Seq(true.B, false.B, false.B, false.B))
     }
-    val chirrtl = ChiselStage.emitChirrtl(new MyModule)
+    val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
     val add = """add.*BitwiseSpec\.scala""".r
     (chirrtl should include).regex(add)
     val bits = """bits.*BitwiseSpec\.scala""".r
@@ -58,7 +57,7 @@ class PopCountSpec extends AnyFlatSpec with Matchers {
       val out = IO(Output(UInt()))
       out := PopCount("b1000".U)
     }
-    val chirrtl = ChiselStage.emitChirrtl(new MyModule)
+    val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
     val add = """add.*BitwiseSpec\.scala""".r
     (chirrtl should include).regex(add)
     val bits = """bits.*BitwiseSpec\.scala""".r
@@ -74,7 +73,7 @@ class FillSpec extends AnyFlatSpec with Matchers {
       val out = IO(Output(UInt()))
       out := Fill(2, "b1000".U)
     }
-    val chirrtl = ChiselStage.emitChirrtl(new MyModule)
+    val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
     val cat = """cat.*BitwiseSpec\.scala""".r
     (chirrtl should include).regex(cat)
     (chirrtl should not).include("Bitwise.scala")
@@ -89,7 +88,7 @@ class ReverseSpec extends AnyFlatSpec with Matchers {
       val out = IO(Output(UInt()))
       out := Reverse("b1101".U)
     }
-    val chirrtl = ChiselStage.emitChirrtl(new MyModule)
+    val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
     val cat = """cat.*BitwiseSpec\.scala""".r
     (chirrtl should include).regex(cat)
     (chirrtl should not).include("Bitwise.scala")

--- a/src/test/scala/chiselTests/util/CatSpec.scala
+++ b/src/test/scala/chiselTests/util/CatSpec.scala
@@ -68,8 +68,7 @@ class CatSpec extends ChiselFlatSpec {
       out := Cat(in)
     }
     val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
-    // This test can fail when run from IntelliJ because the source locator path can be different
-    chirrtl should include("cat(in[0], in[1]) @[src/test/scala/chiselTests/util/CatSpec.scala")
+    chirrtl should include("cat(in[0], in[1])")
     (chirrtl should not).include("Cat.scala")
   }
 
@@ -80,8 +79,7 @@ class CatSpec extends ChiselFlatSpec {
       out := Cat(in(0), in(1))
     }
     val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
-    // This test can fail when run from IntelliJ because the source locator path can be different
-    chirrtl should include("cat(in[0], in[1]) @[src/test/scala/chiselTests/util/CatSpec.scala")
+    chirrtl should include("cat(in[0], in[1])")
     (chirrtl should not).include("Cat.scala")
   }
 

--- a/src/test/scala/chiselTests/util/CatSpec.scala
+++ b/src/test/scala/chiselTests/util/CatSpec.scala
@@ -3,11 +3,10 @@
 package chiselTests.util
 
 import chisel3._
-import chisel3.stage.ChiselStage
-import chisel3.util.Cat
 import chisel3.experimental.noPrefix
-
+import chisel3.util.Cat
 import chiselTests.ChiselFlatSpec
+import circt.stage.ChiselStage
 
 object CatSpec {
 
@@ -39,7 +38,7 @@ class CatSpec extends ChiselFlatSpec {
 
       out := Cat(a, b, c, d)
     }
-    val chirrtl = ChiselStage.emitChirrtl(new MyModule)
+    val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
     for (name <- Seq("a", "b", "c", "d")) {
       chirrtl should include(s"input $name : UInt<8>")
     }
@@ -53,7 +52,7 @@ class CatSpec extends ChiselFlatSpec {
       // noPrefix to avoid `out` as prefix
       out := noPrefix(Cat(in))
     }
-    val chirrtl = ChiselStage.emitChirrtl(new MyModule)
+    val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
     chirrtl should include("node lo_lo = cat(in[6], in[7])")
     chirrtl should include("node lo_hi = cat(in[4], in[5])")
     chirrtl should include("node hi_lo = cat(in[2], in[3])")
@@ -68,7 +67,8 @@ class CatSpec extends ChiselFlatSpec {
       // noPrefix to avoid `out` as prefix
       out := Cat(in)
     }
-    val chirrtl = ChiselStage.emitChirrtl(new MyModule)
+    val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
+    // This test can fail when run from IntelliJ because the source locator path can be different
     chirrtl should include("cat(in[0], in[1]) @[src/test/scala/chiselTests/util/CatSpec.scala")
     (chirrtl should not).include("Cat.scala")
   }
@@ -79,7 +79,8 @@ class CatSpec extends ChiselFlatSpec {
       val out = IO(Output(UInt()))
       out := Cat(in(0), in(1))
     }
-    val chirrtl = ChiselStage.emitChirrtl(new MyModule)
+    val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
+    // This test can fail when run from IntelliJ because the source locator path can be different
     chirrtl should include("cat(in[0], in[1]) @[src/test/scala/chiselTests/util/CatSpec.scala")
     (chirrtl should not).include("Cat.scala")
   }

--- a/src/test/scala/chiselTests/util/PipeSpec.scala
+++ b/src/test/scala/chiselTests/util/PipeSpec.scala
@@ -4,9 +4,8 @@ package chiselTests.util
 
 import chisel3._
 import chisel3.util.{Pipe, Valid}
-import chisel3.stage.ChiselStage.emitChirrtl
-import chisel3.experimental.FlatIO
 import chiselTests.ChiselFlatSpec
+import circt.stage.ChiselStage.emitCHIRRTL
 
 class PipeSpec extends ChiselFlatSpec {
   behavior.of("Pipe")
@@ -17,7 +16,7 @@ class PipeSpec extends ChiselFlatSpec {
       val bar = IO(Output(Valid(UInt(8.W))))
       bar := Pipe(foo.valid, bar.bits, 2)
     }
-    val chirrtl = emitChirrtl(new MyModule)
+    val chirrtl = emitCHIRRTL(new MyModule)
     chirrtl should include("reg bar_pipe_v")
     chirrtl should include("reg bar_pipe_pipe_v")
     chirrtl should include("wire bar_pipe_pipe_out")
@@ -31,7 +30,7 @@ class PipeSpec extends ChiselFlatSpec {
       val bar = IO(Output(Valid(UInt(8.W))))
       bar := Pipe(foo.valid, foo.bits, 0)
     }
-    val chirrtl = emitChirrtl(new MyModule)
+    val chirrtl = emitCHIRRTL(new MyModule)
     (chirrtl should not).include("pipe")
     chirrtl should include("wire bar_out")
     chirrtl should include("bar_out.valid <= foo.valid")

--- a/src/test/scala/chiselTests/util/PriorityMuxSpec.scala
+++ b/src/test/scala/chiselTests/util/PriorityMuxSpec.scala
@@ -3,11 +3,10 @@
 package chiselTests.util
 
 import chisel3._
-import chisel3.util.{is, switch, Counter, PriorityMux}
 import chisel3.testers.BasicTester
-import chisel3.stage.ChiselStage.emitChirrtl
-
+import chisel3.util.{Counter, PriorityMux}
 import chiselTests.ChiselFlatSpec
+import circt.stage.ChiselStage.emitCHIRRTL
 
 class PriorityMuxTester extends BasicTester {
 
@@ -49,7 +48,7 @@ class PriorityMuxSpec extends ChiselFlatSpec {
   }
 
   it should "be stack safe" in {
-    emitChirrtl(new RawModule {
+    emitCHIRRTL(new RawModule {
       val n = 1 << 15
       val in = IO(Input(Vec(n, UInt(8.W))))
       val sel = IO(Input(UInt(n.W)))

--- a/src/test/scala/chiselTests/util/RegSpec.scala
+++ b/src/test/scala/chiselTests/util/RegSpec.scala
@@ -1,9 +1,8 @@
 package chiselTests.util
 
 import chisel3._
-import chisel3.stage.ChiselStage
 import chisel3.util.{RegEnable, ShiftRegister, ShiftRegisters}
-
+import circt.stage.ChiselStage
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -16,7 +15,7 @@ class RegEnableSpec extends AnyFlatSpec with Matchers {
       val out = IO(Output(Bool()))
       out := RegEnable(in, true.B)
     }
-    val chirrtl = ChiselStage.emitChirrtl(new MyModule)
+    val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
     val reset = """reset.*RegSpec.scala""".r
     (chirrtl should include).regex(reset)
     val update = """out_r.* in .*RegSpec.scala""".r
@@ -30,7 +29,7 @@ class RegEnableSpec extends AnyFlatSpec with Matchers {
       val out = IO(Output(Bool()))
       out := RegEnable(in, true.B, true.B)
     }
-    val chirrtl = ChiselStage.emitChirrtl(new MyModule)
+    val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
     val reset = """reset .*RegSpec.scala""".r
     (chirrtl should include).regex(reset)
     val update = """out_r.* in .*RegSpec.scala""".r
@@ -48,7 +47,7 @@ class ShiftRegisterSpec extends AnyFlatSpec with Matchers {
       val out = IO(Output(Bool()))
       out := ShiftRegister(in, 2, true.B)
     }
-    val chirrtl = ChiselStage.emitChirrtl(new MyModule)
+    val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
     val reset = """reset .*RegSpec.scala""".r
     (chirrtl should include).regex(reset)
     val update = """out_r.* in .*RegSpec.scala""".r
@@ -62,7 +61,7 @@ class ShiftRegisterSpec extends AnyFlatSpec with Matchers {
       val out = IO(Output(Bool()))
       out := ShiftRegister(in, 2)
     }
-    val chirrtl = ChiselStage.emitChirrtl(new MyModule)
+    val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
     val reset = """reset .*RegSpec.scala""".r
     (chirrtl should include).regex(reset)
     val update = """out_r.* in .*RegSpec.scala""".r
@@ -76,7 +75,7 @@ class ShiftRegisterSpec extends AnyFlatSpec with Matchers {
       val out = IO(Output(Bool()))
       out := ShiftRegister(in, 2, false.B, true.B)
     }
-    val chirrtl = ChiselStage.emitChirrtl(new MyModule)
+    val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
     val reset = """reset .*RegSpec.scala""".r
     (chirrtl should include).regex(reset)
     val update = """out_r.* in .*RegSpec.scala""".r
@@ -95,7 +94,7 @@ class ShiftRegistersSpec extends AnyFlatSpec with Matchers {
       val out = IO(Output(Bool()))
       out := ShiftRegisters(in, 2, true.B)(0)
     }
-    val chirrtl = ChiselStage.emitChirrtl(new MyModule)
+    val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
     val reset = """reset .*RegSpec.scala""".r
     (chirrtl should include).regex(reset)
     val update = """out_r.* in .*RegSpec.scala""".r
@@ -109,7 +108,7 @@ class ShiftRegistersSpec extends AnyFlatSpec with Matchers {
       val out = IO(Output(Bool()))
       out := ShiftRegisters(in, 2)(0)
     }
-    val chirrtl = ChiselStage.emitChirrtl(new MyModule)
+    val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
     val reset = """reset .*RegSpec.scala""".r
     (chirrtl should include).regex(reset)
     val update = """out_r.* in .*RegSpec.scala""".r
@@ -123,7 +122,7 @@ class ShiftRegistersSpec extends AnyFlatSpec with Matchers {
       val out = IO(Output(Bool()))
       out := ShiftRegisters(in, 2, false.B, true.B)(0)
     }
-    val chirrtl = ChiselStage.emitChirrtl(new MyModule)
+    val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
     val reset = """reset .*RegSpec.scala""".r
     (chirrtl should include).regex(reset)
     val update = """out_r.* in .*RegSpec.scala""".r

--- a/src/test/scala/chiselTests/util/experimental/DecoderTableSpec.scala
+++ b/src/test/scala/chiselTests/util/experimental/DecoderTableSpec.scala
@@ -61,7 +61,7 @@ class DecoderTableSpec extends ChiselFlatSpec {
   }
 
   "DecoderTable" should "elaborate a decoder" in {
-    chisel3.stage.ChiselStage.emitChirrtl(new ExampleALUDecoder)
+    circt.stage.ChiselStage.emitCHIRRTL(new ExampleALUDecoder)
   }
 
   "DecoderTable" should "decode every field" in {

--- a/src/test/scala/chiselTests/util/experimental/TruthTableSpec.scala
+++ b/src/test/scala/chiselTests/util/experimental/TruthTableSpec.scala
@@ -4,7 +4,7 @@ package chiselTests.util.experimental
 
 import chisel3._
 import chisel3.util.BitPat
-import chisel3.util.experimental.decode.{decoder, TruthTable}
+import chisel3.util.experimental.decode.{TruthTable, decoder}
 import org.scalatest.flatspec.AnyFlatSpec
 
 class TruthTableSpec extends AnyFlatSpec {
@@ -78,7 +78,7 @@ class TruthTableSpec extends AnyFlatSpec {
 
       io.out := decoder.qmc(io.in, table)
     }
-    assert(chisel3.stage.ChiselStage.emitChirrtl(new Foo) == chisel3.stage.ChiselStage.emitChirrtl(new Foo))
+    assert(circt.stage.ChiselStage.emitCHIRRTL(new Foo) == circt.stage.ChiselStage.emitCHIRRTL(new Foo))
   }
   "TruthTable" should "accept unknown input width" in {
     val t = TruthTable(

--- a/src/test/scala/chiselTests/util/experimental/TruthTableSpec.scala
+++ b/src/test/scala/chiselTests/util/experimental/TruthTableSpec.scala
@@ -4,7 +4,7 @@ package chiselTests.util.experimental
 
 import chisel3._
 import chisel3.util.BitPat
-import chisel3.util.experimental.decode.{TruthTable, decoder}
+import chisel3.util.experimental.decode.{decoder, TruthTable}
 import org.scalatest.flatspec.AnyFlatSpec
 
 class TruthTableSpec extends AnyFlatSpec {

--- a/src/test/scala/chiselTests/util/random/LFSRSpec.scala
+++ b/src/test/scala/chiselTests/util/random/LFSRSpec.scala
@@ -3,7 +3,7 @@
 package chiselTests.util.random
 
 import chisel3._
-import chisel3.stage.ChiselStage
+import circt.stage.ChiselStage
 import chisel3.util.{Cat, Counter, Enum}
 import chisel3.util.random._
 import chisel3.testers.{BasicTester, TesterDriver}

--- a/src/test/scala/chiselTests/util/random/PRNGSpec.scala
+++ b/src/test/scala/chiselTests/util/random/PRNGSpec.scala
@@ -3,7 +3,7 @@
 package chiselTests.util.random
 
 import chisel3._
-import chisel3.stage.ChiselStage
+import circt.stage.ChiselStage
 import chisel3.testers.BasicTester
 import chisel3.util.Counter
 import chisel3.util.random.PRNG


### PR DESCRIPTION
Change tests to use import circt.stage.ChiselStage instead of
 chisel3.stage.ChiselStage. These are the tests that are trivially done via
emitChirrtl -> emitChirrtl
emitFirrtl  -> emitChirrtl
emitVerilog -> emitSystemVerilog

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [ ] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

- code refactoring

#### API Impact

Only affects tests, using the circt.stage API instead of chisel.stage

#### Backend Code Generation Impact


#### Desired Merge Strategy

- Squash: The PR will be squashed and merged (choose this if you have no preference.

#### Release Notes

Chisel3 unit tests are being moved from chisel.stage API to the circt.stage API. This is the first of two PR that will implement
this

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
