### PR TITLE
Deprecate CIRCTStage (firtool wrapper)

### DIFF
--- a/src/main/scala/circt/stage/CIRCTStage.scala
+++ b/src/main/scala/circt/stage/CIRCTStage.scala
@@ -2,6 +2,7 @@
 
 package circt.stage
 
+import chisel3.deprecatedMFCMessage
 import chisel3.stage.{
   ChiselGeneratorAnnotation,
   PrintFullStackTraceAnnotation,
@@ -30,6 +31,7 @@ trait CLI { this: Shell =>
   *
   * @see [[https://github.com/llvm/circt llvm/circt]]
   */
+@deprecated(deprecatedMFCMessage + " Please use circt.stage.Chiselstage.", "Chisel 3.6")
 class CIRCTStage extends Stage {
 
   override def prerequisites = Seq.empty
@@ -53,4 +55,5 @@ class CIRCTStage extends Stage {
 }
 
 /** Command line utility for [[CIRCTStage]]. */
+@deprecated(deprecatedMFCMessage + " Please use circt.stage.Chiselstage.", "Chisel 3.6")
 object CIRCTMain extends StageMain(new CIRCTStage)


### PR DESCRIPTION
Deprecate CIRCTStage and CIRCTMain.  These are stage-based wrappers around just running firtool that are roughly equivalent to FirrtlStage and FirrtlMain that did this for the SFC.  These do not have users and it is unclear why these should persist given that
circt.stage.ChiselStage subsumes almost all use cases (going Chisel to Verilog or Chisel to CHIRRTL and then using the build system to go from CHIRRTL to Verilog).