### PR TITLE
[circt] Remove reliance on some FIRRTL Phases

### DIFF
--- a/src/main/scala/circt/stage/ChiselStage.scala
+++ b/src/main/scala/circt/stage/ChiselStage.scala
@@ -29,7 +29,7 @@ class ChiselStage extends Stage {
         Dependency[chisel3.stage.ChiselStage],
         Dependency[firrtl.stage.phases.AddImplicitOutputFile],
         Dependency[circt.stage.phases.Checks],
-        Dependency[circt.stage.CIRCTStage]
+        Dependency[circt.stage.phases.CIRCT]
       ),
       currentState = Seq(
         Dependency[firrtl.stage.phases.AddDefaults],

--- a/src/main/scala/circt/stage/phases/CIRCT.scala
+++ b/src/main/scala/circt/stage/phases/CIRCT.scala
@@ -120,8 +120,6 @@ class CIRCT extends Phase {
   import scala.sys.process._
 
   override def prerequisites = Seq(
-    Dependency[firrtl.stage.phases.AddDefaults],
-    Dependency[firrtl.stage.phases.AddImplicitEmitter],
     Dependency[firrtl.stage.phases.AddImplicitOutputFile]
   )
   override def optionalPrerequisites = Seq.empty


### PR DESCRIPTION
Simplify the dependency specification for CIRCT stage/phase infra to enable removal of some FIRRTL phases on the chisel5 branch.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>

This is primarily to remove the dependency on `AddImplicitEmitter`.