### PR TITLE
Move AnnotationNoDedup Test to MFC

### DIFF
--- a/src/main/scala/chisel3/util/experimental/ForceNames.scala
+++ b/src/main/scala/chisel3/util/experimental/ForceNames.scala
@@ -2,6 +2,7 @@
 
 package chisel3.util.experimental
 
+import chisel3.deprecatedMFCMessage
 import chisel3.experimental.{annotate, ChiselAnnotation, RunFirrtlTransform}
 import chisel3.internal.Builder
 import firrtl.Mappers._
@@ -24,6 +25,7 @@ object forceName {
     * @param signal Signal to name
     * @param name Name to force to
     */
+  @deprecated(deprecatedMFCMessage, "Chisel 3.6")
   def apply[T <: chisel3.Element](signal: T, name: String): T = {
     if (!signal.isSynthesizable) Builder.error(s"Using forceName '$name' on non-hardware value $signal")
     annotate(new ChiselAnnotation with RunFirrtlTransform {
@@ -38,6 +40,7 @@ object forceName {
     * This will rename after potential renames from other Custom transforms during FIRRTL compilation
     * @param signal Signal to name
     */
+  @deprecated(deprecatedMFCMessage, "Chisel 3.6")
   def apply[T <: chisel3.Element](signal: T): T = {
     if (!signal.isSynthesizable) Builder.error(s"Using forceName on non-hardware value $signal")
     annotate(new ChiselAnnotation with RunFirrtlTransform {
@@ -83,6 +86,7 @@ object forceName {
   * @param target signal/instance to force the name
   * @param name name to force it to be
   */
+@deprecated(deprecatedMFCMessage, "Chisel 3.6")
 case class ForceNameAnnotation(target: IsMember, name: String) extends SingleTargetAnnotation[IsMember] {
   def duplicate(n: IsMember): ForceNameAnnotation = this.copy(target = n, name)
 
@@ -210,6 +214,7 @@ private object ForceNamesTransform {
   * Common usages:
   *   - Use to avoid prefixing behavior on specific instances whose enclosing modules are inlined
   */
+@deprecated(deprecatedMFCMessage, "Chisel 3.6")
 class ForceNamesTransform extends Transform with DependencyAPIMigration {
   override def optionalPrerequisites:  Seq[TransformDependency] = Seq(Dependency[InlineInstances])
   override def optionalPrerequisiteOf: Seq[TransformDependency] = Forms.LowEmitters

--- a/src/main/scala/chisel3/util/experimental/LoadMemoryTransform.scala
+++ b/src/main/scala/chisel3/util/experimental/LoadMemoryTransform.scala
@@ -18,6 +18,7 @@ import scala.collection.mutable
   * @param fileName      name of input file
   * @param hexOrBinary   use \$readmemh or \$readmemb, i.e. hex or binary text input, default is hex
   */
+@deprecated(deprecatedMFCMessage, "Chisel 3.6")
 case class ChiselLoadMemoryAnnotation[T <: Data](
   target:      MemBase[T],
   fileName:    String,
@@ -194,6 +195,7 @@ object loadMemoryFromFileInline {
   * annotation) when activated it creates additional Verilog files that contain modules bound to the modules that
   * contain an initializable memory.
   */
+@deprecated(deprecatedMFCMessage, "Chisel 3.6")
 class LoadMemoryTransform extends Transform {
   def inputForm:  CircuitForm = LowForm
   def outputForm: CircuitForm = LowForm

--- a/src/test/scala/chiselTests/AnnotationNoDedup.scala
+++ b/src/test/scala/chiselTests/AnnotationNoDedup.scala
@@ -4,8 +4,7 @@ package chiselTests
 
 import chisel3._
 import chisel3.experimental.doNotDedup
-import chisel3.stage.{ChiselGeneratorAnnotation, ChiselStage}
-import firrtl.stage.FirrtlCircuitAnnotation
+import circt.stage.ChiselStage
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -41,39 +40,22 @@ class UsesMuchUsedModule(addAnnos: Boolean) extends Module {
 }
 
 class AnnotationNoDedup extends AnyFreeSpec with Matchers {
-  val stage = new ChiselStage
   "Firrtl provides transform that reduces identical modules to a single instance" - {
     "Annotations can be added which will prevent this deduplication for specific modules instances" in {
-      val lowFirrtl = stage
-        .execute(
-          Array("-X", "low", "--target-dir", "test_run_dir"),
-          Seq(ChiselGeneratorAnnotation(() => new UsesMuchUsedModule(addAnnos = true)))
-        )
-        .collectFirst {
-          case FirrtlCircuitAnnotation(circuit) => circuit.serialize
-        }
-        .getOrElse(fail)
-      lowFirrtl should include("module MuchUsedModule :")
-      lowFirrtl should include("module MuchUsedModule_1 :")
-      lowFirrtl should include("module MuchUsedModule_3 :")
-      (lowFirrtl should not).include("module MuchUsedModule_2 :")
-      (lowFirrtl should not).include("module MuchUsedModule_4 :")
+      val verilog = ChiselStage.emitSystemVerilog(new UsesMuchUsedModule(addAnnos = true))
+      verilog should include("module MuchUsedModule(")
+      verilog should include("module MuchUsedModule_1(")
+      verilog should include("module MuchUsedModule_3(")
+      (verilog should not).include("module MuchUsedModule_2(")
+      (verilog should not).include("module MuchUsedModule_4(")
     }
     "Turning off these annotations dedups all the occurrences" in {
-      val lowFirrtl = stage
-        .execute(
-          Array("-X", "low", "--target-dir", "test_run_dir"),
-          Seq(ChiselGeneratorAnnotation(() => new UsesMuchUsedModule(addAnnos = false)))
-        )
-        .collectFirst {
-          case FirrtlCircuitAnnotation(circuit) => circuit.serialize
-        }
-        .getOrElse(fail)
-      lowFirrtl should include("module MuchUsedModule :")
-      (lowFirrtl should not).include("module MuchUsedModule_1 :")
-      (lowFirrtl should not).include("module MuchUsedModule_3 :")
-      (lowFirrtl should not).include("module MuchUsedModule_2 :")
-      (lowFirrtl should not).include("module MuchUsedModule_4 :")
+      val verilog = ChiselStage.emitSystemVerilog(new UsesMuchUsedModule(addAnnos = false))
+      verilog should include("module MuchUsedModule(")
+      (verilog should not).include("module MuchUsedModule_1(")
+      (verilog should not).include("module MuchUsedModule_3(")
+      (verilog should not).include("module MuchUsedModule_2(")
+      (verilog should not).include("module MuchUsedModule_4(")
     }
   }
 }

--- a/src/test/scala/chiselTests/experimental/ForceNames.scala
+++ b/src/test/scala/chiselTests/experimental/ForceNames.scala
@@ -5,8 +5,9 @@ package chiselTests
 import firrtl._
 import chisel3._
 import chisel3.experimental.annotate
-import chisel3.stage.{ChiselGeneratorAnnotation, ChiselStage}
-import chisel3.util.experimental.{forceName, ForceNameAnnotation, ForceNamesTransform, InlineInstance}
+import chisel3.stage.ChiselGeneratorAnnotation
+import chisel3.util.experimental.{forceName, InlineInstance}
+import circt.stage.ChiselStage
 import firrtl.annotations.{Annotation, ReferenceTarget}
 import firrtl.options.{Dependency, TargetDirAnnotation}
 import firrtl.stage.RunFirrtlTransformAnnotation
@@ -20,7 +21,6 @@ object ForceNamesHierarchy {
     val inst = Module(new Wrapper)
     inst.in := in
     out := inst.out
-    forceName(out, "outt")
   }
   class Wrapper extends Module with InlineInstance {
     val in = IO(Input(UInt(3.W)))
@@ -35,28 +35,6 @@ object ForceNamesHierarchy {
     val out = IO(Output(UInt(3.W)))
     out := in
   }
-  class RenamePortsExample extends Module {
-    val in = IO(Input(UInt(3.W)))
-    val out = IO(Output(UInt(3.W)))
-    val inst = Module(new MyLeaf)
-    inst.in := in
-    out := inst.out
-    forceName(inst.in, "inn")
-  }
-  class ConflictingName extends Module {
-    val in = IO(Input(UInt(3.W)))
-    val out = IO(Output(UInt(3.W)))
-    out := in
-    forceName(out, "in")
-  }
-  class BundleName extends Module {
-    val in = IO(new Bundle {
-      val a = Input(UInt(3.W))
-      val b = Input(UInt(3.W))
-    })
-    val out = IO(Output(UInt(3.W)))
-    out := in.a + in.b
-  }
 }
 
 class ForceNamesSpec extends ChiselFlatSpec {
@@ -67,21 +45,14 @@ class ForceNamesSpec extends ChiselFlatSpec {
     inputAnnos: Seq[Annotation] = Nil,
     info:       LogLevel.Value = LogLevel.None
   ): Iterable[String] = {
-    def stage = new ChiselStage {
-      override val targets = Seq(
-        Dependency[chisel3.stage.phases.Elaborate],
-        Dependency[chisel3.stage.phases.Convert],
-        Dependency[firrtl.stage.phases.Compiler]
-      )
-    }
+    val stage = new ChiselStage
 
     val annos = List(
       TargetDirAnnotation("test_run_dir/ForceNames"),
-      LogLevelAnnotation(info),
       ChiselGeneratorAnnotation(() => dut)
     ) ++ inputAnnos
 
-    val ret = stage.execute(Array(), annos)
+    val ret = stage.execute(Array("--target", "systemverilog"), annos)
     val verilog = ret.collectFirst {
       case e: EmittedVerilogCircuitAnnotation => e.value.value
     }.get
@@ -91,37 +62,5 @@ class ForceNamesSpec extends ChiselFlatSpec {
   "Force Names on a wrapping instance" should "work" in {
     val verilog = run(new ForceNamesHierarchy.WrapperExample, "wrapper")
     exactly(1, verilog) should include("MyLeaf inst")
-  }
-  "Force Names on an instance port" should "work" in {
-    val verilog = run(new ForceNamesHierarchy.RenamePortsExample, "instports")
-    atLeast(1, verilog) should include("input  [2:0] inn")
-  }
-  "Force Names with a conflicting name" should "error" in {
-    intercept[CustomTransformException] {
-      run(new ForceNamesHierarchy.ConflictingName, "conflicts")
-    }
-  }
-  "Force Names of an intermediate bundle" should "error" in {
-    intercept[CustomTransformException] {
-      run(
-        new ForceNamesHierarchy.BundleName,
-        "bundlename",
-        Seq(ForceNameAnnotation(ReferenceTarget("BundleName", "BundleName", Nil, "in", Nil), "inn"))
-      )
-    }
-  }
-  "Force Name of non-hardware value" should "error" in {
-    class Example extends Module {
-      val tpe = UInt(8.W)
-      forceName(tpe, "foobar")
-
-      val in = IO(Input(tpe))
-      val out = IO(Output(tpe))
-      out := in
-    }
-
-    a[ChiselException] shouldBe thrownBy {
-      circt.stage.ChiselStage.elaborate(new Example)
-    }
   }
 }


### PR DESCRIPTION
Convert the AnnotationNoDedup test to use the MFC.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>

This is a stacked PR as it's easier to manage the `chisel5` branch this way.