### PR TITLE
Give a source line and caret for errors when possible

### DIFF
--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/Definition.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/Definition.scala
@@ -103,7 +103,7 @@ object Definition extends SourceInfoDoc {
   ): Definition[T] = {
     val dynamicContext = {
       val context = Builder.captureContext()
-      new DynamicContext(Nil, context.throwOnFirstError, context.warningsAsErrors)
+      new DynamicContext(Nil, context.throwOnFirstError, context.warningsAsErrors, context.sourceRoots)
     }
     Builder.globalNamespace.copyTo(dynamicContext.globalNamespace)
     dynamicContext.inDefinition = true

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -20,6 +20,7 @@ import logger.LazyLogging
 
 import scala.collection.mutable
 import scala.annotation.tailrec
+import java.io.File
 
 private[chisel3] class Namespace(keywords: Set[String]) {
   // This HashMap is compressed, not every name in the namespace is present here.
@@ -425,7 +426,8 @@ private[chisel3] class ChiselContext() {
 private[chisel3] class DynamicContext(
   val annotationSeq:     AnnotationSeq,
   val throwOnFirstError: Boolean,
-  val warningsAsErrors:  Boolean) {
+  val warningsAsErrors:  Boolean,
+  val sourceRoots:       Seq[File]) {
   val importDefinitionAnnos = annotationSeq.collect { case a: ImportDefinitionAnnotation[_] => a }
 
   // Map holding the actual names of extModules
@@ -484,7 +486,7 @@ private[chisel3] class DynamicContext(
   var whenStack:            List[WhenContext] = Nil
   var currentClock:         Option[Clock] = None
   var currentReset:         Option[Reset] = None
-  val errors = new ErrorLog(warningsAsErrors)
+  val errors = new ErrorLog(warningsAsErrors, sourceRoots)
   val namingStack = new NamingStack
 
   // Used to indicate if this is the top-level module of full elaboration, or from a Definition

--- a/src/main/scala/chisel3/aop/injecting/InjectingAspect.scala
+++ b/src/main/scala/chisel3/aop/injecting/InjectingAspect.scala
@@ -62,7 +62,8 @@ abstract class InjectorAspect[T <: RawModule, M <: RawModule](
         new DynamicContext(
           annotationsInAspect,
           chiselOptions.throwOnFirstError,
-          chiselOptions.warningsAsErrors
+          chiselOptions.warningsAsErrors,
+          chiselOptions.sourceRoots
         )
       // Add existing module names into the namespace. If injection logic instantiates new modules
       //  which would share the same name, they will get uniquified accordingly

--- a/src/main/scala/chisel3/stage/ChiselAnnotations.scala
+++ b/src/main/scala/chisel3/stage/ChiselAnnotations.scala
@@ -99,6 +99,30 @@ case object WarningsAsErrorsAnnotation
 
 }
 
+/** A root directory for source files, used for enhanced error reporting
+  *
+  * More than one may be provided. If a source file is found in more than one source root,
+  * the first match will be used in error reporting.
+  */
+case class SourceRootAnnotation(directory: File) extends NoTargetAnnotation with Unserializable with ChiselOption
+
+object SourceRootAnnotation extends HasShellOptions {
+  val options = Seq(
+    new ShellOption[String](
+      longOption = "source-root",
+      toAnnotationSeq = { dir =>
+        val f = new File(dir)
+        if (!f.isDirectory()) {
+          throw new OptionsException(s"Must be directory that exists!")
+        }
+        Seq(SourceRootAnnotation(f))
+      },
+      helpText = "Root directory for source files, used for enhanced error reporting",
+      helpValueName = Some("<file>")
+    )
+  )
+}
+
 /** Warn when reflective naming changes names of signals */
 @deprecated("Support for reflective naming has been removed, this object no longer does anything", "Chisel 3.6")
 case object WarnReflectiveNamingAnnotation

--- a/src/main/scala/chisel3/stage/ChiselCli.scala
+++ b/src/main/scala/chisel3/stage/ChiselCli.scala
@@ -13,6 +13,7 @@ trait ChiselCli { this: Shell =>
     PrintFullStackTraceAnnotation,
     ThrowOnFirstErrorAnnotation,
     WarningsAsErrorsAnnotation,
+    SourceRootAnnotation,
     WarnReflectiveNamingAnnotation,
     ChiselOutputFileAnnotation,
     ChiselGeneratorAnnotation

--- a/src/main/scala/chisel3/stage/ChiselOptions.scala
+++ b/src/main/scala/chisel3/stage/ChiselOptions.scala
@@ -3,6 +3,7 @@
 package chisel3.stage
 
 import chisel3.internal.firrtl.Circuit
+import java.io.File
 
 class ChiselOptions private[stage] (
   val runFirrtlCompiler:   Boolean = true,
@@ -10,7 +11,8 @@ class ChiselOptions private[stage] (
   val throwOnFirstError:   Boolean = false,
   val warningsAsErrors:    Boolean = false,
   val outputFile:          Option[String] = None,
-  val chiselCircuit:       Option[Circuit] = None) {
+  val chiselCircuit:       Option[Circuit] = None,
+  val sourceRoots:         Vector[File] = Vector.empty) {
 
   private[stage] def copy(
     runFirrtlCompiler:   Boolean = runFirrtlCompiler,
@@ -18,7 +20,8 @@ class ChiselOptions private[stage] (
     throwOnFirstError:   Boolean = throwOnFirstError,
     warningsAsErrors:    Boolean = warningsAsErrors,
     outputFile:          Option[String] = outputFile,
-    chiselCircuit:       Option[Circuit] = chiselCircuit
+    chiselCircuit:       Option[Circuit] = chiselCircuit,
+    sourceRoots:         Vector[File] = sourceRoots
   ): ChiselOptions = {
 
     new ChiselOptions(
@@ -27,7 +30,8 @@ class ChiselOptions private[stage] (
       throwOnFirstError = throwOnFirstError,
       warningsAsErrors = warningsAsErrors,
       outputFile = outputFile,
-      chiselCircuit = chiselCircuit
+      chiselCircuit = chiselCircuit,
+      sourceRoots = sourceRoots
     )
 
   }

--- a/src/main/scala/chisel3/stage/package.scala
+++ b/src/main/scala/chisel3/stage/package.scala
@@ -27,6 +27,7 @@ package object stage {
           case WarnReflectiveNamingAnnotation => c // Do nothing, ignored
           case ChiselOutputFileAnnotation(f)  => c.copy(outputFile = Some(f))
           case ChiselCircuitAnnotation(a)     => c.copy(chiselCircuit = Some(a))
+          case SourceRootAnnotation(s)        => c.copy(sourceRoots = c.sourceRoots :+ s)
         }
       }
 

--- a/src/main/scala/chisel3/stage/phases/Elaborate.scala
+++ b/src/main/scala/chisel3/stage/phases/Elaborate.scala
@@ -33,7 +33,8 @@ class Elaborate extends Phase {
           new DynamicContext(
             annotations,
             chiselOptions.throwOnFirstError,
-            chiselOptions.warningsAsErrors
+            chiselOptions.warningsAsErrors,
+            chiselOptions.sourceRoots
           )
         val (circuit, dut) =
           Builder.build(Module(gen()), context)

--- a/src/main/scala/circt/stage/CIRCTStage.scala
+++ b/src/main/scala/circt/stage/CIRCTStage.scala
@@ -6,6 +6,7 @@ import chisel3.deprecatedMFCMessage
 import chisel3.stage.{
   ChiselGeneratorAnnotation,
   PrintFullStackTraceAnnotation,
+  SourceRootAnnotation,
   ThrowOnFirstErrorAnnotation,
   WarningsAsErrorsAnnotation
 }
@@ -23,6 +24,7 @@ trait CLI { this: Shell =>
     PrintFullStackTraceAnnotation,
     ThrowOnFirstErrorAnnotation,
     WarningsAsErrorsAnnotation,
+    SourceRootAnnotation,
     SplitVerilog
   ).foreach(_.addOptions(parser))
 }

--- a/src/test/resources/chisel3/sourceroot1/Foo
+++ b/src/test/resources/chisel3/sourceroot1/Foo
@@ -1,0 +1,3 @@
+This is a fake source file
+It is used to test errors with a caret
+I am the file in sourceroot1

--- a/src/test/resources/chisel3/sourceroot2/Foo
+++ b/src/test/resources/chisel3/sourceroot2/Foo
@@ -1,0 +1,3 @@
+This is a fake source file
+It is used to test errors with a caret
+I am the file in sourceroot2

--- a/src/test/scala/circtTests/stage/ChiselStageSpec.scala
+++ b/src/test/scala/circtTests/stage/ChiselStageSpec.scala
@@ -3,6 +3,7 @@
 package circtTests.stage
 
 import chisel3.stage.ChiselGeneratorAnnotation
+import chisel3.experimental.SourceLine
 
 import circt.stage.{ChiselStage, FirtoolOption, PreserveAggregate}
 
@@ -72,6 +73,16 @@ object ChiselStageSpec {
 
   class RecoverableError extends RawModule {
     3.U >> -1
+  }
+
+  class RecoverableErrorFakeSourceInfo extends RawModule {
+    implicit val info = SourceLine("Foo", 3, 10)
+    3.U >> -1
+  }
+
+  class ErrorCaughtByFirtool extends RawModule {
+    implicit val info = SourceLine("Foo", 3, 10)
+    val w = Wire(UInt(8.W))
   }
 }
 
@@ -382,6 +393,114 @@ class ChiselStageSpec extends AnyFunSpec with Matchers with chiselTests.Utils {
       val stackTrace = exception.getStackTrace.mkString("\n")
       info("The exception should contain a truncated stack trace")
       stackTrace should include("java")
+    }
+
+    it("should include source line and a caret for recoverable errors") {
+      val (stdout, stderr, _) = grabStdOutErr {
+        intercept[java.lang.Exception] {
+          (new ChiselStage)
+            .execute(
+              Array("--target", "chirrtl"),
+              Seq(ChiselGeneratorAnnotation(() => new ChiselStageSpec.RecoverableError))
+            )
+        }
+      }
+
+      val lines = stdout.split("\n")
+      // Fuzzy includes aren't ideal but there is ANSI color in these strings that is hard to match
+      lines(0) should include(
+        "src/test/scala/circtTests/stage/ChiselStageSpec.scala:75:9: Negative shift amounts are illegal (got -1)"
+      )
+      lines(1) should include("    3.U >> -1")
+      lines(2) should include("        ^")
+    }
+
+    it("should NOT include source line and caret with an incorrect --source-root") {
+      val (stdout, stderr, _) = grabStdOutErr {
+        intercept[java.lang.Exception] {
+          (new ChiselStage)
+            .execute(
+              Array("--target", "chirrtl", "--source-root", ".github"),
+              Seq(ChiselGeneratorAnnotation(() => new ChiselStageSpec.RecoverableError))
+            )
+        }
+      }
+
+      val lines = stdout.split("\n")
+      // Fuzzy includes aren't ideal but there is ANSI color in these strings that is hard to match
+      lines.size should equal(2)
+      lines(0) should include(
+        "src/test/scala/circtTests/stage/ChiselStageSpec.scala:75:9: Negative shift amounts are illegal (got -1)"
+      )
+      (lines(1) should not).include("3.U >> -1")
+    }
+
+    it("should include source line and a caret for recoverable errors with multiple --source-roots") {
+      val (stdout, stderr, _) = grabStdOutErr {
+        intercept[java.lang.Exception] {
+          (new ChiselStage)
+            .execute(
+              Array(
+                "--target",
+                "chirrtl",
+                "--source-root",
+                ".",
+                "--source-root",
+                "src/test/resources/chisel3/sourceroot1"
+              ),
+              Seq(ChiselGeneratorAnnotation(() => new ChiselStageSpec.RecoverableErrorFakeSourceInfo))
+            )
+        }
+      }
+
+      val lines = stdout.split("\n")
+      // Fuzzy includes aren't ideal but there is ANSI color in these strings that is hard to match
+      lines(0) should include("Foo:3:10: Negative shift amounts are illegal (got -1)")
+      lines(1) should include("I am the file in sourceroot1")
+      lines(2) should include("         ^")
+    }
+
+    it("should include source line and a caret picking the first --source-root if there is ambiguity") {
+      val (stdout, stderr, _) = grabStdOutErr {
+        intercept[java.lang.Exception] {
+          (new ChiselStage)
+            .execute(
+              Array(
+                "--target",
+                "chirrtl",
+                "--source-root",
+                "src/test/resources/chisel3/sourceroot2",
+                "--source-root",
+                "src/test/resources/chisel3/sourceroot1"
+              ),
+              Seq(ChiselGeneratorAnnotation(() => new ChiselStageSpec.RecoverableErrorFakeSourceInfo))
+            )
+        }
+      }
+
+      val lines = stdout.split("\n")
+      // Fuzzy includes aren't ideal but there is ANSI color in these strings that is hard to match
+      lines(0) should include("Foo:3:10: Negative shift amounts are illegal (got -1)")
+      lines(1) should include("I am the file in sourceroot2")
+      lines(2) should include("         ^")
+    }
+
+    it("should propagate --source-root as --include-dir to firtool") {
+      val e = intercept[java.lang.Exception] {
+        (new ChiselStage)
+          .execute(
+            Array("--target", "systemverilog", "--source-root", "src/test/resources/chisel3/sourceroot1"),
+            Seq(ChiselGeneratorAnnotation(() => new ChiselStageSpec.ErrorCaughtByFirtool))
+          )
+      }
+
+      val lines = e.getMessage.split("\n")
+      val idx = lines.indexWhere(_.contains("not fully initialized"))
+      lines(idx) should include(
+        "src/test/resources/chisel3/sourceroot1/Foo:3:10: error: sink \"w\" not fully initialized"
+      )
+      lines(idx + 1) should equal("I am the file in sourceroot1")
+      lines(idx + 2) should equal("         ^")
     }
 
   }


### PR DESCRIPTION
This includes new command-line option --source-root which allows the user of Chisel to point to the root directory for source files. The default value is "." which should work for typical SBT and Mill projects.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

 - new feature/API 

#### API Impact

New command-line, annotation API into Chisel, but no other API impact.

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

 - Squash

#### Release Notes

Improve error reporting with source line and caret pointing to column. This requires knowing the root directory of source files which can be provided with `--source-root <dir>`. It will default to `.` which is the directory in which the Chisel elaboration process is invoked which should be correct for typical projects.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
