### PR TITLE
Promote ChiselException to package chisel3

### DIFF
--- a/core/src/main/scala/chisel3/Num.scala
+++ b/core/src/main/scala/chisel3/Num.scala
@@ -2,7 +2,6 @@
 
 package chisel3
 
-import chisel3.internal.ChiselException
 import chisel3.internal.firrtl.{BinaryPoint, KnownBinaryPoint}
 import chisel3.internal.sourceinfo.SourceInfoTransform
 import scala.language.experimental.macros

--- a/core/src/main/scala/chisel3/RawModule.scala
+++ b/core/src/main/scala/chisel3/RawModule.scala
@@ -141,6 +141,9 @@ package object internal {
   @deprecated("This function has moved to chisel3.experimental", "Chisel 3.6")
   val noPrefix = chisel3.experimental.noPrefix
 
+  @deprecated("This function has moved to chisel3", "Chisel 3.6")
+  type ChiselException = chisel3.ChiselException
+
   import scala.annotation.implicitNotFound
   @implicitNotFound("You are trying to access a macro-only API. Please use the @public annotation instead.")
   trait MacroGenerated

--- a/core/src/main/scala/chisel3/connectable/Connection.scala
+++ b/core/src/main/scala/chisel3/connectable/Connection.scala
@@ -2,8 +2,8 @@
 
 package chisel3.connectable
 
-import chisel3.{Aggregate, BiConnectException, Data, DontCare, RawModule}
-import chisel3.internal.{BiConnect, Builder, InternalErrorException}
+import chisel3.{Aggregate, BiConnectException, Data, DontCare, InternalErrorException, RawModule}
+import chisel3.internal.{BiConnect, Builder}
 import chisel3.internal.Builder.pushCommand
 import chisel3.internal.firrtl.DefInvalid
 import chisel3.experimental.{prefix, SourceInfo, UnlocatableSourceInfo}

--- a/core/src/main/scala/chisel3/experimental/Attach.scala
+++ b/core/src/main/scala/chisel3/experimental/Attach.scala
@@ -2,7 +2,7 @@
 
 package chisel3.experimental
 
-import chisel3.RawModule
+import chisel3.{ChiselException, RawModule}
 import chisel3.internal._
 import chisel3.internal.Builder.pushCommand
 import chisel3.internal.firrtl._

--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/Hierarchy.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/Hierarchy.scala
@@ -8,7 +8,6 @@ import scala.collection.mutable.{HashMap, HashSet}
 import scala.reflect.runtime.universe.TypeTag
 import chisel3.experimental.BaseModule
 import _root_.firrtl.annotations.IsModule
-import chisel3.internal.InternalErrorException
 
 import scala.annotation.implicitNotFound
 

--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/Instance.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/Instance.scala
@@ -5,7 +5,7 @@ package chisel3.experimental.hierarchy.core
 import scala.language.experimental.macros
 import chisel3._
 import chisel3.experimental.hierarchy.{InstantiableClone, ModuleClone}
-import chisel3.internal.{throwException, Builder, InternalErrorException}
+import chisel3.internal.{throwException, Builder}
 import chisel3.experimental.{BaseModule, ExtModule, SourceInfo}
 import chisel3.internal.sourceinfo.InstanceTransform
 import chisel3.internal.firrtl.{Component, DefBlackBox, DefModule, Port}

--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/Lookupable.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/Lookupable.scala
@@ -10,15 +10,7 @@ import scala.collection.mutable.HashMap
 import chisel3._
 import chisel3.experimental.dataview.{isView, reify, reifySingleData}
 import chisel3.internal.firrtl.{Arg, ILit, Index, ModuleIO, Slot, ULit}
-import chisel3.internal.{
-  throwException,
-  AggregateViewBinding,
-  Builder,
-  ChildBinding,
-  InternalErrorException,
-  ViewBinding,
-  ViewParent
-}
+import chisel3.internal.{throwException, AggregateViewBinding, Builder, ChildBinding, ViewBinding, ViewParent}
 
 /** Represents lookup typeclass to determine how a value accessed from an original IsInstantiable
   *   should be tweaked to return the Instance's version

--- a/core/src/main/scala/chisel3/internal/Error.scala
+++ b/core/src/main/scala/chisel3/internal/Error.scala
@@ -84,70 +84,11 @@ object ExceptionHelpers {
   }
 }
 
-class InternalErrorException(message: String, cause: Throwable = null)
-    extends ChiselException(
-      "Internal Error: Please file an issue at https://github.com/chipsalliance/chisel3/issues:" + message,
-      cause
-    )
-
-class ChiselException(message: String, cause: Throwable = null) extends Exception(message, cause, true, true) {
-
-  /** Examine a [[Throwable]], to extract all its causes. Innermost cause is first.
-    * @param throwable an exception to examine
-    * @return a sequence of all the causes with innermost cause first
-    */
-  @tailrec
-  private def getCauses(throwable: Throwable, acc: Seq[Throwable] = Seq.empty): Seq[Throwable] =
-    throwable.getCause() match {
-      case null => throwable +: acc
-      case a    => getCauses(a, throwable +: acc)
-    }
-
-  /** Returns true if an exception contains */
-  private def containsBuilder(throwable: Throwable): Boolean =
-    throwable
-      .getStackTrace()
-      .collectFirst {
-        case ste if ste.getClassName().startsWith(ExceptionHelpers.builderName) => throwable
-      }
-      .isDefined
-
-  /** Examine this [[ChiselException]] and it's causes for the first [[Throwable]] that contains a stack trace including
-    * a stack trace element whose declaring class is the [[ExceptionHelpers.builderName]]. If no such element exists, return this
-    * [[ChiselException]].
-    */
-  private lazy val likelyCause: Throwable =
-    getCauses(this).collectFirst { case a if containsBuilder(a) => a }.getOrElse(this)
-
-  /** For an exception, return a stack trace trimmed to user code only
-    *
-    * This does the following actions:
-    *
-    *   1. Trims the top of the stack trace while elements match [[ExceptionHelpers.packageTrimlist]]
-    *   2. Trims the bottom of the stack trace until an element matches [[ExceptionHelpers.builderName]]
-    *   3. Trims from the [[ExceptionHelpers.builderName]] all [[ExceptionHelpers.packageTrimlist]]
-    *
-    * @param throwable the exception whose stack trace should be trimmed
-    * @return an array of stack trace elements
-    */
-  private def trimmedStackTrace(throwable: Throwable): Array[StackTraceElement] = {
-    def isBlacklisted(ste: StackTraceElement) = {
-      val packageName = ste.getClassName().takeWhile(_ != '.')
-      ExceptionHelpers.packageTrimlist.contains(packageName)
-    }
-
-    val trimmedLeft = throwable.getStackTrace().view.dropWhile(isBlacklisted)
-    val trimmedReverse = trimmedLeft.toIndexedSeq.reverse.view
-      .dropWhile(ste => !ste.getClassName.startsWith(ExceptionHelpers.builderName))
-      .dropWhile(isBlacklisted)
-    trimmedReverse.toIndexedSeq.reverse.toArray
-  }
-}
-private[chisel3] class Errors(message: String) extends ChiselException(message) with NoStackTrace
+private[chisel3] class Errors(message: String) extends chisel3.ChiselException(message) with NoStackTrace
 
 private[chisel3] object throwException {
   def apply(s: String, t: Throwable = null): Nothing =
-    throw new ChiselException(s, t)
+    throw new chisel3.ChiselException(s, t)
 }
 
 /** Records and reports runtime errors and warnings. */

