### PR TITLE
Add "--split-verilog" circt.*.ChiselStage option

### DIFF
--- a/src/main/scala/circt/stage/Annotations.scala
+++ b/src/main/scala/circt/stage/Annotations.scala
@@ -102,3 +102,24 @@ case class EmittedMLIR(
 }
 
 case class FirtoolOption(option: String) extends NoTargetAnnotation with CIRCTOption
+
+/** Annotation that indicates that firtool should run using the
+  * `--split-verilog` option.  This has two effects: (1) Verilog will be emitted
+  * as one-file-per-module and (2) any other output file attributes created
+  * along the way will have their operations written to other files.  Without
+  * this option, output file attributes will have their operations emitted
+  * inline in the single-file Verilog produced.
+  */
+private[circt] case object SplitVerilog extends NoTargetAnnotation with CIRCTOption with HasShellOptions {
+
+  override def options = Seq(
+    new ShellOption[Unit](
+      longOption = "split-verilog",
+      toAnnotationSeq = _ => Seq(this),
+      helpText =
+        """Indicates that "firtool" should emit one-file-per-module and write separate outputs to separate files""",
+      helpValueName = None
+    )
+  )
+
+}

--- a/src/main/scala/circt/stage/CIRCTOptions.scala
+++ b/src/main/scala/circt/stage/CIRCTOptions.scala
@@ -16,14 +16,16 @@ class CIRCTOptions private[stage] (
   val outputFile:        Option[File] = None,
   val preserveAggregate: Option[PreserveAggregate.Type] = None,
   val target:            Option[CIRCTTarget.Type] = None,
-  val firtoolOptions:    Seq[String] = Seq.empty) {
+  val firtoolOptions:    Seq[String] = Seq.empty,
+  val splitVerilog:      Boolean = false) {
 
   private[stage] def copy(
     inputFile:         Option[File] = inputFile,
     outputFile:        Option[File] = outputFile,
     preserveAggregate: Option[PreserveAggregate.Type] = preserveAggregate,
     target:            Option[CIRCTTarget.Type] = target,
-    firtoolOptions:    Seq[String] = firtoolOptions
-  ): CIRCTOptions = new CIRCTOptions(inputFile, outputFile, preserveAggregate, target, firtoolOptions)
+    firtoolOptions:    Seq[String] = firtoolOptions,
+    splitVerilog:      Boolean = splitVerilog
+  ): CIRCTOptions = new CIRCTOptions(inputFile, outputFile, preserveAggregate, target, firtoolOptions, splitVerilog)
 
 }

--- a/src/main/scala/circt/stage/CIRCTStage.scala
+++ b/src/main/scala/circt/stage/CIRCTStage.scala
@@ -22,7 +22,8 @@ trait CLI { this: Shell =>
     ChiselGeneratorAnnotation,
     PrintFullStackTraceAnnotation,
     ThrowOnFirstErrorAnnotation,
-    WarningsAsErrorsAnnotation
+    WarningsAsErrorsAnnotation,
+    SplitVerilog
   ).foreach(_.addOptions(parser))
 }
 

--- a/src/main/scala/circt/stage/phases/CIRCT.scala
+++ b/src/main/scala/circt/stage/phases/CIRCT.scala
@@ -144,7 +144,7 @@ class CIRCT extends Phase {
     var inferReadWrite = false
     var imcp = true
     var logLevel = _root_.logger.LogLevel.None
-    var split = false
+    var split = circtOptions.splitVerilog
 
     // Partition the annotations into those that will be passed to CIRCT and
     // those that are not.  The annotations that are in the passhtrough set will
@@ -162,6 +162,9 @@ class CIRCT extends Phase {
       }
       case _: firrtl.EmitCircuitAnnotation | _: ImportDefinitionAnnotation[_] => Nil
       case _: firrtl.EmitAllModulesAnnotation => {
+        logger.warn(
+          """[warn] Please switch from "firrtl.EmitAllModulesAnnotation" to "--split-verilog" when using "ChiselStage"."""
+        )
         split = true
         Nil
       }

--- a/src/test/scala/circtTests/stage/ChiselStageSpec.scala
+++ b/src/test/scala/circtTests/stage/ChiselStageSpec.scala
@@ -477,14 +477,14 @@ class ChiselStageSpec extends AnyFunSpec with Matchers with chiselTests.Utils {
         "--target",
         "systemverilog",
         "--target-dir",
-        targetDir.toString
+        targetDir.toString,
+        "--split-verilog"
       )
 
       val annos = (new ChiselStage).execute(
         args,
         Seq(
-          ChiselGeneratorAnnotation(() => new fixture.Foo),
-          firrtl.EmitAllModulesAnnotation(classOf[firrtl.SystemVerilogEmitter])
+          ChiselGeneratorAnnotation(() => new fixture.Foo)
         )
       )
 


### PR DESCRIPTION
Add an option to "circt.stage.ChiselStage", "--split-verilog", which replaces the janky "firrt.EmitAllModulesAnnotation" method of generating one-file-per-module output and output file splitting in "firtool". Leave in the old behavior as a run-time warning until this gets removed sometime after the Chisel 5 release.