### PR TITLE
Convert Scaladoc comment to normal comment, NFC

### DIFF
--- a/src/main/scala/chisel3/util/experimental/decode/QMCMinimizer.scala
+++ b/src/main/scala/chisel3/util/experimental/decode/QMCMinimizer.scala
@@ -170,33 +170,18 @@ object QMCMinimizer extends Minimizer {
     */
   private def getCover(implicants: Seq[Implicant], minterms: Seq[Implicant]): Seq[Implicant] = {
 
-    /** Calculate the implementation cost (using comparators) of a list of implicants, more don't cares is cheaper
-      *
-      * @param cover Implicant list
-      * @return How many comparators need to implement this list of implicants
-      */
+    // Calculate the implementation cost (using comparators) of a list of implicants, more don't cares is cheaper
     def getCost(cover: Seq[Implicant]): Int = cover.map(_.bp.mask.bitCount).sum
 
-    /** Determine if one combination of prime implicants is cheaper when implementing as comparators.
-      * Shorter term list is cheaper, term list with more don't cares is cheaper (less comparators)
-      *
-      * @param a    Operand a
-      * @param b    Operand b
-      * @return `a` < `b`
-      */
+    // Determine if one combination of prime implicants is cheaper when implementing as comparators.
     def cheaper(a: Seq[Implicant], b: Seq[Implicant]): Boolean = {
       val ca = getCost(a)
       val cb = getCost(b)
 
-      /** If `a` < `b`
-        *
-        * Like comparing the dictionary order of two strings.
-        * Define `a` < `b` if both `a` and `b` are empty.
-        *
-        * @param a Operand a
-        * @param b Operand b
-        * @return `a` < `b`
-        */
+      // If `a` < `b`
+      //
+      // Like comparing the dictionary order of two strings.
+      // Define `a` < `b` if both `a` and `b` are empty.
       @tailrec
       def listLess(a: Seq[Implicant], b: Seq[Implicant]): Boolean =
         b.nonEmpty && (a.isEmpty || a.head < b.head || a.head == b.head && listLess(a.tail, b.tail))


### PR DESCRIPTION
Change a comment to workaround an unmoored Scaladoc comment error.

This is done to workaround an error I started seeing here: https://github.com/chipsalliance/chisel3/actions/runs/4256264963/jobs/7404920411#step:8:1225