### PR TITLE
[CIRCT] Remove CombinationalPath Anno Dropping

### DIFF
--- a/src/main/scala/circt/stage/phases/CIRCT.scala
+++ b/src/main/scala/circt/stage/phases/CIRCT.scala
@@ -167,7 +167,6 @@ class CIRCT extends Phase {
         logLevel = anno.globalLogLevel
         Nil
       /* The following can be dropped. */
-      case _: firrtl.transforms.CombinationalPath   => Nil
       case _: _root_.logger.ClassLogLevelAnnotation => Nil
       /* Default case: leave the annotation around and let firtool warn about it. */
       case a => Seq(a)


### PR DESCRIPTION
Change the CIRCT phase to no longer drop the CombinationalPath annotation.  This dropping behavior was done to enable an SFC->MFC handoff where the SFC can produce this annotation.  Chisel can never produce this annotation, so it is safe to have MFC error if it sees it.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>

This is done in preparation to drop this annotation on the `chisel5` branch.