### PR TITLE
Deprecate loadMemoryFromFile SFC Details

### DIFF
--- a/src/main/scala/chisel3/util/experimental/LoadMemoryTransform.scala
+++ b/src/main/scala/chisel3/util/experimental/LoadMemoryTransform.scala
@@ -18,6 +18,7 @@ import scala.collection.mutable
   * @param fileName      name of input file
   * @param hexOrBinary   use \$readmemh or \$readmemb, i.e. hex or binary text input, default is hex
   */
+@deprecated(deprecatedMFCMessage, "Chisel 3.6")
 case class ChiselLoadMemoryAnnotation[T <: Data](
   target:      MemBase[T],
   fileName:    String,
@@ -194,6 +195,7 @@ object loadMemoryFromFileInline {
   * annotation) when activated it creates additional Verilog files that contain modules bound to the modules that
   * contain an initializable memory.
   */
+@deprecated(deprecatedMFCMessage, "Chisel 3.6")
 class LoadMemoryTransform extends Transform {
   def inputForm:  CircuitForm = LowForm
   def outputForm: CircuitForm = LowForm


### PR DESCRIPTION
Deprecate implementation details related to the loadMemoryFromFile API. Specifically, deprecate the Chisel-level annotation and the SFC transform while preserving the Chisel APIs.  The Annotation will, after Chisel 3.6 be made private and the transform will be deleted.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>

I'm planning to remove these from the `chisel5-slice-n-dice` branch and wanted to get these in as deprecated in Chisel 3.6.