### PR TITLE
[circt] Stop dropping RunFirrtlTransformAnnotation

### DIFF
--- a/src/main/scala/circt/stage/phases/CIRCT.scala
+++ b/src/main/scala/circt/stage/phases/CIRCT.scala
@@ -148,15 +148,6 @@ class CIRCT extends Phase {
         split = true
         Nil
       }
-      case a @ RunFirrtlTransformAnnotation(transform) =>
-        transform match {
-          /* Inlining/Flattening happen by default, so these can be dropped. */
-          case _: firrtl.passes.InlineInstances | _: firrtl.transforms.Flatten => Nil
-          /* Any emitters should not be passed to firtool. */
-          case _: firrtl.Emitter => Nil
-          /* Default case: leave the annotation around and let firtool warn about it. */
-          case _ => Seq(a)
-        }
       case firrtl.passes.memlib.InferReadWriteAnnotation =>
         inferReadWrite = true
         Nil


### PR DESCRIPTION
Remove dropping of RunFirrtlTransformAnnotation.  This isn't necessary to drop as firtool will drop these if it sees them.  There is utility in _not_ dropping these as it removes a dependency from the "circt" package on transforms that will be removed from the "firrtl" package on the chisel5 branch.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>