### PR TITLE
Fix FIRRTL direction calculations for Vec and OpaqueType

### DIFF
--- a/core/src/main/scala/chisel3/RawModule.scala
+++ b/core/src/main/scala/chisel3/RawModule.scala
@@ -94,23 +94,7 @@ abstract class RawModule(implicit moduleCompileOptions: CompileOptions) extends 
 
     val firrtlPorts = getModulePortsAndLocators.map {
       case (port, sourceInfo) =>
-        // Special case Vec to make FIRRTL emit the direction of its
-        // element.
-        // Just taking the Vec's specifiedDirection is a bug in cases like
-        // Vec(Flipped()), since the Vec's specifiedDirection is
-        // Unspecified.
-        val direction = port match {
-          case v: Vec[_] =>
-            v.specifiedDirection match {
-              case SpecifiedDirection.Input       => SpecifiedDirection.Input
-              case SpecifiedDirection.Output      => SpecifiedDirection.Output
-              case SpecifiedDirection.Flip        => SpecifiedDirection.flip(v.sample_element.specifiedDirection)
-              case SpecifiedDirection.Unspecified => v.sample_element.specifiedDirection
-            }
-          case _ => port.specifiedDirection
-        }
-
-        Port(port, direction, sourceInfo)
+        Port(port, port.specifiedDirection, sourceInfo)
     }
     _firrtlPorts = Some(firrtlPorts)
 

--- a/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
@@ -351,7 +351,7 @@ private[chisel3] object Converter {
   }
 
   def convert(port: Port, topDir: SpecifiedDirection = SpecifiedDirection.Unspecified): fir.Port = {
-    val resolvedDir = SpecifiedDirection.fromParent(topDir, port.dir)
+    val resolvedDir = SpecifiedDirection.fromParent(topDir, firrtlUserDirOf(port.id))
     val dir = resolvedDir match {
       case SpecifiedDirection.Unspecified | SpecifiedDirection.Output => fir.Output
       case SpecifiedDirection.Flip | SpecifiedDirection.Input         => fir.Input

--- a/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
@@ -307,6 +307,8 @@ private[chisel3] object Converter {
   private def firrtlUserDirOf(d: Data): SpecifiedDirection = d match {
     case d: Vec[_] =>
       SpecifiedDirection.fromParent(d.specifiedDirection, firrtlUserDirOf(d.sample_element))
+    case d: Record if d._isOpaqueType =>
+      SpecifiedDirection.fromParent(d.specifiedDirection, firrtlUserDirOf(d.elementsIterator.next))
     case d => d.specifiedDirection
   }
 

--- a/src/test/scala/chiselTests/RecordSpec.scala
+++ b/src/test/scala/chiselTests/RecordSpec.scala
@@ -3,7 +3,7 @@
 package chiselTests
 
 import chisel3._
-import chisel3.experimental.OpaqueType
+import chisel3.experimental.{AutoCloneType, OpaqueType}
 import chisel3.reflect.DataMirror
 import chisel3.testers.BasicTester
 import chisel3.util.{Counter, Queue}
@@ -12,7 +12,7 @@ import chisel3.reflect.DataMirror
 
 import scala.collection.immutable.{ListMap, SeqMap}
 
-trait RecordSpecUtils {
+object RecordSpec {
   class MyBundle extends Bundle {
     val foo = UInt(32.W)
     val bar = UInt(32.W)
@@ -209,19 +209,21 @@ trait RecordSpecUtils {
       if (boxed) new Boxed(gen) else new Unboxed(gen)
     }
   }
-  class Boxed[T <: Data](gen: T) extends MaybeBoxed[T] {
+  class Boxed[T <: Data](gen: T) extends MaybeBoxed[T] with AutoCloneType {
     def boxed = true
-    lazy val elements = SeqMap("underlying" -> gen.cloneType)
+    lazy val elements = SeqMap("underlying" -> gen)
     def underlying = elements.head._2
   }
-  class Unboxed[T <: Data](gen: T) extends MaybeBoxed[T] with OpaqueType {
+  class Unboxed[T <: Data](gen: T) extends MaybeBoxed[T] with OpaqueType with AutoCloneType {
     def boxed = false
-    lazy val elements = SeqMap("" -> gen.cloneType)
+    lazy val elements = SeqMap("" -> gen)
     def underlying = elements.head._2
   }
 }
 
-class RecordSpec extends ChiselFlatSpec with RecordSpecUtils with Utils {
+class RecordSpec extends ChiselFlatSpec with Utils {
+  import RecordSpec._
+
   behavior.of("Records")
 
   they should "bulk connect similarly to Bundles" in {


### PR DESCRIPTION
I noticed that `OpaqueTypes` do not get the proper direction in the output FIRRTL. When debugging why this was the case, I realized that it's the same fundamental issue as my nemesis bug...

The bug that will never die, see https://github.com/chipsalliance/chisel3/pull/945, https://github.com/chipsalliance/chisel3/issues/1063, https://github.com/chipsalliance/chisel3/issues/1192, and https://github.com/chipsalliance/chisel3/pull/1196 (I would not be surprised if there are more that my quick search missed).

For years, Chisel always seemed to have bugs around whether you put direction operators inside or outside of a Vec, `Output(Vec(2, ...))` vs. `Vec(2, Output(...))`. Our fixes to this in the past were piecemeal, never addressing the true root cause, and it turns out... **it's still broken**.

The solution for top-level Vec ports was not properly recursive, so for nested Vecs, it's still broken: https://scastie.scala-lang.org/rdiDRQIqRrqL2OZbdRsRIw
We also never applied that solution to BlackBoxes, so even the simple case is broken there: https://scastie.scala-lang.org/vuMe2HxNSJCbkXWcglOQ0A

It also turns out, that the correct recursive solution already exists and was being used for calculating flippedness of Vec elements _inside_ of Records, so the fix is to just use the same function for ports. This function is then the right place to handle OpaqueTypes as it's basically the same issue of having more than 1 Chisel direction that need to map to a single direction (or flip) in FIRRTL.

Given my history with this bug, I'm far too humbled to think this is the last time we'll deal with it, but a boy can dream.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

 - bug fix 

#### API Impact

No impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

  - Squash

#### Release Notes

Fix calculation of direction and Bundle field flippedness for Vecs and OpaqueTypes.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
