### PR TITLE
Catch private default constructors for Bundles and Records

### DIFF
--- a/plugin/src/main/scala/chisel3/internal/plugin/BundleComponent.scala
+++ b/plugin/src/main/scala/chisel3/internal/plugin/BundleComponent.scala
@@ -96,7 +96,12 @@ private[plugin] class BundleComponent(val global: Global, arguments: ChiselPlugi
         case acc: ValDef if acc.symbol.isParamAccessor =>
           paramAccessors += acc.symbol
         case con: DefDef if con.symbol.isPrimaryConstructor =>
+          if (con.symbol.isPrivate) { // distinguish between package private and private
+            val msg = "Private bundle constructors cannot automatically be cloned"
+            global.reporter.error(con.pos, msg)
+          }
           primaryConstructor = Some(con)
+
         case d: DefDef if isNullaryMethodNamed("_cloneTypeImpl", d) =>
           val msg = "Users cannot override _cloneTypeImpl. Let the compiler plugin generate it."
           global.reporter.error(d.pos, msg)
@@ -144,6 +149,10 @@ private[plugin] class BundleComponent(val global: Global, arguments: ChiselPlugi
       val ttpe =
         if (tparamList.nonEmpty) AppliedTypeTree(Ident(record.symbol), tparamList) else Ident(record.symbol)
       val newUntyped = New(ttpe, conArgs)
+
+      // TODO For private default constructors this crashes with a
+      // TypeError. Figure out how to make this local to the object so
+      // that private default constructors work.
       val neww = localTyper.typed(newUntyped)
 
       // Create the symbol for the method and have it be associated with the Record class

--- a/plugin/src/main/scala/chisel3/internal/plugin/BundleComponent.scala
+++ b/plugin/src/main/scala/chisel3/internal/plugin/BundleComponent.scala
@@ -96,11 +96,12 @@ private[plugin] class BundleComponent(val global: Global, arguments: ChiselPlugi
         case acc: ValDef if acc.symbol.isParamAccessor =>
           paramAccessors += acc.symbol
         case con: DefDef if con.symbol.isPrimaryConstructor =>
-          if (con.symbol.isPrivate) { // distinguish between package private and private
-            val msg = "Private bundle constructors cannot automatically be cloned"
+          if (con.symbol.isPrivate) {
+            val msg = "Private bundle constructors cannot automatically be cloned, try making it package private"
             global.reporter.error(con.pos, msg)
+          } else {
+            primaryConstructor = Some(con)
           }
-          primaryConstructor = Some(con)
 
         case d: DefDef if isNullaryMethodNamed("_cloneTypeImpl", d) =>
           val msg = "Users cannot override _cloneTypeImpl. Let the compiler plugin generate it."

--- a/src/test/scala/chiselTests/AutoClonetypeSpec.scala
+++ b/src/test/scala/chiselTests/AutoClonetypeSpec.scala
@@ -441,4 +441,19 @@ class AutoClonetypeSpec extends ChiselFlatSpec with Utils {
     }
     elaborate(new MyModule)
   }
+
+  it should "compile with package private default bundle constructors" in {
+    class PrivateDefaultConsBundle private[chiselTests] (w: Int) extends Bundle {
+      val x = UInt(w.W)
+    }
+    object PrivateDefaultConsBundle {
+      def apply(w: Int): PrivateDefaultConsBundle = new PrivateDefaultConsBundle(w)
+    }
+    class MyModule extends Module {
+      val in = IO(Input(PrivateDefaultConsBundle(8)))
+      val out = IO(Output(PrivateDefaultConsBundle(8)))
+      out := in
+    }
+    elaborate(new MyModule)
+  }
 }


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [ ] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
   - code refactoring                  
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->
Using private default constructors for bundles will issue an error

#### Backend Code Generation Impact
N/A
<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
- Squash: The PR will be squashed and merged (choose this if you have no preference.
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
Private default bundle constructors now error during evaluation

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
