### PR TITLE
Remove a FIRRTL phase CIRCTStage "currentState"

### DIFF
--- a/src/main/scala/circt/stage/CIRCTStage.scala
+++ b/src/main/scala/circt/stage/CIRCTStage.scala
@@ -42,9 +42,6 @@ class CIRCTStage extends Stage {
   final val phaseManager = new PhaseManager(
     targets = Seq(
       Dependency[circt.stage.phases.CIRCT]
-    ),
-    currentState = Seq(
-      Dependency[firrtl.stage.phases.AddImplicitEmitter]
     )
   )
 


### PR DESCRIPTION
Remove an unnecessary "currentState" argument when constructing the internal PhaseManager of CIRCTStage.  This is no longer necessary given that CIRCTState doesn't have to interoperate with SFC in any way.

This enables removal of this phase on the chisel5 branch.