### PR TITLE
Add DataMirror.queryNameGuess

### DIFF
--- a/core/src/main/scala/chisel3/reflect/DataMirror.scala
+++ b/core/src/main/scala/chisel3/reflect/DataMirror.scala
@@ -42,6 +42,21 @@ object DataMirror {
     */
   def isReg(x: Data): Boolean = hasBinding[RegBinding](x)
 
+  /** Get an early guess for the name of this [[Data]]
+    *
+    * '''Warning: it is not guaranteed that this name will end up in the output FIRRTL or Verilog.'''
+    *
+    * Name guesses are not stable and may change due to a subsequent [[Data.suggestName]] or
+    * plugin-related naming.
+    * Name guesses are not necessarily legal Verilog identifiers.
+    * Name guesses for elements of Bundles or Records will include periods, and guesses for elements
+    * of Vecs will include square brackets.
+    */
+  def queryNameGuess(x: Data): String = {
+    requireIsHardware(x, "To queryNameGuess,")
+    x.earlyName
+  }
+
   /** Check if two Chisel types are the same type.
     * Internally, this is dispatched to each Chisel type's
     * `typeEquivalent` function for each type to determine

--- a/src/test/scala/chiselTests/reflect/DataMirrorSpec.scala
+++ b/src/test/scala/chiselTests/reflect/DataMirrorSpec.scala
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-package chiselTests.experimental
+package chiselTests.reflect
 
 import chisel3._
 import chisel3.reflect.DataMirror
@@ -86,5 +86,29 @@ class DataMirrorSpec extends ChiselFlatSpec {
       DataMirror.getParent(this) should be(None)
     }
     ChiselStage.elaborate(new Top)
+  }
+
+  it should "support getting name guesses even though they may change" in {
+    import DataMirror.queryNameGuess
+    class MyModule extends Module {
+      val io = {
+        val port = IO(new Bundle {
+          val foo = Output(UInt(8.W))
+        })
+        queryNameGuess(port) should be("io_port")
+        queryNameGuess(port.foo) should be("io_port.foo")
+        port
+      }
+      queryNameGuess(io) should be("io")
+      queryNameGuess(io.foo) should be("io.foo")
+      io.suggestName("potato")
+      queryNameGuess(io) should be("potato")
+      queryNameGuess(io.foo) should be("potato.foo")
+    }
+    ChiselStage.elaborate(new MyModule)
+  }
+
+  it should "not support name guesses for non-hardware" in {
+    an[ExpectedHardwareException] should be thrownBy DataMirror.queryNameGuess(UInt(8.W))
   }
 }


### PR DESCRIPTION
This allows users to see what name Chisel plans to give a Data. This name is NOT guaranteed and the docs warn heavily about that.

This has been requested for debugging purposes--it's not an API I'd recommend using but that's why it's in `DataMirror` with a bit of an obnoxious name 😇 

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

  - new feature/API

#### API Impact

API expansion

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

- Squash

#### Release Notes

Add `DataMirror.queryNameGuess` for getting some information about what Chisel might name a `Data`. This should not be relied upon and often will not match the name in the output Verilog, see API docs.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
