### PR TITLE
[website] Make Contributors fetching more robust

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -179,6 +179,8 @@ jobs:
         uses: ./.github/workflows/install-circt
       - name: Build the microsite
         run: make -C website
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Deploy Website to GitHub Pages (From Master Branch)
         if: (github.event_name == 'push') && (github.ref_type == 'branch') && (github.ref_name == 'master')
         uses: JamesIves/github-pages-deploy-action@3.7.1

--- a/website/project/Contributors.scala
+++ b/website/project/Contributors.scala
@@ -22,7 +22,7 @@ object Contributors {
     JavaNetClientBuilder[IO](blocker).create // use BlazeClientBuilder for production use
   }
 
-  val token: Option[String] = sys.env.get("GITHUB4S_ACCESS_TOKEN")
+  val token: Option[String] = sys.env.get("GITHUB_TOKEN")
 
   def contributors(repo: GitHubRepository): List[User] =
     Github[IO](httpClient, token)
@@ -30,7 +30,10 @@ object Contributors {
       .listContributors(repo.owner, repo.repo)
       .unsafeRunSync()
       .result match {
-        case Left(e) => throw new Exception(s"Unable to fetch contributors for ${repo.serialize}. Did you misspell it? Did the repository move?")
+        case Left(e) => throw new Exception(
+          s"Unable to fetch contributors for ${repo.serialize}. Did you misspell it? Did the repository move?" +
+          s" Is access token defined: ${token.isDefined}? Original exception: ${e.getMessage}"
+        )
         case Right(r) => r
       }
 


### PR DESCRIPTION
Things seem to randomly fail when looking up the contributors. This will provide more information when that occurs and also fix what I suspect to be the cause (we had the token environment variable wrong).

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [NA] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [NA] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

  - bug fix 

#### API Impact

No impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

 - Squash

#### Release Notes


### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
