### PR TITLE
Remove unconditional log

### DIFF
--- a/src/main/scala/circt/stage/phases/CIRCT.scala
+++ b/src/main/scala/circt/stage/phases/CIRCT.scala
@@ -234,7 +234,6 @@ class CIRCT extends Phase {
         })
 
     logger.info(s"""Running CIRCT: '${cmd.mkString(" ")} < $$input'""")
-    println(s"""Running CIRCT: '${cmd.mkString(" ")} < $$input'""")
     val stdoutStream, stderrStream = new java.io.ByteArrayOutputStream
     val stdoutWriter = new java.io.PrintWriter(stdoutStream)
     val stderrWriter = new java.io.PrintWriter(stderrStream)


### PR DESCRIPTION
There already exists a `logger` invocation to get at this data if it is necessary. By using an unconditional println we cannot suppress this log.