### PR TITLE
[circt] Remove -verify-each=false firtool option

### DIFF
--- a/src/main/scala/circt/stage/phases/CIRCT.scala
+++ b/src/main/scala/circt/stage/phases/CIRCT.scala
@@ -193,7 +193,7 @@ class CIRCT extends Phase {
     val binary = "firtool"
 
     val cmd =
-      Seq(binary, "-format=fir", "-warn-on-unprocessed-annotations", "-verify-each=false", "-dedup") ++
+      Seq(binary, "-format=fir", "-warn-on-unprocessed-annotations", "-dedup") ++
         Seq("-output-annotation-file", circtAnnotationFilename) ++
         circtOptions.firtoolOptions ++
         logLevel.toCIRCTOptions ++


### PR DESCRIPTION
Remove the default option of "-verify-each=false" to firtool.  This shouldn't be necessary and shouldn't be turned on.  I had left this on when doing some performance comparisons and it made its way into upstream chisel.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>