### PR TITLE
Deprecate group API

### DIFF
--- a/src/main/scala/chisel3/util/experimental/group.scala
+++ b/src/main/scala/chisel3/util/experimental/group.scala
@@ -28,6 +28,7 @@ import firrtl.transforms.{GroupAnnotation, GroupComponents}
   *       because they are also connected to their module's clock port. This means that if you want
   *       a register to be included in a group, it must be explicitly referred to in the input list.
   */
+@deprecated(deprecatedMFCMessage, "Chisel 3.6")
 object group {
 
   /** Marks a set of components (and their interconnected components) to be included in a new


### PR DESCRIPTION
Deprecated chisel3.util.experimental.group since Chisel 3.6 as this is an API unsupported by the MFC.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>