### PR TITLE
Cleanup warnings final

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ lazy val commonSettings = Seq(
   // Macros paradise is integrated into 2.13 but requires a scalacOption
   scalacOptions ++= {
     CrossVersion.partialVersion(scalaVersion.value) match {
-      case Some((2, n)) if n >= 13 => "-Ymacro-annotations" :: "-Werror" :: Nil
+      case Some((2, n)) if n >= 13 => "-Ymacro-annotations" :: Nil
       case _                       => Nil
     }
   },
@@ -31,6 +31,15 @@ lazy val commonSettings = Seq(
     CrossVersion.partialVersion(scalaVersion.value) match {
       case Some((2, n)) if n >= 13 => Nil
       case _                       => compilerPlugin(("org.scalamacros" % "paradise" % "2.1.1").cross(CrossVersion.full)) :: Nil
+    }
+  }
+)
+
+lazy val fatalWarningsSettings = Seq(
+  scalacOptions ++= {
+    CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((2, n)) if n >= 13 => "-Werror" :: Nil
+      case _                       => Nil
     }
   }
 )
@@ -181,6 +190,7 @@ lazy val core = (project in file("core"))
   .settings(publishSettings: _*)
   .settings(mimaPreviousArtifacts := Set())
   .settings(warningSuppression: _*)
+  .settings(fatalWarningsSettings: _*)
   .settings(
     name := "chisel3-core",
     libraryDependencies ++= Seq(
@@ -212,6 +222,7 @@ lazy val chisel = (project in file("."))
   .dependsOn(core)
   .aggregate(macros, core, plugin)
   .settings(warningSuppression: _*)
+  .settings(fatalWarningsSettings: _*)
   .settings(
     mimaPreviousArtifacts := Set(),
     Test / scalacOptions ++= Seq("-language:reflectiveCalls"),
@@ -263,6 +274,8 @@ lazy val integrationTests = (project in file("integration-tests"))
   .dependsOn(chisel)
   .dependsOn(standardLibrary)
   .settings(commonSettings: _*)
+  .settings(warningSuppression: _*)
+  .settings(fatalWarningsSettings: _*)
   .settings(chiselSettings: _*)
   .settings(usePluginSettings: _*)
   .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ lazy val commonSettings = Seq(
   // Macros paradise is integrated into 2.13 but requires a scalacOption
   scalacOptions ++= {
     CrossVersion.partialVersion(scalaVersion.value) match {
-      case Some((2, n)) if n >= 13 => "-Ymacro-annotations" :: Nil
+      case Some((2, n)) if n >= 13 => "-Ymacro-annotations" :: "-Werror" :: Nil
       case _                       => Nil
     }
   },

--- a/src/main/scala/chisel3/util/experimental/BoringUtils.scala
+++ b/src/main/scala/chisel3/util/experimental/BoringUtils.scala
@@ -99,7 +99,7 @@ class BoringUtilsException(message: String) extends Exception(message)
 object BoringUtils {
   /* A global namespace for boring ids */
   private[chisel3] case object CacheKey extends BuilderContextCache.Key[Namespace]
-  private val boringNamespace = Builder.contextCache.getOrElseUpdate(CacheKey, Namespace.empty)
+  private def boringNamespace = Builder.contextCache.getOrElseUpdate(CacheKey, Namespace.empty)
 
   /* Get a new name (value) from the namespace */
   private def newName(value: String): String = {

--- a/src/main/scala/chisel3/util/experimental/BoringUtils.scala
+++ b/src/main/scala/chisel3/util/experimental/BoringUtils.scala
@@ -4,7 +4,7 @@ package chisel3.util.experimental
 
 import chisel3._
 import chisel3.experimental.{annotate, ChiselAnnotation, RunFirrtlTransform}
-import chisel3.internal.{NamedComponent, Namespace}
+import chisel3.internal.{Builder, BuilderContextCache, NamedComponent, Namespace}
 import firrtl.transforms.{DontTouchAnnotation, NoDedupAnnotation}
 import firrtl.passes.wiring.{SinkAnnotation, SourceAnnotation, WiringTransform}
 import firrtl.annotations.{ComponentName, ModuleName}
@@ -98,19 +98,18 @@ class BoringUtilsException(message: String) extends Exception(message)
   */
 object BoringUtils {
   /* A global namespace for boring ids */
-  private val namespace: SyncVar[Namespace] = new SyncVar
-  namespace.put(Namespace.empty)
+  private[chisel3] case object CacheKey extends BuilderContextCache.Key[Namespace]
+  private val boringNamespace = Builder.contextCache.getOrElseUpdate(CacheKey, Namespace.empty)
 
   /* Get a new name (value) from the namespace */
   private def newName(value: String): String = {
-    val ns = namespace.take()
-    val valuex = ns.name(value)
-    namespace.put(ns)
-    valuex
+    boringNamespace.name(value)
   }
+  /* True if the requested name (value) exists in the namespace */
+  private def checkName(value: String): Boolean = boringNamespace.contains(value)
 
   /* True if the requested name (value) exists in the namespace */
-  private def checkName(value: String): Boolean = namespace.get.contains(value)
+  //  private def checkName(value: String): Boolean = namespace.get.contains(value)
 
   /** Add a named source cross module reference
     * @param component source circuit component
@@ -199,5 +198,4 @@ object BoringUtils {
     sinks.foreach(addSink(_, genName, true, true))
     genName
   }
-
 }

--- a/src/main/scala/chisel3/util/experimental/BoringUtils.scala
+++ b/src/main/scala/chisel3/util/experimental/BoringUtils.scala
@@ -108,9 +108,6 @@ object BoringUtils {
   /* True if the requested name (value) exists in the namespace */
   private def checkName(value: String): Boolean = boringNamespace.contains(value)
 
-  /* True if the requested name (value) exists in the namespace */
-  //  private def checkName(value: String): Boolean = namespace.get.contains(value)
-
   /** Add a named source cross module reference
     * @param component source circuit component
     * @param name unique identifier for this source

--- a/src/main/scala/circt/stage/phases/CIRCT.scala
+++ b/src/main/scala/circt/stage/phases/CIRCT.scala
@@ -24,6 +24,7 @@ import firrtl.options.phases.WriteOutputAnnotations
 import firrtl.options.Viewer.view
 import firrtl.stage.{FirrtlOptions, RunFirrtlTransformAnnotation}
 import _root_.logger.LogLevel
+import chisel3.InternalErrorException
 
 import java.io.File
 
@@ -282,6 +283,8 @@ class CIRCT extends Phase {
           throw new Exception(
             "No 'circtOptions.target' specified. This should be impossible if dependencies are satisfied!"
           )
+        case unknown =>
+          throw new InternalErrorException(s"Match Error: Unknon CIRCTTarget: $unknown")
       })
     }
 

--- a/src/main/scala/circt/stage/phases/CIRCT.scala
+++ b/src/main/scala/circt/stage/phases/CIRCT.scala
@@ -46,7 +46,7 @@ private object Helpers {
     */
   def extractAnnotationFile(string: String, filename: String): AnnotationSeq = {
     var inAnno = false
-    val filtered: String = string.lines.filter {
+    val filtered: String = string.linesIterator.filter {
       case line if line.startsWith("// ----- 8< ----- FILE") && line.contains(filename) =>
         inAnno = true
         false


### PR DESCRIPTION
Fixed up two final warnings.
In BoringUtils replace deprecated SyncVar with BuilderContextCache
In stage.phases.CIRCT fixed possible not exhaustive match
Number of warnings in 2.13 == 0