### PR TITLE
Deprecate forceName Component APIs, Transform

### DIFF
--- a/src/main/scala/chisel3/util/experimental/ForceNames.scala
+++ b/src/main/scala/chisel3/util/experimental/ForceNames.scala
@@ -2,6 +2,7 @@
 
 package chisel3.util.experimental
 
+import chisel3.deprecatedMFCMessage
 import chisel3.experimental.{annotate, ChiselAnnotation, RunFirrtlTransform}
 import chisel3.internal.Builder
 import firrtl.Mappers._
@@ -24,6 +25,7 @@ object forceName {
     * @param signal Signal to name
     * @param name Name to force to
     */
+  @deprecated(deprecatedMFCMessage, "Chisel 3.6")
   def apply[T <: chisel3.Element](signal: T, name: String): T = {
     if (!signal.isSynthesizable) Builder.error(s"Using forceName '$name' on non-hardware value $signal")
     annotate(new ChiselAnnotation with RunFirrtlTransform {
@@ -38,6 +40,7 @@ object forceName {
     * This will rename after potential renames from other Custom transforms during FIRRTL compilation
     * @param signal Signal to name
     */
+  @deprecated(deprecatedMFCMessage, "Chisel 3.6")
   def apply[T <: chisel3.Element](signal: T): T = {
     if (!signal.isSynthesizable) Builder.error(s"Using forceName on non-hardware value $signal")
     annotate(new ChiselAnnotation with RunFirrtlTransform {
@@ -83,6 +86,7 @@ object forceName {
   * @param target signal/instance to force the name
   * @param name name to force it to be
   */
+@deprecated(deprecatedMFCMessage, "Chisel 3.6")
 case class ForceNameAnnotation(target: IsMember, name: String) extends SingleTargetAnnotation[IsMember] {
   def duplicate(n: IsMember): ForceNameAnnotation = this.copy(target = n, name)
 
@@ -210,6 +214,7 @@ private object ForceNamesTransform {
   * Common usages:
   *   - Use to avoid prefixing behavior on specific instances whose enclosing modules are inlined
   */
+@deprecated(deprecatedMFCMessage, "Chisel 3.6")
 class ForceNamesTransform extends Transform with DependencyAPIMigration {
   override def optionalPrerequisites:  Seq[TransformDependency] = Seq(Dependency[InlineInstances])
   override def optionalPrerequisiteOf: Seq[TransformDependency] = Forms.LowEmitters

--- a/src/main/scala/chisel3/util/experimental/LoadMemoryTransform.scala
+++ b/src/main/scala/chisel3/util/experimental/LoadMemoryTransform.scala
@@ -18,6 +18,7 @@ import scala.collection.mutable
   * @param fileName      name of input file
   * @param hexOrBinary   use \$readmemh or \$readmemb, i.e. hex or binary text input, default is hex
   */
+@deprecated(deprecatedMFCMessage, "Chisel 3.6")
 case class ChiselLoadMemoryAnnotation[T <: Data](
   target:      MemBase[T],
   fileName:    String,
@@ -194,6 +195,7 @@ object loadMemoryFromFileInline {
   * annotation) when activated it creates additional Verilog files that contain modules bound to the modules that
   * contain an initializable memory.
   */
+@deprecated(deprecatedMFCMessage, "Chisel 3.6")
 class LoadMemoryTransform extends Transform {
   def inputForm:  CircuitForm = LowForm
   def outputForm: CircuitForm = LowForm


### PR DESCRIPTION
Deprecate forceName APIs on components.  These are only supported on modules/instances in the MFC.  (This could be revived in the future if desired.)

Deprecate the ForceNamesTransform.  This doesn't need to be public given that the forceName Chisel API is available to users.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>

This PR is stacked on #2986.