### PR TITLE
Deprecate Protobuf Emission

### DIFF
--- a/src/main/scala/chisel3/stage/ChiselAnnotations.scala
+++ b/src/main/scala/chisel3/stage/ChiselAnnotations.scala
@@ -190,6 +190,10 @@ object CircuitSerializationAnnotation {
   case object FirrtlFileFormat extends Format {
     def extension = ".fir"
   }
+  @deprecated(
+    deprecatedMFCMessage + " Protobuf emission is deprecated and the MFC does not support reading Protobuf. Please switch to FIRRTL text emission.",
+    "Chisel 3.6"
+  )
   case object ProtoBufFileFormat extends Format {
     def extension = ".pb"
   }

--- a/src/main/scala/chisel3/stage/phases/AddSerializationAnnotations.scala
+++ b/src/main/scala/chisel3/stage/phases/AddSerializationAnnotations.scala
@@ -28,9 +28,15 @@ class AddSerializationAnnotations extends Phase {
     }
     val baseFilename = chiselOptions.outputFile.getOrElse(circuit.name)
 
-    val (filename, format) =
-      if (baseFilename.endsWith(".pb")) (baseFilename.stripSuffix(".pb"), ProtoBufFileFormat)
-      else (baseFilename.stripSuffix(".fir"), FirrtlFileFormat)
+    val (filename, format) = baseFilename match {
+      case _ if baseFilename.endsWith(".pb") =>
+        logger.warn(
+          """[warn] Protobuf emission is deprecated in Chisel 3.6 and unsupported by the MFC. Change to an output file which does not include a ".pb" suffix. This behavior will change in Chisel 5 to emit FIRRTL text even if you provide a ".pb" suffix."""
+        )
+        (baseFilename.stripSuffix(".pb"), ProtoBufFileFormat)
+      case _ => (baseFilename.stripSuffix(".fir"), FirrtlFileFormat)
+    }
+
     CircuitSerializationAnnotation(circuit, filename, format) +: annotations
   }
 }


### PR DESCRIPTION
Deprecate ProtoBufFileFormat and warn if a user is doing Protobuf emission.  This will be ripped out in Chisel 5.