### PR TITLE
Deprecate chisel3.stage.ChiselStage

### DIFF
--- a/docs/src/cookbooks/hierarchy.md
+++ b/docs/src/cookbooks/hierarchy.md
@@ -85,7 +85,7 @@ class AddTwoInstantiate(width: Int) extends Module {
 }
 ```
 ```scala mdoc:verilog
-chisel3.stage.ChiselStage.emitVerilog(new AddTwoInstantiate(16))
+circt.stage.ChiselStage.emitSystemVerilog(new AddTwoInstantiate(16))
 ```
 
 ## How do I access internal fields of an instance?

--- a/src/main/scala/chisel3/stage/ChiselStage.scala
+++ b/src/main/scala/chisel3/stage/ChiselStage.scala
@@ -24,6 +24,7 @@ import chisel3.stage.CircuitSerializationAnnotation.FirrtlFileFormat
 
 import java.io.{PrintWriter, StringWriter}
 
+@deprecated(pleaseSwitchToCIRCT, "Chisel 3.6")
 class ChiselStage extends Stage {
 
   override def prerequisites = Seq.empty
@@ -126,9 +127,11 @@ class ChiselStage extends Stage {
   }
 }
 
+@deprecated(pleaseSwitchToCIRCT, "Chisel 3.6")
 object ChiselMain extends StageMain(new ChiselStage)
 
 /** Helper methods for working with [[ChiselStage]] */
+@deprecated(pleaseSwitchToCIRCT, "Chisel 3.6")
 object ChiselStage {
 
   /** Return a Chisel circuit for a Chisel module

--- a/src/main/scala/chisel3/stage/package.scala
+++ b/src/main/scala/chisel3/stage/package.scala
@@ -12,6 +12,8 @@ import scala.annotation.nowarn
 
 package object stage {
 
+  final val pleaseSwitchToCIRCT = deprecatedMFCMessage + " Please switch to circt.stage.ChiselStage."
+
   @nowarn("cat=deprecation&msg=WarnReflectiveNamingAnnotation")
   implicit object ChiselOptionsView extends OptionsView[ChiselOptions] {
 


### PR DESCRIPTION
Deprecate existing ChiselStage class and object as this will be removed in Chisel 5.  Add a message telling people to switch to the equivalent circt class/object.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>

I'm preparing to remove this on the `chisel5` branch, hence the deprecation. This would be ideal to get this into Chisel 3.6.