--- a/core/src/main/scala/chisel3/package.scala
+++ b/core/src/main/scala/chisel3/package.scala
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import chisel3.internal.firrtl.BinaryPoint
+import chisel3.internal.ExceptionHelpers
 import java.util.{MissingFormatArgumentException, UnknownFormatConversionException}
 import scala.collection.mutable
+import scala.annotation.tailrec
 
 /** This package contains the main chisel3 API.
   */
@@ -332,7 +334,65 @@ package object chisel3 {
 
   implicit def string2Printable(str: String): Printable = PString(str)
 
-  type ChiselException = internal.ChiselException
+  class InternalErrorException(message: String, cause: Throwable = null)
+      extends ChiselException(
+        "Internal Error: Please file an issue at https://github.com/chipsalliance/chisel3/issues:" + message,
+        cause
+      )
+
+  class ChiselException(message: String, cause: Throwable = null) extends Exception(message, cause, true, true) {
+
+    /** Examine a [[Throwable]], to extract all its causes. Innermost cause is first.
+      * @param throwable an exception to examine
+      * @return a sequence of all the causes with innermost cause first
+      */
+    @tailrec
+    private def getCauses(throwable: Throwable, acc: Seq[Throwable] = Seq.empty): Seq[Throwable] =
+      throwable.getCause() match {
+        case null => throwable +: acc
+        case a    => getCauses(a, throwable +: acc)
+      }
+
+    /** Returns true if an exception contains */
+    private def containsBuilder(throwable: Throwable): Boolean =
+      throwable
+        .getStackTrace()
+        .collectFirst {
+          case ste if ste.getClassName().startsWith(ExceptionHelpers.builderName) => throwable
+        }
+        .isDefined
+
+    /** Examine this [[ChiselException]] and it's causes for the first [[Throwable]] that contains a stack trace including
+      * a stack trace element whose declaring class is the [[ExceptionHelpers.builderName]]. If no such element exists, return this
+      * [[ChiselException]].
+      */
+    private lazy val likelyCause: Throwable =
+      getCauses(this).collectFirst { case a if containsBuilder(a) => a }.getOrElse(this)
+
+    /** For an exception, return a stack trace trimmed to user code only
+      *
+      * This does the following actions:
+      *
+      *   1. Trims the top of the stack trace while elements match [[ExceptionHelpers.packageTrimlist]]
+      *   2. Trims the bottom of the stack trace until an element matches [[ExceptionHelpers.builderName]]
+      *   3. Trims from the [[ExceptionHelpers.builderName]] all [[ExceptionHelpers.packageTrimlist]]
+      *
+      * @param throwable the exception whose stack trace should be trimmed
+      * @return an array of stack trace elements
+      */
+    private def trimmedStackTrace(throwable: Throwable): Array[StackTraceElement] = {
+      def isBlacklisted(ste: StackTraceElement) = {
+        val packageName = ste.getClassName().takeWhile(_ != '.')
+        ExceptionHelpers.packageTrimlist.contains(packageName)
+      }
+
+      val trimmedLeft = throwable.getStackTrace().view.dropWhile(isBlacklisted)
+      val trimmedReverse = trimmedLeft.toIndexedSeq.reverse.view
+        .dropWhile(ste => !ste.getClassName.startsWith(ExceptionHelpers.builderName))
+        .dropWhile(isBlacklisted)
+      trimmedReverse.toIndexedSeq.reverse.toArray
+    }
+  }
 
   // Debugger/Tester access to internal Chisel data structures and methods.
   def getDataElements(a: Aggregate): Seq[Element] = {

--- a/src/main/scala/chisel3/aop/Select.scala
+++ b/src/main/scala/chisel3/aop/Select.scala
@@ -3,7 +3,7 @@
 package chisel3.aop
 
 import chisel3._
-import chisel3.internal.{HasId, InternalErrorException, PseudoModule}
+import chisel3.internal.{HasId, PseudoModule}
 import chisel3.experimental.BaseModule
 import chisel3.experimental.FixedPoint
 import chisel3.internal.firrtl.{Definition => DefinitionIR, _}

--- a/src/main/scala/chisel3/compatibility.scala
+++ b/src/main/scala/chisel3/compatibility.scala
@@ -86,7 +86,7 @@ package object Chisel {
   }
 
   @deprecated("Chisel compatibility mode is deprecated. Use the chisel3 package instead.", "Chisel 3.6")
-  type ChiselException = chisel3.internal.ChiselException
+  type ChiselException = chisel3.ChiselException
 
   @deprecated("Chisel compatibility mode is deprecated. Use the chisel3 package instead.", "Chisel 3.6")
   type Data = chisel3.Data

--- a/src/main/scala/chisel3/stage/phases/AddSerializationAnnotations.scala
+++ b/src/main/scala/chisel3/stage/phases/AddSerializationAnnotations.scala
@@ -8,7 +8,7 @@ import firrtl.options.Viewer.view
 
 import chisel3.stage._
 import chisel3.stage.CircuitSerializationAnnotation._
-import chisel3.internal.ChiselException
+import chisel3.ChiselException
 
 /** Adds [[stage.CircuitSerializationAnnotation]]s based on [[ChiselOutputFileAnnotation]]
   */

--- a/src/main/scala/chisel3/util/experimental/ForceNames.scala
+++ b/src/main/scala/chisel3/util/experimental/ForceNames.scala
@@ -2,9 +2,9 @@
 
 package chisel3.util.experimental
 
-import chisel3.deprecatedMFCMessage
+import chisel3.{deprecatedMFCMessage, InternalErrorException}
 import chisel3.experimental.{annotate, ChiselAnnotation, RunFirrtlTransform}
-import chisel3.internal.{Builder, InternalErrorException}
+import chisel3.internal.Builder
 import firrtl.Mappers._
 import firrtl._
 import firrtl.annotations._

--- a/src/main/scala/chisel3/util/experimental/decode/QMCMinimizer.scala
+++ b/src/main/scala/chisel3/util/experimental/decode/QMCMinimizer.scala
@@ -3,7 +3,7 @@
 package chisel3.util.experimental.decode
 
 import chisel3.util.BitPat
-import chisel3.internal.InternalErrorException
+import chisel3.InternalErrorException
 
 import scala.annotation.tailrec
 import scala.math.Ordered.orderingToOrdered

--- a/src/test/scala/chiselTests/ChiselEnum.scala
+++ b/src/test/scala/chiselTests/ChiselEnum.scala
@@ -362,7 +362,6 @@ class IsOneOfTester extends BasicTester {
 }
 
 class ChiselEnumSpec extends ChiselFlatSpec with Utils {
-  import chisel3.internal.ChiselException
 
   behavior.of("ChiselEnum")
 

--- a/src/test/scala/chiselTests/InstanceNameSpec.scala
+++ b/src/test/scala/chiselTests/InstanceNameSpec.scala
@@ -6,8 +6,6 @@ import chisel3._
 import circt.stage.ChiselStage
 import chisel3.util.Queue
 
-import chisel3.internal.ChiselException
-
 class InstanceNameModule extends Module {
   val io = IO(new Bundle {
     val foo = Input(UInt(32.W))

--- a/src/test/scala/chiselTests/LiteralToTargetSpec.scala
+++ b/src/test/scala/chiselTests/LiteralToTargetSpec.scala
@@ -11,7 +11,7 @@ class LiteralToTargetSpec extends AnyFreeSpec with Matchers {
 
   "Literal Data should fail to be converted to ReferenceTarget" in {
 
-    (the[chisel3.internal.ChiselException] thrownBy {
+    (the[ChiselException] thrownBy {
 
       class Bar extends RawModule {
         val a = 1.U

--- a/src/test/scala/chiselTests/MultiAssign.scala
+++ b/src/test/scala/chiselTests/MultiAssign.scala
@@ -33,7 +33,7 @@ class MultiAssignSpec extends ChiselFlatSpec {
 
 class IllegalAssignSpec extends ChiselFlatSpec with Utils {
   "Reassignments to literals" should "be disallowed" in {
-    intercept[chisel3.internal.ChiselException] {
+    intercept[ChiselException] {
       extractCause[ChiselException] {
         ChiselStage.elaborate {
           new BasicTester {
@@ -45,7 +45,7 @@ class IllegalAssignSpec extends ChiselFlatSpec with Utils {
   }
 
   "Reassignments to ops" should "be disallowed" in {
-    intercept[chisel3.internal.ChiselException] {
+    intercept[ChiselException] {
       extractCause[ChiselException] {
         ChiselStage.elaborate {
           new BasicTester {
@@ -57,7 +57,7 @@ class IllegalAssignSpec extends ChiselFlatSpec with Utils {
   }
 
   "Reassignments to bit slices" should "be disallowed" in {
-    intercept[chisel3.internal.ChiselException] {
+    intercept[ChiselException] {
       extractCause[ChiselException] {
         ChiselStage.elaborate {
           new BasicTester {
@@ -69,7 +69,7 @@ class IllegalAssignSpec extends ChiselFlatSpec with Utils {
   }
 
   "Bulk-connecting two read-only nodes" should "be disallowed" in {
-    intercept[chisel3.internal.ChiselException] {
+    intercept[ChiselException] {
       extractCause[ChiselException] {
         ChiselStage.elaborate {
           new BasicTester {

--- a/src/test/scala/chiselTests/OneHotMuxSpec.scala
+++ b/src/test/scala/chiselTests/OneHotMuxSpec.scala
@@ -4,7 +4,6 @@ package chiselTests
 
 import chisel3._
 import chisel3.experimental.FixedPoint
-import chisel3.internal.ChiselException
 import chisel3.testers.BasicTester
 import chisel3.util.{Mux1H, UIntToOH}
 import org.scalatest._

--- a/src/test/scala/chiselTests/RawModuleSpec.scala
+++ b/src/test/scala/chiselTests/RawModuleSpec.scala
@@ -73,7 +73,7 @@ class RawModuleSpec extends ChiselFlatSpec with Utils {
   }
 
   "ImplicitModule directly in a RawModule" should "fail" in {
-    intercept[chisel3.internal.ChiselException] {
+    intercept[ChiselException] {
       extractCause[ChiselException] {
         ChiselStage.elaborate { new RawModuleWithDirectImplicitModule }
       }
@@ -81,7 +81,7 @@ class RawModuleSpec extends ChiselFlatSpec with Utils {
   }
 
   "ImplicitModule directly in a RawModule in an ImplicitModule" should "fail" in {
-    intercept[chisel3.internal.ChiselException] {
+    intercept[ChiselException] {
       extractCause[ChiselException] {
         ChiselStage.elaborate { new ImplicitModuleDirectlyInRawModuleTester }
       }

--- a/src/test/scala/chiselTests/ToTargetSpec.scala
+++ b/src/test/scala/chiselTests/ToTargetSpec.scala
@@ -3,7 +3,6 @@
 package chiselTests
 
 import chisel3._
-import chisel3.internal.ChiselException
 import circt.stage.ChiselStage
 
 class ToTargetSpec extends ChiselFlatSpec with Utils {

--- a/src/test/scala/chiselTests/stage/ChiselMainSpec.scala
+++ b/src/test/scala/chiselTests/stage/ChiselMainSpec.scala
@@ -241,12 +241,12 @@ class ChiselMainSpec extends AnyFeatureSpec with GivenWhenThen with Matchers wit
   info("I screw up and compile some bad code")
   Feature("Stack trace trimming of ChiselException") {
     Seq(
-      ChiselMainExceptionTest[chisel3.internal.ChiselException](
+      ChiselMainExceptionTest[ChiselException](
         args = Array("-X", "low"),
         generator = Some(classOf[DifferentTypesModule]),
         stackTrace = Seq(Left("java"), Right(classOf[DifferentTypesModule].getName))
       ),
-      ChiselMainExceptionTest[chisel3.internal.ChiselException](
+      ChiselMainExceptionTest[ChiselException](
         args = Array("-X", "low", "--full-stacktrace"),
         generator = Some(classOf[DifferentTypesModule]),
         stackTrace = Seq(Right("java"), Right(classOf[DifferentTypesModule].getName))
@@ -269,7 +269,7 @@ class ChiselMainSpec extends AnyFeatureSpec with GivenWhenThen with Matchers wit
   }
   Feature("Builder.error errors with source info") {
     runStageExpectException(
-      ChiselMainExceptionTest[chisel3.internal.ChiselException](
+      ChiselMainExceptionTest[ChiselException](
         args = Array("-X", "low"),
         generator = Some(classOf[BuilderErrorModule]),
         message = Seq(Right("Fatal errors during hardware elaboration")),
@@ -283,7 +283,7 @@ class ChiselMainSpec extends AnyFeatureSpec with GivenWhenThen with Matchers wit
   }
   Feature("Stack trace trimming and Builder.error errors") {
     runStageExpectException(
-      ChiselMainExceptionTest[chisel3.internal.ChiselException](
+      ChiselMainExceptionTest[ChiselException](
         args = Array("-X", "low"),
         generator = Some(classOf[BuilderErrorNoSourceInfoModule]),
         message = Seq(Right("Fatal errors during hardware elaboration")),


### PR DESCRIPTION
It was previously aliased from chisel3.internal which is bad for ScalaDoc.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

  - code cleanup

#### API Impact

ChiselException has moved, this is binary incompatible but source compatible because there is a deprecated alias in package chisel3.internal

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

   - Squash

#### Release Notes

Move Chisel exception from package chisel3.internal to package chisel3. It had been aliased in package chisel3 but moving it allows it to show up in the ScalaDoc.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
