### PR TITLE
Added deprecation for non-Undefined read-under-write mems

### DIFF
--- a/core/src/main/scala/chisel3/Mem.scala
+++ b/core/src/main/scala/chisel3/Mem.scala
@@ -318,6 +318,9 @@ object SyncReadMem {
     if (compileOptions.declaredTypeMustBeUnbound) {
       requireIsChiselType(t, "memory type")
     }
+    if (ruw != Undefined) {
+      Builder.warning(s"specifying read-under-write behavior other than Undefined is deprecated 3.6 and removed in 5.0")
+    }
     val mt = t.cloneTypeFull
     val mem = new SyncReadMem(mt, size, ruw)
     mt.bind(MemTypeBinding(mem))


### PR DESCRIPTION
It turns out that because there is no syntax for declaring non-undefined read-under-write mems in FIRRTL/CHIRRTL, going through that serialization path actually reverts the behavior to Undefined.

This is an opportunity to revisit adding CHIRRTL to the FIRRTL spec and adding this back in, but until then, we should not be generating this from Chisel.

### Contributor Checklist

- [N/A] Did you add Scaladoc to every public function/method?
- [N/A] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [N/A] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
 - removed feature/API

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->
Users of non-undefined memory behavior will get a warning, and in Chisel 5.0, it will get removed. Likely in the future, we will add back the feature once the backing compiler infra supports it more fully.

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->
None.


#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

Deprecated generating memories with non-Undefined read-under-write collision semantics, as they would silently get changed to Undefined r-u-w behavior if going through a CHIRRTL serialization step.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
