### PR TITLE
TruthTable improvements: structural equality and delete sort

### DIFF
--- a/src/main/scala/chisel3/util/experimental/decode/TruthTable.scala
+++ b/src/main/scala/chisel3/util/experimental/decode/TruthTable.scala
@@ -6,7 +6,7 @@ import chisel3.util.BitPat
 import scala.util.hashing.MurmurHash3
 import scala.collection.mutable
 
-sealed class TruthTable private (val table: Seq[(BitPat, BitPat)], val default: BitPat, val sort: Boolean) {
+sealed class TruthTable private (val table: Seq[(BitPat, BitPat)], val default: BitPat) {
   def inputWidth = table.head._1.getWidth
 
   def outputWidth = table.head._2.getWidth
@@ -18,8 +18,8 @@ sealed class TruthTable private (val table: Seq[(BitPat, BitPat)], val default: 
     (table.map(writeRow) ++ Seq(s"${" " * (inputWidth + 2)}${default.rawString}")).mkString("\n")
   }
 
-  def copy(table: Seq[(BitPat, BitPat)] = this.table, default: BitPat = this.default, sort: Boolean = this.sort) =
-    TruthTable(table, default, sort)
+  def copy(table: Seq[(BitPat, BitPat)] = this.table, default: BitPat = this.default) =
+    TruthTable(table, default)
 
   override def equals(y: Any): Boolean = {
     y match {
@@ -115,7 +115,7 @@ object TruthTable {
     }
 
     import BitPat.bitPatOrder
-    new TruthTable(if (sort) finalTable.sorted else finalTable, default, sort)
+    new TruthTable(if (sort) finalTable.sorted else finalTable, default)
   }
 
   /** Parse TruthTable from its string representation. */

--- a/src/main/scala/chisel3/util/experimental/decode/TruthTable.scala
+++ b/src/main/scala/chisel3/util/experimental/decode/TruthTable.scala
@@ -3,6 +3,7 @@
 package chisel3.util.experimental.decode
 
 import chisel3.util.BitPat
+import scala.util.hashing.MurmurHash3
 import scala.collection.mutable
 
 sealed class TruthTable private (val table: Seq[(BitPat, BitPat)], val default: BitPat, val sort: Boolean) {
@@ -22,10 +23,12 @@ sealed class TruthTable private (val table: Seq[(BitPat, BitPat)], val default: 
 
   override def equals(y: Any): Boolean = {
     y match {
-      case y: TruthTable => toString == y.toString
+      case that: TruthTable => this.table == that.table && this.default == that.default
       case _ => false
     }
   }
+
+  override lazy val hashCode: Int = MurmurHash3.productHash((table, default))
 }
 
 object TruthTable {

--- a/src/test/scala/chiselTests/util/experimental/TruthTableSpec.scala
+++ b/src/test/scala/chiselTests/util/experimental/TruthTableSpec.scala
@@ -35,7 +35,9 @@ class TruthTableSpec extends AnyFlatSpec {
     assert(table.toString contains "     0")
   }
   "TruthTable" should "deserialize" in {
-    assert(TruthTable.fromString(str) == table)
+    val table2 = TruthTable.fromString(str)
+    assert(table2 === table)
+    assert(table2.hashCode === table.hashCode)
   }
   "TruthTable" should "merge same key" in {
     assert(


### PR DESCRIPTION
Make TruthTable implement structural equality

We had implemented equals, but not hashCode. This PR also changes the implemental of equals to just use the underlying values instead of wasting the compute calling .toString.

Also, delete sort, it is unused. I will deprecate it on the backport.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

- bug fix 
- performance improvement


#### API Impact

This removes the public sort method from `TruthTable`, it was not functional but does need to be deprecated in 3.5.x.

#### Backend Code Generation Impact

No impact.

#### Desired Merge Strategy

- Squash

#### Release Notes

Implement TruthTable.hashCode so that caching will now work. Also delete TruthTable.sort which was unused.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
