### PR TITLE
[circt] Remove CIRCTStage optional prereq on SFC

### DIFF
--- a/src/main/scala/circt/stage/CIRCTStage.scala
+++ b/src/main/scala/circt/stage/CIRCTStage.scala
@@ -33,7 +33,7 @@ trait CLI { this: Shell =>
 class CIRCTStage extends Stage {
 
   override def prerequisites = Seq.empty
-  override def optionalPrerequisites = Seq(Dependency[firrtl.stage.phases.Compiler])
+  override def optionalPrerequisites = Seq.empty
   override def optionalPrerequisiteOf = Seq.empty
   override def invalidates(a: Phase) = false
 


### PR DESCRIPTION
Remove an unnecessary optionalPrerequisite of CIRCTStage on the SFC Compiler phase.  This is entirely unnecessary given that there is no longer an SFC -> MFC handoff path within CIRCT-based Chisel compilation flows.