### PR TITLE
Decouple {circt, chisel3}.stage.ChiselStage

### DIFF
--- a/src/main/scala/circt/stage/Annotations.scala
+++ b/src/main/scala/circt/stage/Annotations.scala
@@ -42,6 +42,9 @@ object CIRCTTarget {
   /** The parent type of all CIRCT targets */
   sealed trait Type
 
+  /** Specification FIRRTL */
+  case object CHIRRTL extends Type
+
   /** The FIRRTL dialect */
   case object FIRRTL extends Type
 
@@ -65,6 +68,7 @@ object CIRCTTargetAnnotation extends HasShellOptions {
     new ShellOption[String](
       longOption = "target",
       toAnnotationSeq = _ match {
+        case "chirrtl"       => Seq(CIRCTTargetAnnotation(CIRCTTarget.CHIRRTL))
         case "firrtl"        => Seq(CIRCTTargetAnnotation(CIRCTTarget.FIRRTL))
         case "hw"            => Seq(CIRCTTargetAnnotation(CIRCTTarget.HW))
         case "verilog"       => Seq(CIRCTTargetAnnotation(CIRCTTarget.Verilog))
@@ -72,7 +76,7 @@ object CIRCTTargetAnnotation extends HasShellOptions {
         case a               => throw new OptionsException(s"Unknown target name '$a'! (Did you misspell it?)")
       },
       helpText = "The CIRCT",
-      helpValueName = Some("{firrtl|rtl|systemverilog}")
+      helpValueName = Some("{chirrtl|firrtl|hw|verilog|systemverilog}")
     )
   )
 

--- a/src/main/scala/circt/stage/CIRCTStage.scala
+++ b/src/main/scala/circt/stage/CIRCTStage.scala
@@ -2,7 +2,12 @@
 
 package circt.stage
 
-import chisel3.stage.ChiselGeneratorAnnotation
+import chisel3.stage.{
+  ChiselGeneratorAnnotation,
+  PrintFullStackTraceAnnotation,
+  ThrowOnFirstErrorAnnotation,
+  WarningsAsErrorsAnnotation
+}
 
 import firrtl.AnnotationSeq
 import firrtl.options.{Dependency, Phase, PhaseManager, Shell, Stage, StageMain}
@@ -13,7 +18,10 @@ trait CLI { this: Shell =>
   Seq(
     CIRCTTargetAnnotation,
     PreserveAggregate,
-    ChiselGeneratorAnnotation
+    ChiselGeneratorAnnotation,
+    PrintFullStackTraceAnnotation,
+    ThrowOnFirstErrorAnnotation,
+    WarningsAsErrorsAnnotation
   ).foreach(_.addOptions(parser))
 }
 

--- a/src/main/scala/circt/stage/phases/CIRCT.scala
+++ b/src/main/scala/circt/stage/phases/CIRCT.scala
@@ -128,6 +128,13 @@ class CIRCT extends Phase {
 
   override def transform(annotations: AnnotationSeq): AnnotationSeq = {
     val circtOptions = view[CIRCTOptions](annotations)
+
+    // Early exit (do not run firtool) if the target is "CHIRRTL", i.e., specification FIRRTL.
+    circtOptions.target match {
+      case Some(CIRCTTarget.CHIRRTL) => return annotations
+      case _                         =>
+    }
+
     val firrtlOptions = view[FirrtlOptions](annotations)
     val stageOptions = view[StageOptions](annotations)
 

--- a/src/test/scala/chiselTests/Printf.scala
+++ b/src/test/scala/chiselTests/Printf.scala
@@ -3,28 +3,27 @@
 package chiselTests
 
 import chisel3._
-import chisel3.testers.BasicTester
 import circt.stage.ChiselStage
 
-class SinglePrintfTester() extends BasicTester {
+class SinglePrintfTester() extends Module {
   val x = 254.U
   printf("x=%x", x)
   stop()
 }
 
-class ASCIIPrintfTester() extends BasicTester {
+class ASCIIPrintfTester() extends Module {
   printf((0x20 to 0x7e).map(_.toChar).mkString.replace("%", "%%"))
   stop()
 }
 
-class MultiPrintfTester() extends BasicTester {
+class MultiPrintfTester() extends Module {
   val x = 254.U
   val y = 255.U
   printf("x=%x y=%x", x, y)
   stop()
 }
 
-class ASCIIPrintableTester extends BasicTester {
+class ASCIIPrintableTester extends Module {
   printf(PString((0x20 to 0x7e).map(_.toChar).mkString("")))
   stop()
 }
@@ -41,43 +40,35 @@ class ScopeTesterModule extends Module {
   val wp = cf"$w"
 }
 
-class PrintablePrintfScopeTester extends BasicTester {
-  ChiselStage.elaborate {
-    new Module {
-      val mod = Module(new ScopeTesterModule)
-      printf(mod.p)
-    }
-  }
-  stop()
-}
-
-class PrintablePrintfWireScopeTester extends BasicTester {
-  ChiselStage.elaborate {
-    new Module {
-      val mod = Module(new ScopeTesterModule)
-      printf(mod.wp)
-    }
-  }
-  stop()
-}
-
 class PrintfSpec extends ChiselFlatSpec {
-  "A printf with a single argument" should "run" in {
-    assertTesterPasses { new SinglePrintfTester }
+  "A printf with a single argument" should "elaborate" in {
+    ChiselStage.elaborate(new SinglePrintfTester)
   }
-  "A printf with multiple arguments" should "run" in {
-    assertTesterPasses { new MultiPrintfTester }
+  "A printf with multiple arguments" should "elaborate" in {
+    ChiselStage.elaborate(new MultiPrintfTester)
   }
-  "A printf with ASCII characters 1-127" should "run" in {
-    assertTesterPasses { new ASCIIPrintfTester }
+  "A printf with ASCII characters 1-127" should "elaborate" in {
+    ChiselStage.elaborate(new ASCIIPrintfTester)
   }
-  "A printf with Printable ASCII characters 1-127" should "run" in {
-    assertTesterPasses { new ASCIIPrintableTester }
+  "A printf with Printable ASCII characters 1-127" should "elaborate" in {
+    ChiselStage.elaborate(new ASCIIPrintableTester)
   }
-  "A printf with Printable" should "respect port scopes" in {
-    assertTesterPasses { new PrintablePrintfScopeTester }
+  "A printf with Printable targeting a format string using a port in another module" should "elaborate" in {
+    ChiselStage.elaborate {
+      new Module {
+        val mod = Module(new ScopeTesterModule)
+        printf(mod.p)
+      }
+    }
   }
-  "A printf with Printable" should "respect wire scopes" in {
-    a[ChiselException] should be thrownBy { assertTesterPasses { new PrintablePrintfWireScopeTester } }
+  "A printf with Printable targeting a format string using a wire inside another module" should "error" in {
+    a[ChiselException] should be thrownBy {
+      circt.stage.ChiselStage.elaborate {
+        new Module {
+          val mod = Module(new ScopeTesterModule)
+          printf(mod.wp)
+        }
+      }
+    }
   }
 }

--- a/src/test/scala/circtTests/stage/ChiselStageSpec.scala
+++ b/src/test/scala/circtTests/stage/ChiselStageSpec.scala
@@ -81,6 +81,27 @@ class ChiselStageSpec extends AnyFunSpec with Matchers {
 
   describe("ChiselStage") {
 
+    it("should elaborate a Chisel module and emit specification FIRRTL (CHIRRTL)") {
+
+      val targetDir = new File("test_run_dir/ChiselStageSpec")
+
+      val args: Array[String] = Array(
+        "--target",
+        "chirrtl",
+        "--target-dir",
+        targetDir.toString
+      )
+
+      val expectedOutput = new File(targetDir, "Foo.fir")
+      expectedOutput.delete()
+
+      (new ChiselStage).execute(args, Seq(ChiselGeneratorAnnotation(() => new ChiselStageSpec.Foo)))
+
+      info(s"'$expectedOutput' exists")
+      expectedOutput should (exist)
+
+    }
+
     it("should compile a Chisel module to FIRRTL dialect") {
 
       val targetDir = new File("test_run_dir/ChiselStageSpec")
@@ -559,6 +580,18 @@ class ChiselStageSpec extends AnyFunSpec with Matchers {
   }
 
   describe("ChiselStage$") {
+
+    it("should convert a module to FIRRTL IR") {
+
+      ChiselStage.convert(new ChiselStageSpec.Foo).main should be("Foo")
+
+    }
+
+    it("should emit specification FIRRTL (CHIRRTL)") {
+
+      ChiselStage.emitCHIRRTL(new ChiselStageSpec.Foo) should include("circuit Foo")
+
+    }
 
     it("should emit FIRRTL dialect") {
 


### PR DESCRIPTION
Remove the dependency of circt.stage.ChiselStage on chisel3.stage.ChiselStage.  Remove the internal call to ChiselStage and instead directly construct a PhaseManager that uses the target phases of ChiselStage directly.

Add a new argument type to the existing "--target" option of circt.stage.ChiselStage, "chirrtl", to indicate that specification FIRRTL (in the specification textual format and not MLIR) should be produced.

Use this new option to migrate two methods of ChiselStage$, emitCHIRRTL and convert, away from using a call to chisel3.stage.ChiselStage.

Add tests of the new option, emitCHIRRTL, and convert.