### PR TITLE
Fix bug in "--split-verilog" output

### DIFF
--- a/src/main/scala/circt/stage/package.scala
+++ b/src/main/scala/circt/stage/package.scala
@@ -27,6 +27,7 @@ package object stage {
             case CIRCTTargetAnnotation(a) => acc.copy(target = Some(a))
             case PreserveAggregate(a)     => acc.copy(preserveAggregate = Some(a))
             case FirtoolOption(a)         => acc.copy(firtoolOptions = acc.firtoolOptions :+ a)
+            case SplitVerilog             => acc.copy(splitVerilog = true)
             case _                        => acc
           }
         }

--- a/src/test/scala/chiselTests/BlackBoxImpl.scala
+++ b/src/test/scala/chiselTests/BlackBoxImpl.scala
@@ -107,10 +107,9 @@ class BlackBoxImplSpec extends AnyFreeSpec with Matchers {
       val annotations = Seq(
         TargetDirAnnotation(targetDir),
         ChiselGeneratorAnnotation(() => new UsesBlackBoxAddViaInline),
-        firrtl.EmitAllModulesAnnotation(classOf[firrtl.Emitter]),
         BlackBoxTargetDirAnno(".")
       )
-      (new ChiselStage).execute(Array("--target", "systemverilog"), annotations)
+      (new ChiselStage).execute(Array("--target", "systemverilog", "--split-verilog"), annotations)
 
       val verilogOutput = new File(targetDir, "BlackBoxAdd.v")
       verilogOutput.exists() should be(true)
@@ -120,10 +119,9 @@ class BlackBoxImplSpec extends AnyFreeSpec with Matchers {
       val annotations = Seq(
         TargetDirAnnotation(targetDir),
         ChiselGeneratorAnnotation(() => new UsesBlackBoxMinusViaResource),
-        firrtl.EmitAllModulesAnnotation(classOf[firrtl.Emitter]),
         BlackBoxTargetDirAnno(".")
       )
-      (new ChiselStage).execute(Array("--target", "systemverilog"), annotations)
+      (new ChiselStage).execute(Array("--target", "systemverilog", "--split-verilog"), annotations)
 
       val verilogOutput = new File(targetDir, "BlackBoxTest.v")
       verilogOutput.exists() should be(true)
@@ -136,10 +134,9 @@ class BlackBoxImplSpec extends AnyFreeSpec with Matchers {
       val annotations = Seq(
         TargetDirAnnotation(targetDir),
         ChiselGeneratorAnnotation(() => new UsesBlackBoxMinusViaPath),
-        firrtl.EmitAllModulesAnnotation(classOf[firrtl.Emitter]),
         BlackBoxTargetDirAnno(".")
       )
-      (new ChiselStage).execute(Array("--target", "systemverilog"), annotations)
+      (new ChiselStage).execute(Array("--target", "systemverilog", "--split-verilog"), annotations)
 
       val verilogOutput = new File(targetDir, "BlackBoxTest.v")
       verilogOutput.exists() should be(true)

--- a/src/test/scala/chiselTests/ExtModuleImpl.scala
+++ b/src/test/scala/chiselTests/ExtModuleImpl.scala
@@ -114,10 +114,9 @@ class ExtModuleImplSpec extends AnyFreeSpec with Matchers {
       val annotations = Seq(
         TargetDirAnnotation(targetDir),
         ChiselGeneratorAnnotation(() => new UsesExtModuleAddViaInline),
-        firrtl.EmitAllModulesAnnotation(classOf[firrtl.Emitter]),
         BlackBoxTargetDirAnno(".")
       )
-      (new ChiselStage).execute(Array("--target", "systemverilog"), annotations)
+      (new ChiselStage).execute(Array("--target", "systemverilog", "--split-verilog"), annotations)
 
       val verilogOutput = new File(targetDir, "ExtModuleAdd.v")
       verilogOutput should exist
@@ -129,10 +128,9 @@ class ExtModuleImplSpec extends AnyFreeSpec with Matchers {
       val annotations = Seq(
         TargetDirAnnotation(targetDir),
         ChiselGeneratorAnnotation(() => new UsesExtModuleMinusViaResource),
-        firrtl.EmitAllModulesAnnotation(classOf[firrtl.Emitter]),
         BlackBoxTargetDirAnno(".")
       )
-      (new ChiselStage).execute(Array("--target", "systemverilog"), annotations)
+      (new ChiselStage).execute(Array("--target", "systemverilog", "--split-verilog"), annotations)
 
       val verilogOutput = new File(targetDir, "BlackBoxTest.v")
       verilogOutput should exist
@@ -146,10 +144,9 @@ class ExtModuleImplSpec extends AnyFreeSpec with Matchers {
       val annotations = Seq(
         TargetDirAnnotation(targetDir),
         ChiselGeneratorAnnotation(() => new UsesExtModuleMinusViaPath),
-        firrtl.EmitAllModulesAnnotation(classOf[firrtl.Emitter]),
         BlackBoxTargetDirAnno(".")
       )
-      (new ChiselStage).execute(Array("--target", "systemverilog"), annotations)
+      (new ChiselStage).execute(Array("--target", "systemverilog", "--split-verilog"), annotations)
 
       val verilogOutput = new File(targetDir, "BlackBoxTest.v")
       verilogOutput should exist

--- a/src/test/scala/chiselTests/LoadMemoryFromFileSpec.scala
+++ b/src/test/scala/chiselTests/LoadMemoryFromFileSpec.scala
@@ -150,17 +150,18 @@ class LoadMemoryFromFileSpec extends AnyFreeSpec with Matchers {
   def compile(gen: => RawModule, targetDirName: File, splitVerilog: Boolean = true): Unit = {
     deleteRecursively(targetDirName)
     (new ChiselStage).execute(
-      args = Array("--target-dir", targetDirName.getPath(), "--target", "systemverilog"),
-      annotations = {
-        val annos = scala.collection.mutable.ArrayBuffer[firrtl.annotations.Annotation](
-          ChiselGeneratorAnnotation(() => gen),
-          FirtoolOption("-disable-all-randomization"),
-          FirtoolOption("-strip-debug-info")
-        )
+      args = {
+        val args = scala.collection.mutable
+          .ArrayBuffer[String]("--target-dir", targetDirName.getPath(), "--target", "systemverilog")
         if (splitVerilog)
-          annos.append(firrtl.EmitAllModulesAnnotation(classOf[firrtl.Emitter]))
-        annos.toSeq
-      }
+          args.append("--split-verilog")
+        args.toArray
+      },
+      annotations = Seq(
+        ChiselGeneratorAnnotation(() => gen),
+        FirtoolOption("-disable-all-randomization"),
+        FirtoolOption("-strip-debug-info")
+      )
     )
   }
 

--- a/src/test/scala/chiselTests/experimental/TraceSpec.scala
+++ b/src/test/scala/chiselTests/experimental/TraceSpec.scala
@@ -25,10 +25,9 @@ class TraceSpec extends ChiselFlatSpec with Matchers {
   def compile(testName: String, gen: () => Module): (os.Path, AnnotationSeq) = {
     val testDir = os.Path(createTestDirectory(testName).getAbsolutePath)
     val annos = (new ChiselStage).execute(
-      Array("--target-dir", s"$testDir", "--target", "systemverilog"),
+      Array("--target-dir", s"$testDir", "--target", "systemverilog", "--split-verilog"),
       Seq(
-        ChiselGeneratorAnnotation(gen),
-        firrtl.EmitAllModulesAnnotation(classOf[firrtl.Emitter])
+        ChiselGeneratorAnnotation(gen)
       )
     )
     (testDir, annos)

--- a/src/test/scala/chiselTests/experimental/hierarchy/SeparateElaborationSpec.scala
+++ b/src/test/scala/chiselTests/experimental/hierarchy/SeparateElaborationSpec.scala
@@ -176,12 +176,11 @@ class SeparateElaborationSpec extends ChiselFunSpec with Utils {
       }
 
       (new ChiselStage).execute(
-        Array("--target-dir", testDir, "--target", "systemverilog"),
+        Array("--target-dir", testDir, "--target", "systemverilog", "--split-verilog"),
         Seq(
           ChiselGeneratorAnnotation(() => new Testbench(dutDef0, dutDef1)),
           ImportDefinitionAnnotation(dutDef0),
-          ImportDefinitionAnnotation(dutDef1),
-          firrtl.EmitAllModulesAnnotation(classOf[firrtl.Emitter])
+          ImportDefinitionAnnotation(dutDef1)
         )
       )
 


### PR DESCRIPTION
Fix a bug where "--split-verilog" was not properly passed into the CIRCTOptions struct.  Add a test to lock in the correct behavior.

Also, move _all_ tests over to use "--split-verilog".