### PR TITLE
Remove loadMemoryFromFile from Deprecated Roadmap, NFC

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -43,7 +43,6 @@ spec and the Chisel APIs. Thus, the 3.6 release will:
   - Injecting Aspects
   - EnumAnnotations
   - RunFirrtlTransformAnnotation
-  - LoadMemoryFromFile
   - ChiselAnnotation/custom annotations
 - Publish Roadmap
 


### PR DESCRIPTION
Remove loadMemoryFromFile (and implicitly loadMemoryFromFileInline) from the non-exhaustive list of deprecated things in the Roadmap.  This is now planned to be supported by MFC (https://github.com/llvm/circt/pull/4622).

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>