### PR TITLE
Cleanup warnings 3

### DIFF
--- a/core/src/main/scala/chisel3/Bits.scala
+++ b/core/src/main/scala/chisel3/Bits.scala
@@ -1086,7 +1086,7 @@ sealed class SInt private[chisel3] (width: Width) extends Bits(width) with Num[S
   )(
     implicit sourceInfo: SourceInfo,
     compileOptions:      CompileOptions
-  ) {
+  ): Unit = {
     this := that.asSInt
   }
 }

--- a/core/src/main/scala/chisel3/Data.scala
+++ b/core/src/main/scala/chisel3/Data.scala
@@ -418,7 +418,7 @@ abstract class Data extends HasId with NamedComponent with SourceInfoDoc {
   private def _binding:    Option[Binding] = Option(_bindingVar)
   // Only valid after node is bound (synthesizable), crashes otherwise
   protected[chisel3] def binding: Option[Binding] = _binding
-  protected def binding_=(target: Binding) {
+  protected def binding_=(target: Binding): Unit = {
     if (_binding.isDefined) {
       throw RebindingException(s"Attempted reassignment of binding to $this, from: ${target}")
     }
@@ -468,7 +468,7 @@ abstract class Data extends HasId with NamedComponent with SourceInfoDoc {
   private def _direction:    Option[ActualDirection] = Option(_directionVar)
 
   private[chisel3] def direction: ActualDirection = _direction.get
-  private[chisel3] def direction_=(actualDirection: ActualDirection) {
+  private[chisel3] def direction_=(actualDirection: ActualDirection): Unit = {
     if (_direction.isDefined) {
       throw RebindingException(s"Attempted reassignment of resolved direction to $this")
     }

--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -314,7 +314,7 @@ package experimental {
     // Fresh Namespace because in Firrtl, Modules namespaces are disjoint with the global namespace
     private[chisel3] val _namespace = Namespace.empty
     private val _ids = ArrayBuffer[HasId]()
-    private[chisel3] def addId(d: HasId) {
+    private[chisel3] def addId(d: HasId): Unit = {
       if (Builder.aspectModule(this).isDefined) {
         aspectModule(this).get.addId(d)
       } else {
@@ -524,7 +524,7 @@ package experimental {
       *
       * TODO: remove this, perhaps by removing Bindings checks in compatibility mode.
       */
-    def _compatAutoWrapPorts() {}
+    def _compatAutoWrapPorts(): Unit = {}
 
     /** Chisel2 code didn't require the IO(...) wrapper and would assign a Chisel type directly to
       * io, then do operations on it. This binds a Chisel type in-place (mutably) as an IO.

--- a/core/src/main/scala/chisel3/RawModule.scala
+++ b/core/src/main/scala/chisel3/RawModule.scala
@@ -25,7 +25,7 @@ abstract class RawModule(implicit moduleCompileOptions: CompileOptions) extends 
   // Perhaps this should be an ArrayBuffer (or ArrayBuilder), but DefModule is public and has Seq[Command]
   // so our best option is to share a single Seq datastructure with that
   private val _commands = new VectorBuilder[Command]()
-  private[chisel3] def addCommand(c: Command) {
+  private[chisel3] def addCommand(c: Command): Unit = {
     require(!_closed, "Can't write to module after module close")
     _commands += c
   }

--- a/core/src/main/scala/chisel3/experimental/hierarchy/Instantiate.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/Instantiate.scala
@@ -10,8 +10,8 @@ import scala.collection.mutable
 
 import chisel3._
 import chisel3.experimental.{BaseModule, SourceInfo, UnlocatableSourceInfo}
-import chisel3.experimental.DataMirror
-import chisel3.experimental.DataMirror.internal.isSynthesizable
+import chisel3.reflect.DataMirror
+import chisel3.reflect.DataMirror.internal.isSynthesizable
 import chisel3.internal.Builder
 import chisel3.ExplicitCompileOptions
 

--- a/core/src/main/scala/chisel3/experimental/package.scala
+++ b/core/src/main/scala/chisel3/experimental/package.scala
@@ -62,7 +62,7 @@ package object experimental {
   object requireIsHardware {
     def apply(node: Data, msg: String = ""): Unit = {
       node._parent match { // Compatibility layer hack
-        case Some(x: BaseModule) => x._compatAutoWrapPorts
+        case Some(x) => x._compatAutoWrapPorts
         case _ =>
       }
       if (!node.isSynthesizable) {

--- a/core/src/main/scala/chisel3/experimental/package.scala
+++ b/core/src/main/scala/chisel3/experimental/package.scala
@@ -63,7 +63,7 @@ package object experimental {
     def apply(node: Data, msg: String = ""): Unit = {
       node._parent match { // Compatibility layer hack
         case Some(x) => x._compatAutoWrapPorts
-        case _ =>
+        case _       =>
       }
       if (!node.isSynthesizable) {
         val prefix = if (msg.nonEmpty) s"$msg " else ""

--- a/core/src/main/scala/chisel3/experimental/package.scala
+++ b/core/src/main/scala/chisel3/experimental/package.scala
@@ -92,7 +92,7 @@ package object experimental {
     import dataview._
     def coerceDirection(d: Data) = {
       import chisel3.{SpecifiedDirection => SD}
-      DataMirror.specifiedDirectionOf(gen) match {
+      chisel3.reflect.DataMirror.specifiedDirectionOf(gen) match {
         case SD.Flip   => Flipped(d)
         case SD.Input  => Input(d)
         case SD.Output => Output(d)

--- a/core/src/main/scala/chisel3/internal/BiConnect.scala
+++ b/core/src/main/scala/chisel3/internal/BiConnect.scala
@@ -376,14 +376,15 @@ private[chisel3] object BiConnect {
     val left_mod:  BaseModule = left.topBinding.location.getOrElse(context_mod)
     val right_mod: BaseModule = right.topBinding.location.getOrElse(context_mod)
 
-    val left_parent = Builder.retrieveParent(left_mod, context_mod).getOrElse(None)
-    val right_parent = Builder.retrieveParent(right_mod, context_mod).getOrElse(None)
+    val left_parent_opt = Builder.retrieveParent(left_mod, context_mod)
+    val right_parent_opt = Builder.retrieveParent(right_mod, context_mod)
+    val context_mod_opt = Some(context_mod)
 
     val left_direction = BindingDirection.from(left.topBinding, left.direction)
     val right_direction = BindingDirection.from(right.topBinding, right.direction)
 
     // CASE: Context is same module as left node and right node is in a child module
-    if ((left_mod == context_mod) && (right_parent == context_mod)) {
+    if ((left_mod == context_mod) && (right_parent_opt == context_mod_opt)) {
       // Thus, right node better be a port node and thus have a direction hint
       ((left_direction, right_direction): @unchecked) match {
         //    CURRENT MOD   CHILD MOD
@@ -400,7 +401,7 @@ private[chisel3] object BiConnect {
     }
 
     // CASE: Context is same module as right node and left node is in child module
-    else if ((right_mod == context_mod) && (left_parent == context_mod)) {
+    else if ((right_mod == context_mod) && (left_parent_opt == context_mod_opt)) {
       // Thus, left node better be a port node and thus have a direction hint
       ((left_direction, right_direction): @unchecked) match {
         //    CHILD MOD     CURRENT MOD
@@ -443,7 +444,7 @@ private[chisel3] object BiConnect {
     // CASE: Context is the parent module of both the module containing left node
     //                                        and the module containing right node
     //   Note: This includes case when left and right in same module but in parent
-    else if ((left_parent == context_mod) && (right_parent == context_mod)) {
+    else if ((left_parent_opt == context_mod_opt) && (right_parent_opt == context_mod_opt)) {
       // Thus both nodes must be ports and have a direction hint
       ((left_direction, right_direction): @unchecked) match {
         //    CHILD MOD     CHILD MOD

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -872,7 +872,7 @@ object DynamicNamingStack {
     prefixRef
   }
 
-  def length(): Int = Builder.namingStackOption.get.length
+  def length(): Int = Builder.namingStackOption.get.length()
 }
 
 /** Casts BigInt to Int, issuing an error when the input isn't representable. */

--- a/core/src/main/scala/chisel3/internal/MonoConnect.scala
+++ b/core/src/main/scala/chisel3/internal/MonoConnect.scala
@@ -243,8 +243,9 @@ private[chisel3] object MonoConnect {
     val sink_mod:   BaseModule = sink.topBinding.location.getOrElse(throw UnwritableSinkException(sink, source))
     val source_mod: BaseModule = source.topBinding.location.getOrElse(context_mod)
 
-    val sink_parent = Builder.retrieveParent(sink_mod, context_mod).getOrElse(None)
-    val source_parent = Builder.retrieveParent(source_mod, context_mod).getOrElse(None)
+    val sink_parent_opt = Builder.retrieveParent(sink_mod, context_mod)
+    val source_parent_opt = Builder.retrieveParent(source_mod, context_mod)
+    val context_mod_opt = Some(context_mod)
 
     val sink_is_port = sink.topBinding match {
       case PortBinding(_) => true
@@ -269,7 +270,7 @@ private[chisel3] object MonoConnect {
     }
 
     // CASE: Context is same module as sink node and source node is in a child module
-    else if ((sink_mod == context_mod) && (source_parent == context_mod)) {
+    else if ((sink_mod == context_mod) && (source_parent_opt == context_mod_opt)) {
       // NOTE: Workaround for bulk connecting non-agnostified FIRRTL ports
       // See: https://github.com/freechipsproject/firrtl/issues/1703
       // Original behavior should just check if the sink direction is an Input
@@ -288,7 +289,7 @@ private[chisel3] object MonoConnect {
     }
 
     // CASE: Context is same module as source node and sink node is in child module
-    else if ((source_mod == context_mod) && (sink_parent == context_mod)) {
+    else if ((source_mod == context_mod) && (sink_parent_opt == context_mod_opt)) {
       // NOTE: Workaround for bulk connecting non-agnostified FIRRTL ports
       // See: https://github.com/freechipsproject/firrtl/issues/1703
       // Original behavior should just check if the sink direction is an Input
@@ -302,7 +303,7 @@ private[chisel3] object MonoConnect {
     // CASE: Context is the parent module of both the module containing sink node
     //                                        and the module containing source node
     //   Note: This includes case when sink and source in same module but in parent
-    else if ((sink_parent == context_mod) && (source_parent == context_mod)) {
+    else if ((sink_parent_opt == context_mod_opt) && (source_parent_opt == context_mod_opt)) {
       // Thus both nodes must be ports and have a direction
       if (!source_is_port) { !connectCompileOptions.dontAssumeDirectionality }
       else if (sink_is_port) {
@@ -403,8 +404,9 @@ private[chisel3] object MonoConnect {
     val sink_mod:   BaseModule = sink.topBinding.location.getOrElse(throw UnwritableSinkException(sink, source))
     val source_mod: BaseModule = source.topBinding.location.getOrElse(context_mod)
 
-    val sink_parent = Builder.retrieveParent(sink_mod, context_mod).getOrElse(None)
-    val source_parent = Builder.retrieveParent(source_mod, context_mod).getOrElse(None)
+    val sink_parent_opt = Builder.retrieveParent(sink_mod, context_mod)
+    val source_parent_opt = Builder.retrieveParent(source_mod, context_mod)
+    val context_mod_opt = Some(context_mod)
 
     val sink_direction = BindingDirection.from(sink.topBinding, sink.direction)
     val source_direction = BindingDirection.from(source.topBinding, source.direction)
@@ -429,7 +431,7 @@ private[chisel3] object MonoConnect {
     }
 
     // CASE: Context is same module as sink node and right node is in a child module
-    else if ((sink_mod == context_mod) && (source_parent == context_mod)) {
+    else if ((sink_mod == context_mod) && (source_parent_opt == context_mod_opt)) {
       // Thus, right node better be a port node and thus have a direction
       ((sink_direction, source_direction): @unchecked) match {
         //    SINK          SOURCE
@@ -451,7 +453,7 @@ private[chisel3] object MonoConnect {
     }
 
     // CASE: Context is same module as source node and sink node is in child module
-    else if ((source_mod == context_mod) && (sink_parent == context_mod)) {
+    else if ((source_mod == context_mod) && (sink_parent_opt == context_mod_opt)) {
       // Thus, left node better be a port node and thus have a direction
       ((sink_direction, source_direction): @unchecked) match {
         //    SINK          SOURCE
@@ -465,7 +467,7 @@ private[chisel3] object MonoConnect {
     // CASE: Context is the parent module of both the module containing sink node
     //                                        and the module containing source node
     //   Note: This includes case when sink and source in same module but in parent
-    else if ((sink_parent == context_mod) && (source_parent == context_mod)) {
+    else if ((sink_parent_opt == context_mod_opt) && (source_parent_opt == context_mod_opt)) {
       // Thus both nodes must be ports and have a direction
       ((sink_direction, source_direction): @unchecked) match {
         //    SINK          SOURCE

--- a/core/src/main/scala/chisel3/internal/Namer.scala
+++ b/core/src/main/scala/chisel3/internal/Namer.scala
@@ -53,7 +53,7 @@ sealed trait NamingContextInterface {
     * so that actual naming calls (HasId.suggestName) can happen.
     * Recursively names descendants, for those whose return value have an associated name.
     */
-  def namePrefix(prefix: String)
+  def namePrefix(prefix: String): Unit
 }
 
 /** Dummy implementation to allow for naming annotations in a non-Builder context.
@@ -76,7 +76,7 @@ class NamingContext extends NamingContextInterface {
     * prefixed with the name given to the reference object, if the reference object is named in the
     * scope of this context.
     */
-  def addDescendant(ref: Any, descendant: NamingContext) {
+  def addDescendant(ref: Any, descendant: NamingContext): Unit = {
     ref match {
       case ref: AnyRef =>
         // getOrElseUpdate

--- a/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
@@ -308,7 +308,7 @@ private[chisel3] object Converter {
     case d: Vec[_] =>
       SpecifiedDirection.fromParent(d.specifiedDirection, firrtlUserDirOf(d.sample_element))
     case d: Record if d._isOpaqueType =>
-      SpecifiedDirection.fromParent(d.specifiedDirection, firrtlUserDirOf(d.elementsIterator.next))
+      SpecifiedDirection.fromParent(d.specifiedDirection, firrtlUserDirOf(d.elementsIterator.next()))
     case d => d.specifiedDirection
   }
 

--- a/macros/src/main/scala/chisel3/internal/InstantiableMacro.scala
+++ b/macros/src/main/scala/chisel3/internal/InstantiableMacro.scala
@@ -49,8 +49,8 @@ private[chisel3] object instantiableMacro {
       }
       val (newClz, implicitClzs, tpname) = clz match {
         case q"$mods class $tpname[..$tparams] $ctorMods(...$paramss) extends { ..$earlydefns } with ..$parents { $self => ..$stats }" =>
-          val defname = TypeName(tpname + c.freshName())
-          val instname = TypeName(tpname + c.freshName())
+          val defname = TypeName(tpname.toString + c.freshName())
+          val instname = TypeName(tpname.toString + c.freshName())
           val (newStats, extensions) = processBody(stats)
           val argTParams = tparams.map(_.name)
           (
@@ -62,8 +62,8 @@ private[chisel3] object instantiableMacro {
             tpname
           )
         case q"$mods trait $tpname[..$tparams] extends { ..$earlydefns } with ..$parents { $self => ..$stats }" =>
-          val defname = TypeName(tpname + c.freshName())
-          val instname = TypeName(tpname + c.freshName())
+          val defname = TypeName(tpname.toString + c.freshName())
+          val instname = TypeName(tpname.toString + c.freshName())
           val (newStats, extensions) = processBody(stats)
           val argTParams = tparams.map(_.name)
           (

--- a/src/main/scala/chisel3/aop/Select.scala
+++ b/src/main/scala/chisel3/aop/Select.scala
@@ -481,9 +481,9 @@ object Select {
   // Given a loc, return all subcomponents of id that could be assigned to in connect
   private def getEffected(a: Arg): Seq[Data] = a match {
     case Node(id: Data) => getIntermediateAndLeafs(id)
-    case Slot(imm, name)   => Seq(imm.id.asInstanceOf[Record].elements(name))
-    case Index(imm, value) => getEffected(imm)
-    case _                 => throw new InternalErrorException("Match error: a=$a")
+    case Slot(imm, name) => Seq(imm.id.asInstanceOf[Record].elements(name))
+    case Index(imm, _)   => getEffected(imm)
+    case _               => throw new InternalErrorException("Match error: a=$a")
   }
 
   // Given an arg, return the corresponding id. Don't use on a loc of a connect.

--- a/src/main/scala/chisel3/util/Conditional.scala
+++ b/src/main/scala/chisel3/util/Conditional.scala
@@ -66,19 +66,19 @@ object is {
   // TODO: Begin deprecation of non-type-parameterized is statements.
   /** Executes `block` if the switch condition is equal to any of the values in `v`.
     */
-  def apply(v: Iterable[Element])(block: => Any) {
+  def apply(v: Iterable[Element])(block: => Any): Unit = {
     require(false, "The 'is' keyword may not be used outside of a switch.")
   }
 
   /** Executes `block` if the switch condition is equal to `v`.
     */
-  def apply(v: Element)(block: => Any) {
+  def apply(v: Element)(block: => Any): Unit = {
     require(false, "The 'is' keyword may not be used outside of a switch.")
   }
 
   /** Executes `block` if the switch condition is equal to any of the values in the argument list.
     */
-  def apply(v: Element, vr: Element*)(block: => Any) {
+  def apply(v: Element, vr: Element*)(block: => Any): Unit = {
     require(false, "The 'is' keyword may not be used outside of a switch.")
   }
 }

--- a/src/main/scala/chisel3/util/Counter.scala
+++ b/src/main/scala/chisel3/util/Counter.scala
@@ -55,7 +55,7 @@ class Counter private (r: Range, oldN: Option[Int] = None) extends AffectsChisel
     *
     * @param n number of steps before the counter resets
     */
-  def this(n: Int) { this(0 until math.max(1, n), Some(n)) }
+  def this(n: Int) = { this(0 until math.max(1, n), Some(n)) }
 
   /** The current value of the counter. */
   val value = if (r.length > 1) RegInit(r.head.U(width.W)) else WireInit(r.head.U)

--- a/src/main/scala/chisel3/util/Decoupled.scala
+++ b/src/main/scala/chisel3/util/Decoupled.scala
@@ -6,7 +6,8 @@
 package chisel3.util
 
 import chisel3._
-import chisel3.experimental.{requireIsChiselType, DataMirror, Direction}
+import chisel3.experimental.{requireIsChiselType, Direction}
+import chisel3.reflect.DataMirror
 
 import scala.annotation.nowarn
 

--- a/src/test/scala/chiselTests/AsTypeOfTester.scala
+++ b/src/test/scala/chiselTests/AsTypeOfTester.scala
@@ -3,7 +3,7 @@
 package chiselTests
 
 import chisel3._
-import chisel3.experimental.{DataMirror, FixedPoint}
+import chisel3.reflect.DataMirror
 import chisel3.testers.BasicTester
 
 class AsTypeOfBundleTester extends BasicTester {

--- a/src/test/scala/chiselTests/BlackBox.scala
+++ b/src/test/scala/chiselTests/BlackBox.scala
@@ -5,6 +5,7 @@ package chiselTests
 import circt.stage.ChiselStage
 import chisel3._
 import chisel3.experimental._
+import chisel3.reflect.DataMirror
 import chisel3.testers.{BasicTester, TesterDriver}
 import chisel3.util._
 

--- a/src/test/scala/chiselTests/ChiselEnum.scala
+++ b/src/test/scala/chiselTests/ChiselEnum.scala
@@ -744,7 +744,7 @@ class ChiselEnumAnnotationSpec extends AnyFreeSpec with Matchers {
     CorrectVecAnno("bund.inner_bundle1.v", enumExampleName, Set())
   )
 
-  def printAnnos(annos: Seq[Annotation]) {
+  def printAnnos(annos: Seq[Annotation]): Unit = {
     println("Enum definitions:")
     annos.foreach {
       case EnumDefAnnotation(enumTypeName, definition) => println(s"\t$enumTypeName: $definition")
@@ -801,7 +801,7 @@ class ChiselEnumAnnotationSpec extends AnyFreeSpec with Matchers {
   def allCorrectVecs(annos: Seq[EnumVecAnnotation], corrects: Seq[CorrectVecAnno]): Boolean =
     corrects.forall(c => annos.exists(isCorrect(_, c)))
 
-  def test(strongEnumAnnotatorGen: () => Module) {
+  def test(strongEnumAnnotatorGen: () => Module): Unit = {
     val annos = (new chisel3.stage.ChiselStage).execute(
       Array("--target-dir", "test_run_dir", "--no-run-firrtl"),
       Seq(ChiselGeneratorAnnotation(strongEnumAnnotatorGen))

--- a/src/test/scala/chiselTests/CompatibilitySpec.scala
+++ b/src/test/scala/chiselTests/CompatibilitySpec.scala
@@ -516,7 +516,7 @@ class CompatibilitySpec extends ChiselFlatSpec with ScalaCheckDrivenPropertyChec
       chisel3.assert(vec.read(UInt(1)) === UInt(3))
 
       val (_, done) = Counter(Bool(true), 4)
-      when(done) { stop }
+      when(done) { stop() }
     }
 
     assertTesterPasses(new Foo)

--- a/src/test/scala/chiselTests/ConnectableSpec.scala
+++ b/src/test/scala/chiselTests/ConnectableSpec.scala
@@ -10,7 +10,8 @@ import chisel3.experimental.BundleLiterals._
 import chisel3.experimental.VecLiterals._
 import chisel3.stage.ChiselStage
 import chisel3.testers.BasicTester
-import chisel3.experimental.{DataMirror, OpaqueType}
+import chisel3.experimental.OpaqueType
+import chisel3.reflect.DataMirror
 import scala.collection.immutable.SeqMap
 
 object ConnectableSpec {

--- a/src/test/scala/chiselTests/CustomBundle.scala
+++ b/src/test/scala/chiselTests/CustomBundle.scala
@@ -3,7 +3,8 @@
 package chiselTests
 
 import chisel3._
-import chisel3.experimental.{requireIsChiselType, DataMirror}
+import chisel3.experimental.requireIsChiselType
+import chisel3.reflect.DataMirror
 import scala.collection.immutable.ListMap
 
 // An example of how Record might be extended

--- a/src/test/scala/chiselTests/Decoder.scala
+++ b/src/test/scala/chiselTests/Decoder.scala
@@ -36,14 +36,14 @@ class DecoderSpec extends ChiselPropSpec {
   val bitpatPair = for (seed <- Arbitrary.arbitrary[Int]) yield {
     val rnd = new scala.util.Random(seed)
     val bs = seed.toBinaryString
-    val bp = bs.map(if (rnd.nextBoolean) _ else "?")
+    val bp = bs.map(if (rnd.nextBoolean()) _ else "?")
 
     // The following randomly throws in white space and underscores which are legal and ignored.
     val bpp = bp.map { a =>
-      if (rnd.nextBoolean) {
-        a
+      if (rnd.nextBoolean()) {
+        a.toString
       } else {
-        a + (if (rnd.nextBoolean) "_" else " ")
+        a.toString + (if (rnd.nextBoolean()) "_" else " ")
       }
     }.mkString
 

--- a/src/test/scala/chiselTests/Direction.scala
+++ b/src/test/scala/chiselTests/Direction.scala
@@ -131,7 +131,8 @@ class DirectionSpec extends ChiselPropSpec with Matchers with Utils {
     })
   }
 
-  import chisel3.experimental.{DataMirror, Direction}
+  import chisel3.experimental.Direction
+  import chisel3.reflect.DataMirror
 
   property("Flipped should flip the specified direction of a Bundle") {
     class MyBundle extends Bundle {

--- a/src/test/scala/chiselTests/ExtModule.scala
+++ b/src/test/scala/chiselTests/ExtModule.scala
@@ -6,6 +6,7 @@ import chisel3._
 import chisel3.experimental._
 import circt.stage.ChiselStage
 import chisel3.testers.{BasicTester, TesterDriver}
+import chisel3.reflect.DataMirror
 
 // Avoid collisions with regular BlackBox tests by putting ExtModule blackboxes
 // in their own scope.

--- a/src/test/scala/chiselTests/InlineSpec.scala
+++ b/src/test/scala/chiselTests/InlineSpec.scala
@@ -60,7 +60,7 @@ class InlineSpec extends AnyFreeSpec with ChiselRunners with Matchers {
             case FirrtlCircuitAnnotation(circuit) => circuit
           }
           .map(collectInstances(_, Some("Top")))
-          .getOrElse(fail)
+          .getOrElse(fail())
 
       instanceNames should contain theSameElementsAs Set("Top", "Top.x_sub", "Top.y_sub", "Top.z", "Top.z.sub")
     }
@@ -88,7 +88,7 @@ class InlineSpec extends AnyFreeSpec with ChiselRunners with Matchers {
             case FirrtlCircuitAnnotation(circuit) => circuit
           }
           .map(collectInstances(_, Some("Top")))
-          .getOrElse(fail)
+          .getOrElse(fail())
 
       instanceNames should contain theSameElementsAs Set("Top", "Top.x")
     }

--- a/src/test/scala/chiselTests/LoadMemoryFromFileSpec.scala
+++ b/src/test/scala/chiselTests/LoadMemoryFromFileSpec.scala
@@ -135,7 +135,7 @@ class LoadMemoryFromFileSpec extends AnyFreeSpec with Matchers {
     file should exist
     mem.foreach(m => {
       info(s"Memory $m is referenced in $file")
-      val found = io.Source.fromFile(file).getLines.exists { _.contains(s"""readmemh("$m"""") }
+      val found = io.Source.fromFile(file).getLines().exists { _.contains(s"""readmemh("$m"""") }
       found should be(true)
     })
   }

--- a/src/test/scala/chiselTests/MemorySearch.scala
+++ b/src/test/scala/chiselTests/MemorySearch.scala
@@ -14,7 +14,7 @@ class MemorySearch extends Module {
   })
   val vals = Array(0, 4, 15, 14, 2, 5, 13)
   val index = RegInit(0.U(3.W))
-  val elts = VecInit(vals.map(_.asUInt(4.W)))
+  val elts = VecInit(vals.toIndexedSeq.map(_.asUInt(4.W)))
   // val elts  = Mem(UInt(32.W), 8) TODO ????
   val elt = elts(index)
   val end = !io.en && ((elt === io.target) || (index === 7.U))

--- a/src/test/scala/chiselTests/PrintableSpec.scala
+++ b/src/test/scala/chiselTests/PrintableSpec.scala
@@ -17,7 +17,7 @@ class PrintableSpec extends AnyFlatSpec with Matchers with Utils {
   private case class Printf(str: String, args: Seq[String])
   private def getPrintfs(firrtl: String): Seq[Printf] = {
     def processArgs(str: String): Seq[String] =
-      str.split(",").map(_.trim).filter(_.nonEmpty)
+      str.split(",").toIndexedSeq.map(_.trim).filter(_.nonEmpty)
     def processBody(str: String): (String, Seq[String]) = {
       str match {
         case StringRegex(_, fmt, args) =>
@@ -25,7 +25,7 @@ class PrintableSpec extends AnyFlatSpec with Matchers with Utils {
         case _ => fail(s"Regex to process Printf should work on $str!")
       }
     }
-    firrtl.split("\n").collect {
+    firrtl.split("\n").toIndexedSeq.collect {
       case PrintfRegex(matched) =>
         val (str, args) = processBody(matched)
         Printf(str, args)

--- a/src/test/scala/chiselTests/RecordSpec.scala
+++ b/src/test/scala/chiselTests/RecordSpec.scala
@@ -8,7 +8,6 @@ import chisel3.reflect.DataMirror
 import chisel3.testers.BasicTester
 import chisel3.util.{Counter, Queue}
 import circt.stage.ChiselStage
-import chisel3.reflect.DataMirror
 
 import scala.collection.immutable.{ListMap, SeqMap}
 
@@ -282,7 +281,7 @@ class RecordSpec extends ChiselFlatSpec with Utils {
   they should "work correctly with DataMirror in nested OpaqueType Records" in {
     var mod: NestedRecordModule = null
     ChiselStage.elaborate { mod = new NestedRecordModule; mod }
-    val ports = chisel3.experimental.DataMirror.fullModulePorts(mod.inst)
+    val ports = DataMirror.fullModulePorts(mod.inst)
     val expectedPorts = Seq(
       ("clock", mod.inst.clock),
       ("reset", mod.inst.reset),

--- a/src/test/scala/chiselTests/Vec.scala
+++ b/src/test/scala/chiselTests/Vec.scala
@@ -95,7 +95,7 @@ class ValueTester(w: Int, values: List[Int]) extends BasicTester {
 
 class TabulateTester(n: Int) extends BasicTester {
   val v = VecInit(Range(0, n).map(i => (i * 2).asUInt))
-  val x = VecInit(Array.tabulate(n) { i => (i * 2).asUInt })
+  val x = VecInit(Array.tabulate(n) { i => (i * 2).asUInt }.toIndexedSeq)
   val u = VecInit.tabulate(n)(i => (i * 2).asUInt)
 
   assert(v.asUInt === x.asUInt)
@@ -106,7 +106,7 @@ class TabulateTester(n: Int) extends BasicTester {
 }
 
 class FillTester(n: Int, value: Int) extends BasicTester {
-  val x = VecInit(Array.fill(n)(value.U))
+  val x = VecInit(Array.fill(n)(value.U).toIndexedSeq)
   val u = VecInit.fill(n)(value.U)
 
   assert(x.asUInt === u.asUInt, cf"Expected Vec to be filled like $x, instead VecInit.fill created $u")

--- a/src/test/scala/chiselTests/VerificationSpec.scala
+++ b/src/test/scala/chiselTests/VerificationSpec.scala
@@ -30,7 +30,7 @@ class VerificationSpec extends ChiselPropSpec with Matchers {
 
   property("basic equality check should work") {
     val fir = ChiselStage.emitCHIRRTL(new SimpleTest)
-    val lines = fir.split("\n").map(_.trim)
+    val lines = fir.split("\n").map(_.trim).toIndexedSeq
 
     // reset guard around the verification statement
     assertContains(lines, "when _T_2 : ")
@@ -64,7 +64,7 @@ class VerificationSpec extends ChiselPropSpec with Matchers {
     // read in FIRRTL file
     val svFile = new File(testDir, "AnnotationTest.sv")
     svFile should exist
-    val svLines = scala.io.Source.fromFile(svFile).getLines.toList
+    val svLines = scala.io.Source.fromFile(svFile).getLines().toList
 
     // check that verification appear in verilog output
     exactly(1, svLines) should include("cover__cov: cov")

--- a/src/test/scala/chiselTests/experimental/hierarchy/SeparateElaborationSpec.scala
+++ b/src/test/scala/chiselTests/experimental/hierarchy/SeparateElaborationSpec.scala
@@ -77,7 +77,7 @@ class SeparateElaborationSpec extends ChiselFunSpec with Utils {
         )
       )
 
-      val tb_rtl = Source.fromFile(s"$testDir/Testbench.v").getLines.mkString
+      val tb_rtl = Source.fromFile(s"$testDir/Testbench.v").getLines().mkString
       tb_rtl should include("module AddOne_1(")
       tb_rtl should include("AddOne_1 mod (")
       (tb_rtl should not).include("module AddOne(")
@@ -109,7 +109,7 @@ class SeparateElaborationSpec extends ChiselFunSpec with Utils {
         )
       )
 
-      val tb_rtl = Source.fromFile(s"$testDir/Testbench.v").getLines.mkString
+      val tb_rtl = Source.fromFile(s"$testDir/Testbench.v").getLines().mkString
       tb_rtl should include("module AddOne_1(")
       tb_rtl should include("AddOne_1 inst0 (")
       (tb_rtl should not).include("module AddOne(")
@@ -182,12 +182,12 @@ class SeparateElaborationSpec extends ChiselFunSpec with Utils {
         )
       )
 
-      val dutDef0_rtl = Source.fromFile(s"$testDir/dutDef0/AddOneParameterized.v").getLines.mkString
+      val dutDef0_rtl = Source.fromFile(s"$testDir/dutDef0/AddOneParameterized.v").getLines().mkString
       dutDef0_rtl should include("module AddOneParameterized(")
-      val dutDef1_rtl = Source.fromFile(s"$testDir/dutDef1/AddOneParameterized_1.v").getLines.mkString
+      val dutDef1_rtl = Source.fromFile(s"$testDir/dutDef1/AddOneParameterized_1.v").getLines().mkString
       dutDef1_rtl should include("module AddOneParameterized_1(")
 
-      val tb_rtl = Source.fromFile(s"$testDir/Testbench.v").getLines.mkString
+      val tb_rtl = Source.fromFile(s"$testDir/Testbench.v").getLines().mkString
       tb_rtl should include("AddOneParameterized inst0 (")
       tb_rtl should include("AddOneParameterized_1 inst1 (")
       (tb_rtl should not).include("module AddOneParameterized(")
@@ -226,9 +226,9 @@ class SeparateElaborationSpec extends ChiselFunSpec with Utils {
 
       // Because these elaborations have no knowledge of each other, they create
       // modules of the same name
-      val dutDef0_rtl = Source.fromFile(s"$testDir/dutDef0/AddOneParameterized.v").getLines.mkString
+      val dutDef0_rtl = Source.fromFile(s"$testDir/dutDef0/AddOneParameterized.v").getLines().mkString
       dutDef0_rtl should include("module AddOneParameterized(")
-      val dutDef1_rtl = Source.fromFile(s"$testDir/dutDef1/AddOneParameterized.v").getLines.mkString
+      val dutDef1_rtl = Source.fromFile(s"$testDir/dutDef1/AddOneParameterized.v").getLines().mkString
       dutDef1_rtl should include("module AddOneParameterized(")
 
       val errMsg = intercept[ChiselException] {
@@ -280,10 +280,10 @@ class SeparateElaborationSpec extends ChiselFunSpec with Utils {
         inst1.in := 0.U
       }
 
-      val dutDef0_rtl = Source.fromFile(s"$testDir/dutDef0/AddTwoMixedModules.v").getLines.mkString
+      val dutDef0_rtl = Source.fromFile(s"$testDir/dutDef0/AddTwoMixedModules.v").getLines().mkString
       dutDef0_rtl should include("module AddOne(")
       dutDef0_rtl should include("module AddTwoMixedModules(")
-      val dutDef1_rtl = Source.fromFile(s"$testDir/dutDef1/AddTwoMixedModules_1.v").getLines.mkString
+      val dutDef1_rtl = Source.fromFile(s"$testDir/dutDef1/AddTwoMixedModules_1.v").getLines().mkString
       dutDef1_rtl should include("module AddOne_2(")
       dutDef1_rtl should include("module AddTwoMixedModules_1(")
 
@@ -294,7 +294,7 @@ class SeparateElaborationSpec extends ChiselFunSpec with Utils {
         ) ++ importDefinitionAnnos0 ++ importDefinitionAnnos1
       )
 
-      val tb_rtl = Source.fromFile(s"$testDir/Testbench.v").getLines.mkString
+      val tb_rtl = Source.fromFile(s"$testDir/Testbench.v").getLines().mkString
       tb_rtl should include("AddTwoMixedModules inst0 (")
       tb_rtl should include("AddTwoMixedModules_1 inst1 (")
       (tb_rtl should not).include("module AddTwoMixedModules(")
@@ -335,10 +335,10 @@ class SeparateElaborationSpec extends ChiselFunSpec with Utils {
       inst1.in := 0.U
     }
 
-    val dutDef0_rtl = Source.fromFile(s"$testDir/dutDef0/AddTwoMixedModules.v").getLines.mkString
+    val dutDef0_rtl = Source.fromFile(s"$testDir/dutDef0/AddTwoMixedModules.v").getLines().mkString
     dutDef0_rtl should include("module AddOne(")
     dutDef0_rtl should include("module AddTwoMixedModules(")
-    val dutDef1_rtl = Source.fromFile(s"$testDir/dutDef1/AddTwoMixedModules_1.v").getLines.mkString
+    val dutDef1_rtl = Source.fromFile(s"$testDir/dutDef1/AddTwoMixedModules_1.v").getLines().mkString
     dutDef1_rtl should include("module AddOne(")
     dutDef1_rtl should include("module AddTwoMixedModules_1(")
 
@@ -379,7 +379,7 @@ class SeparateElaborationSpec extends ChiselFunSpec with Utils {
         )
       )
 
-      val tb_rtl = Source.fromFile(s"$testDir/Testbench.v").getLines.mkString
+      val tb_rtl = Source.fromFile(s"$testDir/Testbench.v").getLines().mkString
 
       tb_rtl should include("module AddOne_1(")
       tb_rtl should include("AddOne_1 mod (")
@@ -429,12 +429,12 @@ class SeparateElaborationSpec extends ChiselFunSpec with Utils {
       )
     )
 
-    val dutDef0_rtl = Source.fromFile(s"$testDir/dutDef0/AddOneParameterized.v").getLines.mkString
+    val dutDef0_rtl = Source.fromFile(s"$testDir/dutDef0/AddOneParameterized.v").getLines().mkString
     dutDef0_rtl should include("module AddOneParameterized(")
-    val dutDef1_rtl = Source.fromFile(s"$testDir/dutDef1/AddOneParameterized_1.v").getLines.mkString
+    val dutDef1_rtl = Source.fromFile(s"$testDir/dutDef1/AddOneParameterized_1.v").getLines().mkString
     dutDef1_rtl should include("module AddOneParameterized_1(")
 
-    val tb_rtl = Source.fromFile(s"$testDir/Testbench.v").getLines.mkString
+    val tb_rtl = Source.fromFile(s"$testDir/Testbench.v").getLines().mkString
     tb_rtl should include("Inst1_Prefix_AddOnePramaterized_Inst1_Suffix inst0 (")
     tb_rtl should include("Inst2_Prefix_AddOnePrameterized_1_Inst2_Suffix inst1 (")
     (tb_rtl should not).include("module AddOneParameterized(")
@@ -475,9 +475,9 @@ class SeparateElaborationSpec extends ChiselFunSpec with Utils {
       inst1.in := 0.U
     }
 
-    val dutDef0_rtl = Source.fromFile(s"$testDir/dutDef0/AddOneParameterized.v").getLines.mkString
+    val dutDef0_rtl = Source.fromFile(s"$testDir/dutDef0/AddOneParameterized.v").getLines().mkString
     dutDef0_rtl should include("module AddOneParameterized(")
-    val dutDef1_rtl = Source.fromFile(s"$testDir/dutDef1/AddOneParameterized_1.v").getLines.mkString
+    val dutDef1_rtl = Source.fromFile(s"$testDir/dutDef1/AddOneParameterized_1.v").getLines().mkString
     dutDef1_rtl should include("module AddOneParameterized_1(")
 
     val errMsg = intercept[ChiselException] {

--- a/src/test/scala/chiselTests/stage/ChiselMainSpec.scala
+++ b/src/test/scala/chiselTests/stage/ChiselMainSpec.scala
@@ -71,7 +71,7 @@ class ChiselMainSpec extends AnyFeatureSpec with GivenWhenThen with Matchers wit
 
   class TargetDirectoryFixture(dirName: String) {
     val dir = new File(s"test_run_dir/ChiselStageSpec/$dirName")
-    val buildDir = new File(dir + "/build")
+    val buildDir = new File(dir.toString + "/build")
     dir.mkdirs()
   }
 
@@ -112,7 +112,7 @@ class ChiselMainSpec extends AnyFeatureSpec with GivenWhenThen with Matchers wit
       val f = new ChiselMainFixture
       val td = new TargetDirectoryFixture(p.testName)
 
-      p.files.foreach(f => new File(td.buildDir + s"/$f").delete())
+      p.files.foreach(f => new File(td.buildDir.toString + s"/$f").delete())
 
       When(s"""the user tries to compile with '${p.argsString}'""")
       val module: Array[String] =
@@ -155,7 +155,7 @@ class ChiselMainSpec extends AnyFeatureSpec with GivenWhenThen with Matchers wit
 
       p.files.foreach { f =>
         And(s"file '$f' should be emitted in the target directory")
-        val out = new File(td.buildDir + s"/$f")
+        val out = new File(td.buildDir.toString + s"/$f")
         out should (exist)
         p.fileChecks.get(f).map(_(out))
       }

--- a/src/test/scala/chiselTests/stage/phases/EmitterSpec.scala
+++ b/src/test/scala/chiselTests/stage/phases/EmitterSpec.scala
@@ -29,7 +29,7 @@ class EmitterSpec extends AnyFlatSpec with Matchers {
       (new Elaborate).transform(Seq(TargetDirAnnotation(dir.toString), ChiselGeneratorAnnotation(() => new FooModule)))
     val annotationsx = phase.transform(annotations)
 
-    val Seq(fooFile, barFile) = Seq("Foo.fir", "Bar.fir").map(f => new File(dir + "/" + f))
+    val Seq(fooFile, barFile) = Seq("Foo.fir", "Bar.fir").map(f => new File(dir.toString + "/" + f))
 
     info(s"$fooFile does not exist")
     fooFile should not(exist)
@@ -47,7 +47,7 @@ class EmitterSpec extends AnyFlatSpec with Matchers {
     val annotations =
       phase.transform(Seq(TargetDirAnnotation(dir.toString), circuit, ChiselOutputFileAnnotation("Baz")))
 
-    val bazFile = new File(dir + "/Baz.fir")
+    val bazFile = new File(dir.toString + "/Baz.fir")
 
     info(s"$bazFile exists")
     bazFile should (exist)

--- a/src/test/scala/circtTests/stage/CIRCTStageSpec.scala
+++ b/src/test/scala/circtTests/stage/CIRCTStageSpec.scala
@@ -63,7 +63,7 @@ class CIRCTStageSpec extends AnyFunSpec with Matchers {
       outputFile should exist
 
       info(s"file looks like Verilog")
-      Source.fromFile(outputFile).getLines.mkString should include("endmodule")
+      Source.fromFile(outputFile).getLines().mkString should include("endmodule")
 
     }
 


### PR DESCRIPTION
Fixed code generating warnings, targeting most frequently occurring ones.
Explicit typing of methods returning unit
Fixed lines requiring explicit .toString
Fix up of incorrectly implemented check of option in Bi and Mono connect
Fixed method calls requiring parens
Fixed DataMirror imports
