### PR TITLE
Get rid of warnings in / doc build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -133,7 +133,7 @@ jobs:
         uses: ./.github/workflows/install-circt
         #TODO: make the microsite building include building ScalaDoc
       - name: Build the docs
-        run: sbt -DdisableFatalWarnings doc
+        run: sbt doc
       - name: Build the microsite
         run: make -C website
         env:

--- a/build.sbt
+++ b/build.sbt
@@ -56,6 +56,19 @@ lazy val warningSuppression = Seq(
     "msg=Importing from firrtl:s",
     "msg=migration to the MLIR:s",
     "msg=method hasDefiniteSize in trait IterableOnceOps is deprecated:s",  // replacement `knownSize` is not in 2.12
+    "msg=object JavaConverters in package collection is deprecated:s",
+    "msg=INTERNALskipFile:s",
+    "msg=undefined in comment for method cf in class PrintableHelper:s",
+    "msg=method checkLengths in class StringContext is deprecated:s"
+  ).mkString(",")
+)
+
+lazy val docWarningSuppression = Seq(
+  scalacOptions += "-Wconf:" + Seq(
+    "msg=APIs in chisel3.internal:s",
+    "msg=Importing from firrtl:s",
+    "msg=migration to the MLIR:s",
+    "msg=method hasDefiniteSize in trait IterableOnceOps is deprecated:s",  // replacement `knownSize` is not in 2.12
     "msg=object JavaConverters in package collection is deprecated:s"
   ).mkString(",")
 )
@@ -110,6 +123,8 @@ lazy val chiselSettings = Seq(
 )
 
 autoCompilerPlugins := true
+autoAPIMappings := true
+autoAPIMappings := true
 
 // Plugin must be fully cross-versioned (published for Scala minor version)
 // The plugin only works in Scala 2.12+
@@ -318,7 +333,3 @@ lazy val docs = project // new documentation project
     )
   )
   .settings(fatalWarningsSettings: _*)
-
-addCommandAlias("com", "all compile")
-addCommandAlias("lint", "; compile:scalafix --check ; test:scalafix --check")
-addCommandAlias("fix", "all compile:scalafix test:scalafix")

--- a/build.sbt
+++ b/build.sbt
@@ -57,19 +57,7 @@ lazy val warningSuppression = Seq(
     "msg=migration to the MLIR:s",
     "msg=method hasDefiniteSize in trait IterableOnceOps is deprecated:s",  // replacement `knownSize` is not in 2.12
     "msg=object JavaConverters in package collection is deprecated:s",
-    "msg=INTERNALskipFile:s",
-    "msg=undefined in comment for method cf in class PrintableHelper:s",
-    "msg=method checkLengths in class StringContext is deprecated:s"
-  ).mkString(",")
-)
-
-lazy val docWarningSuppression = Seq(
-  scalacOptions += "-Wconf:" + Seq(
-    "msg=APIs in chisel3.internal:s",
-    "msg=Importing from firrtl:s",
-    "msg=migration to the MLIR:s",
-    "msg=method hasDefiniteSize in trait IterableOnceOps is deprecated:s",  // replacement `knownSize` is not in 2.12
-    "msg=object JavaConverters in package collection is deprecated:s"
+    "msg=undefined in comment for method cf in class PrintableHelper:s"
   ).mkString(",")
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -124,7 +124,6 @@ lazy val chiselSettings = Seq(
 
 autoCompilerPlugins := true
 autoAPIMappings := true
-autoAPIMappings := true
 
 // Plugin must be fully cross-versioned (published for Scala minor version)
 // The plugin only works in Scala 2.12+

--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -227,7 +227,7 @@ sealed class Vec[T <: Data] private[chisel3] (gen: => T, val length: Int) extend
 
   /** The "bulk connect operator", assigning elements in this Vec from elements in a Seq.
     *
-    * For chisel3._, uses the [[BiConnect]] algorithm; sub-elements of `that` may end up driving sub-elements of `this`
+    * For chisel3._, uses the `chisel3.internal.BiConnect` algorithm; sub-elements of `that` may end up driving sub-elements of `this`
     *  - Complicated semantics, will likely be deprecated in the future
     *
     * For Chisel._, emits the FIRRTL.<- operator
@@ -249,7 +249,7 @@ sealed class Vec[T <: Data] private[chisel3] (gen: => T, val length: Int) extend
 
   /** The "bulk connect operator", assigning elements in this Vec from elements in a Vec.
     *
-    * For chisel3._, uses the [[BiConnect]] algorithm; sub-elements of `that` may end up driving sub-elements of `this`
+    * For chisel3._, uses the `chisel3.internal.BiConnect` algorithm; sub-elements of `that` may end up driving sub-elements of `this`
     *  - See docs/src/explanations/connection-operators.md for details
     *
     * For Chisel._, emits the FIRRTL.<- operator

--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -1159,11 +1159,11 @@ abstract class Record(private[chisel3] implicit val compileOptions: CompileOptio
     clone
   }
 
-  /** The collection of [[Data]]
+  /** The collection of [[chisel3.Data]]
     *
     * This underlying datastructure is a ListMap because the elements must
     * remain ordered for serialization/deserialization. Elements added later
-    * are higher order when serialized (this is similar to [[Vec]]). For example:
+    * are higher order when serialized (this is similar to `Vec`). For example:
     * {{{
     *   // Assume we have some type MyRecord that creates a Record from the ListMap
     *   val record = MyRecord(ListMap("fizz" -> UInt(16.W), "buzz" -> UInt(16.W)))

--- a/core/src/main/scala/chisel3/Annotation.scala
+++ b/core/src/main/scala/chisel3/Annotation.scala
@@ -28,11 +28,7 @@ trait ChiselMultiAnnotation {
   def toFirrtl: Seq[Annotation]
 }
 
-/** Mixin for [[ChiselAnnotation]] that instantiates an associated FIRRTL Transform when this Annotation is present
-  * during a run of
-  * [[Driver$.execute(args:Array[String],dut:()=>chisel3\.RawModule)* Driver.execute]].
-  * Automatic Transform instantiation is *not* supported when the Circuit and Annotations are serialized before invoking
-  * FIRRTL.
+/** Mixin for [[ChiselAnnotation]] that instantiates an associated Transform when this Annotation is present
   */
 trait RunFirrtlTransform extends ChiselAnnotation {
   def transformClass: Class[_ <: Transform]
@@ -81,7 +77,7 @@ object annotate {
   *
   * @note Calling this on [[Data]] creates an annotation that Chisel emits to a separate annotations
   * file. This file must be passed to FIRRTL independently of the `.fir` file. The execute methods
-  * in [[chisel3.Driver]] will pass the annotations to FIRRTL automatically.
+  * in `chisel3.Driver` will pass the annotations to FIRRTL automatically.
   */
 
 object doNotDedup {

--- a/core/src/main/scala/chisel3/Annotation.scala
+++ b/core/src/main/scala/chisel3/Annotation.scala
@@ -74,12 +74,7 @@ object annotate {
   *  io.out(1) := fullAdder(io.a, io.b, "mod2")
   * }
   * }}}
-  *
-  * @note Calling this on [[Data]] creates an annotation that Chisel emits to a separate annotations
-  * file. This file must be passed to FIRRTL independently of the `.fir` file. The execute methods
-  * in `chisel3.Driver` will pass the annotations to FIRRTL automatically.
   */
-
 object doNotDedup {
 
   /** Marks a module to be ignored in Dedup Transform in Firrtl

--- a/core/src/main/scala/chisel3/Bits.scala
+++ b/core/src/main/scala/chisel3/Bits.scala
@@ -374,10 +374,10 @@ sealed abstract class Bits(private[chisel3] val width: Width) extends Element wi
   /** @group SourceInfoTransformMacro */
   def do_asSInt(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): SInt
 
-  /** Reinterpret this $coll as a [[FixedPoint]].
+  /** Reinterpret this $coll as a `FixedPoint`.
     *
     * @note The value is not guaranteed to be preserved. For example, a [[UInt]] of width 3 and value 7 (0b111) would
-    * become a [[FixedPoint]] with value -1. The interpretation of the number is also affected by the specified binary
+    * become a `FixedPoint` with value -1. The interpretation of the number is also affected by the specified binary
     * point. '''Caution is advised!'''
     */
   @deprecated(deprecatedMFCMessage, "Chisel 3.6")
@@ -1331,7 +1331,7 @@ package experimental {
     @deprecated(deprecatedMFCMessage, "Chisel 3.6")
     def binaryPoint: BinaryPoint
 
-    /** Return the [[Double]] value of this instance if it is a Literal
+    /** Return the `Double` value of this instance if it is a Literal
       * @note this method may throw an exception if the literal value won't fit in a Double
       */
     @deprecated(deprecatedMFCMessage, "Chisel 3.6")
@@ -1348,7 +1348,7 @@ package experimental {
     @deprecated(deprecatedMFCMessage, "Chisel 3.6")
     def litToDouble: Double = litToDoubleOption.get
 
-    /** Return the [[BigDecimal]] value of this instance if it is a Literal
+    /** Return the [[scala.math.BigDecimal]] value of this instance if it is a Literal
       * @note this method may throw an exception if the literal value won't fit in a BigDecimal
       */
     @deprecated(deprecatedMFCMessage, "Chisel 3.6")
@@ -1360,7 +1360,7 @@ package experimental {
       }
     }
 
-    /** Return the [[BigDecimal]] value of this instance assuming it is a literal (convenience method)
+    /** Return the [[scala.math.BigDecimal]] value of this instance assuming it is a literal (convenience method)
       * @return
       */
     @deprecated(deprecatedMFCMessage, "Chisel 3.6")
@@ -1860,7 +1860,7 @@ package experimental {
     *   val one = 1.I
     *   val six = Seq.fill(6)(one).reduce(_ + _)
     * }}}
-    * A UInt computed in this way would require a [[Width]]
+    * A UInt computed in this way would require a `Width`
     * binary point
     * The width and binary point may be inferred.
     *

--- a/core/src/main/scala/chisel3/Data.scala
+++ b/core/src/main/scala/chisel3/Data.scala
@@ -723,7 +723,7 @@ abstract class Data extends HasId with NamedComponent with SourceInfoDoc {
 
   /** The "bulk connect operator", assigning elements in this Vec from elements in a Vec.
     *
-    * For chisel3._, uses the [[BiConnect]] algorithm; sub-elements of `that` may end up driving sub-elements of `this`
+    * For chisel3._, uses the `chisel3.internal.BiConnect` algorithm; sub-elements of that` may end up driving sub-elements of `this`
     *  - Complicated semantics, hard to write quickly, will likely be deprecated in the future
     *
     * For Chisel._, emits the FIRRTL.<- operator

--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -401,8 +401,8 @@ package experimental {
 
     /** The desired name of this module (which will be used in generated FIRRTL IR or Verilog).
       *
-      * The name of a module approximates the behavior of the Java Reflection [[`getSimpleName` method
-      * https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html#getSimpleName--]] with some modifications:
+      * The name of a module approximates the behavior of the Java Reflection `getSimpleName` method
+      * https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html#getSimpleName-- with some modifications:
       *
       * - Anonymous modules will get an `"_Anon"` tag
       * - Modules defined in functions will use their class name and not a numeric name

--- a/core/src/main/scala/chisel3/VerificationStatement.scala
+++ b/core/src/main/scala/chisel3/VerificationStatement.scala
@@ -64,7 +64,7 @@ object assert extends VerifPrintMacrosDoc {
     * @param cond condition, assertion fires (simulation fails) on a rising clock edge when false and reset is not asserted
     * @param message optional chisel Printable type message
     *
-    * @note See `printf.apply(fmt:Printable)` for documentation on printf using Printables
+    * @note See [[printf.apply(pable:chisel3\.Printable)*]] for documentation on printf using Printables
     * @note currently cannot be used in core Chisel / libraries because macro
     * defs need to be compiled first and the SBT project is not set up to do
     * that
@@ -239,7 +239,7 @@ object assume extends VerifPrintMacrosDoc {
     * @param cond condition, assertion fires (simulation fails) when false
     * @param message optional Printable type message when the assertion fires
     *
-    * @note See ``printf.apply(fmt:Printable`` for documentation on printf using Printables
+    * @note See [[printf.apply(pable:chisel3\.Printable)*]] for documentation on printf using Printables
     */
   def apply(
     cond:    Bool,

--- a/core/src/main/scala/chisel3/VerificationStatement.scala
+++ b/core/src/main/scala/chisel3/VerificationStatement.scala
@@ -64,7 +64,7 @@ object assert extends VerifPrintMacrosDoc {
     * @param cond condition, assertion fires (simulation fails) on a rising clock edge when false and reset is not asserted
     * @param message optional chisel Printable type message
     *
-    * @note See [[printf.apply(fmt:Printable)]] for documentation on printf using Printables
+    * @note See `printf.apply(fmt:Printable)` for documentation on printf using Printables
     * @note currently cannot be used in core Chisel / libraries because macro
     * defs need to be compiled first and the SBT project is not set up to do
     * that
@@ -239,7 +239,7 @@ object assume extends VerifPrintMacrosDoc {
     * @param cond condition, assertion fires (simulation fails) when false
     * @param message optional Printable type message when the assertion fires
     *
-    * @note See [[printf.apply(fmt:Printable]] for documentation on printf using Printables
+    * @note See ``printf.apply(fmt:Printable`` for documentation on printf using Printables
     */
   def apply(
     cond:    Bool,

--- a/core/src/main/scala/chisel3/connectable/Connectable.scala
+++ b/core/src/main/scala/chisel3/connectable/Connectable.scala
@@ -125,7 +125,7 @@ object Connectable {
     * $chiselTypeRestrictions
     *
     * Additional notes:
-    * - Connecting two [[util.DecoupledIO]]'s would connect `bits`, `valid`, AND `ready` from producer to consumer (despite `ready` being flipped)
+    * - Connecting two `util.DecoupledIO`'s would connect `bits`, `valid`, AND `ready` from producer to consumer (despite `ready` being flipped)
     * - Functionally equivalent to chisel3.:=, but different than Chisel.:=
     *
     * @group connection
@@ -143,7 +143,7 @@ object Connectable {
     * $chiselTypeRestrictions
     *
     * Additional notes:
-    *  - Connecting two [[util.DecoupledIO]]'s would connect `bits` and `valid` from producer to consumer, but leave `ready` unconnected
+    *  - Connecting two `util.DecoupledIO`'s would connect `bits` and `valid` from producer to consumer, but leave `ready` unconnected
     *
     * @group connection
     *
@@ -160,7 +160,7 @@ object Connectable {
     * $chiselTypeRestrictions
     *
     * Additional notes:
-    *  - Connecting two [[util.DecoupledIO]]'s would connect `ready` from consumer to producer, but leave `bits` and `valid` unconnected
+    *  - Connecting two `util.DecoupledIO`'s would connect `ready` from consumer to producer, but leave `bits` and `valid` unconnected
     *
     * @group connection
     *
@@ -182,7 +182,7 @@ object Connectable {
     * - An additional type restriction is that all relative orientations of `consumer` and `producer` must match exactly.
     *
     * Additional notes:
-    *  - Connecting two wires of [[util.DecoupledIO]] chisel type would connect `bits` and `valid` from producer to consumer, and `ready` from consumer to producer.
+    *  - Connecting two wires of `util.DecoupledIO` chisel type would connect `bits` and `valid` from producer to consumer, and `ready` from consumer to producer.
     *  - If the types of consumer and producer also have identical relative flips, then we can emit FIRRTL.<= as it is a stricter version of chisel3.:<>=
     *  - "turk-duck-en" is a dish where a turkey is stuffed with a duck, which is stuffed with a chicken; `:<>=` is a `:=` stuffed with a `<>`
     *

--- a/core/src/main/scala/chisel3/connectable/package.scala
+++ b/core/src/main/scala/chisel3/connectable/package.scala
@@ -5,6 +5,9 @@ package chisel3
 import chisel3.internal.{BiConnect, Builder}
 import chisel3.experimental.{prefix, SourceInfo}
 
+/*
+ * * @define colonGreaterEq The "flipped connection operator", or the "backpressure connection operator" between a producer and consumer.
+ */
 package object connectable {
 
   import Connection.connect

--- a/core/src/main/scala/chisel3/connectable/package.scala
+++ b/core/src/main/scala/chisel3/connectable/package.scala
@@ -5,9 +5,6 @@ package chisel3
 import chisel3.internal.{BiConnect, Builder}
 import chisel3.experimental.{prefix, SourceInfo}
 
-/*
- * * @define colonGreaterEq The "flipped connection operator", or the "backpressure connection operator" between a producer and consumer.
- */
 package object connectable {
 
   import Connection.connect

--- a/core/src/main/scala/chisel3/dontTouch.scala
+++ b/core/src/main/scala/chisel3/dontTouch.scala
@@ -19,6 +19,8 @@ import firrtl.transforms.DontTouchAnnotation
   *   dontTouch(dead) // Marking it as such will preserve it
   * }
   * }}}
+  * @note Because this is an optimization barrier, constants will not be propagated through a signal marked as
+  * dontTouch.
   */
 object dontTouch {
 

--- a/core/src/main/scala/chisel3/dontTouch.scala
+++ b/core/src/main/scala/chisel3/dontTouch.scala
@@ -19,11 +19,6 @@ import firrtl.transforms.DontTouchAnnotation
   *   dontTouch(dead) // Marking it as such will preserve it
   * }
   * }}}
-  * @note Calling this on [[Data]] creates an annotation that Chisel emits to a separate annotations
-  * file. This file must be passed to FIRRTL independently of the `.fir` file. The execute methods
-  * in [[chisel3.Driver]] will pass the annotations to FIRRTL automatically.
-  * @note Because this is an optimization barrier, constants will not be propagated through a signal marked as
-  * dontTouch.
   */
 object dontTouch {
 

--- a/core/src/main/scala/chisel3/experimental/Trace.scala
+++ b/core/src/main/scala/chisel3/experimental/Trace.scala
@@ -59,7 +59,7 @@ object Trace {
     def duplicate(n: T): Annotation = this.copy(target = n)
   }
 
-  /** Get [[CompleteTarget]] of the target `x` for `annos`.
+  /** Get `CompleteTarget` of the target `x` for `annos`.
     * This API can be used to find the final reference to a signal or module which is marked by `traceName`
     */
   def finalTarget(annos: AnnotationSeq)(x: HasId): Seq[CompleteTarget] = finalTargetMap(annos)

--- a/core/src/main/scala/chisel3/experimental/dataview/DataProduct.scala
+++ b/core/src/main/scala/chisel3/experimental/dataview/DataProduct.scala
@@ -92,7 +92,7 @@ object DataProduct extends LowPriorityDataProduct {
     }
   }
 
-  /** [[DataProduct]] implementation for any [[Tuple2]] where each field has an implementation of `DataProduct`. */
+  /** [[DataProduct]] implementation for any [[scala.Tuple2]] where each field has an implementation of `DataProduct`. */
   implicit def tuple2DataProduct[A: DataProduct, B: DataProduct]: DataProduct[(A, B)] = new DataProduct[(A, B)] {
     def dataIterator(tup: (A, B), path: String): Iterator[(Data, String)] = {
       val dpa = implicitly[DataProduct[A]]
@@ -102,7 +102,7 @@ object DataProduct extends LowPriorityDataProduct {
     }
   }
 
-  /** [[DataProduct]] implementation for any [[Tuple3]] where each field has an implementation of `DataProduct`. */
+  /** [[DataProduct]] implementation for any [[scala.Tuple3]] where each field has an implementation of `DataProduct`. */
   implicit def tuple3DataProduct[A: DataProduct, B: DataProduct, C: DataProduct]: DataProduct[(A, B, C)] =
     new DataProduct[(A, B, C)] {
       def dataIterator(tup: (A, B, C), path: String): Iterator[(Data, String)] = {
@@ -114,7 +114,7 @@ object DataProduct extends LowPriorityDataProduct {
       }
     }
 
-  /** [[DataProduct]] implementation for any [[Tuple4]] where each field has an implementation of `DataProduct`. */
+  /** [[DataProduct]] implementation for any [[scala.Tuple4]] where each field has an implementation of `DataProduct`. */
   implicit def tuple4DataProduct[
     A: DataProduct,
     B: DataProduct,
@@ -135,7 +135,7 @@ object DataProduct extends LowPriorityDataProduct {
       }
     }
 
-  /** [[DataProduct]] implementation for any [[Tuple5]] where each field has an implementation of `DataProduct`. */
+  /** [[DataProduct]] implementation for any [[scala.Tuple5]] where each field has an implementation of `DataProduct`. */
   implicit def tuple5DataProduct[
     A: DataProduct,
     B: DataProduct,
@@ -159,7 +159,7 @@ object DataProduct extends LowPriorityDataProduct {
       }
     }
 
-  /** [[DataProduct]] implementation for any [[Tuple6]] where each field has an implementation of `DataProduct`. */
+  /** [[DataProduct]] implementation for any [[scala.Tuple6]] where each field has an implementation of `DataProduct`. */
   implicit def tuple6DataProduct[
     A: DataProduct,
     B: DataProduct,
@@ -186,7 +186,7 @@ object DataProduct extends LowPriorityDataProduct {
       }
     }
 
-  /** [[DataProduct]] implementation for any [[Tuple7]] where each field has an implementation of `DataProduct`. */
+  /** [[DataProduct]] implementation for any [[scala.Tuple7]] where each field has an implementation of `DataProduct`. */
   implicit def tuple7DataProduct[
     A: DataProduct,
     B: DataProduct,
@@ -216,7 +216,7 @@ object DataProduct extends LowPriorityDataProduct {
       }
     }
 
-  /** [[DataProduct]] implementation for any [[Tuple8]] where each field has an implementation of `DataProduct`. */
+  /** [[DataProduct]] implementation for any [[scala.Tuple8]] where each field has an implementation of `DataProduct`. */
   implicit def tuple8DataProduct[
     A: DataProduct,
     B: DataProduct,
@@ -249,7 +249,7 @@ object DataProduct extends LowPriorityDataProduct {
       }
     }
 
-  /** [[DataProduct]] implementation for any [[Tuple9]] where each field has an implementation of `DataProduct`. */
+  /** [[DataProduct]] implementation for any [[scala.Tuple9]] where each field has an implementation of `DataProduct`. */
   implicit def tuple9DataProduct[
     A: DataProduct,
     B: DataProduct,
@@ -285,7 +285,7 @@ object DataProduct extends LowPriorityDataProduct {
       }
     }
 
-  /** [[DataProduct]] implementation for any [[Tuple9]] where each field has an implementation of `DataProduct`. */
+  /** [[DataProduct]] implementation for any [[scala.Tuple9]] where each field has an implementation of `DataProduct`. */
   implicit def tuple10DataProduct[
     A: DataProduct,
     B: DataProduct,

--- a/core/src/main/scala/chisel3/experimental/dataview/DataView.scala
+++ b/core/src/main/scala/chisel3/experimental/dataview/DataView.scala
@@ -170,7 +170,7 @@ object DataView {
     )
   }
 
-  /** Provides implementations of [[DataView]] for [[Tuple2]] to [[HWTuple2]] */
+  /** Provides implementations of [[DataView]] for `Tuple2`  to [[HWTuple2]] */
   implicit def tuple2DataView[T1: DataProduct, T2: DataProduct, V1 <: Data, V2 <: Data](
     implicit v1: DataView[T1, V1],
     v2:          DataView[T2, V2],
@@ -184,7 +184,7 @@ object DataView {
       }
     )
 
-  /** Provides implementations of [[DataView]] for [[Tuple3]] to [[HWTuple3]] */
+  /** Provides implementations of [[DataView]] for `Tuple3` to [[HWTuple3]] */
   implicit def tuple3DataView[T1: DataProduct, T2: DataProduct, T3: DataProduct, V1 <: Data, V2 <: Data, V3 <: Data](
     implicit v1: DataView[T1, V1],
     v2:          DataView[T2, V2],
@@ -199,7 +199,7 @@ object DataView {
       }
     )
 
-  /** Provides implementations of [[DataView]] for [[Tuple4]] to [[HWTuple4]] */
+  /** Provides implementations of [[DataView]] for `Tuple4` to [[HWTuple4]] */
   implicit def tuple4DataView[
     T1: DataProduct,
     T2: DataProduct,
@@ -227,7 +227,7 @@ object DataView {
       }
     )
 
-  /** Provides implementations of [[DataView]] for [[Tuple5]] to [[HWTuple5]] */
+  /** Provides implementations of [[DataView]] for `Tuple5` to [[HWTuple5]] */
   implicit def tuple5DataView[
     T1: DataProduct,
     T2: DataProduct,
@@ -272,7 +272,7 @@ object DataView {
     )
   }
 
-  /** Provides implementations of [[DataView]] for [[Tuple6]] to [[HWTuple6]] */
+  /** Provides implementations of [[DataView]] for `Tuple6` to [[HWTuple6]] */
   implicit def tuple6DataView[
     T1: DataProduct,
     T2: DataProduct,
@@ -320,7 +320,7 @@ object DataView {
       }
     )
 
-  /** Provides implementations of [[DataView]] for [[Tuple7]] to [[HWTuple7]] */
+  /** Provides implementations of [[DataView]] for `Tuple7` to [[HWTuple7]] */
   implicit def tuple7DataView[
     T1: DataProduct,
     T2: DataProduct,
@@ -373,7 +373,7 @@ object DataView {
       }
     )
 
-  /** Provides implementations of [[DataView]] for [[Tuple8]] to [[HWTuple8]] */
+  /** Provides implementations of [[DataView]] for `Tuple8` to [[HWTuple8]] */
   implicit def tuple8DataView[
     T1: DataProduct,
     T2: DataProduct,
@@ -431,7 +431,7 @@ object DataView {
       }
     )
 
-  /** Provides implementations of [[DataView]] for [[Tuple9]] to [[HWTuple9]] */
+  /** Provides implementations of [[DataView]] for `Tuple9` to [[HWTuple9]] */
   implicit def tuple9DataView[
     T1: DataProduct,
     T2: DataProduct,
@@ -494,7 +494,7 @@ object DataView {
       }
     )
 
-  /** Provides implementations of [[DataView]] for [[Tuple10]] to [[HWTuple10]] */
+  /** Provides implementations of [[DataView]] for `Tuple10` to [[HWTuple10]] */
   implicit def tuple10DataView[
     T1:  DataProduct,
     T2:  DataProduct,

--- a/core/src/main/scala/chisel3/experimental/dataview/DataView.scala
+++ b/core/src/main/scala/chisel3/experimental/dataview/DataView.scala
@@ -170,7 +170,7 @@ object DataView {
     )
   }
 
-  /** Provides implementations of [[DataView]] for `Tuple2`  to [[HWTuple2]] */
+  /** Provides implementations of [[DataView]] for [[scala.Tuple2]]  to [[HWTuple2]] */
   implicit def tuple2DataView[T1: DataProduct, T2: DataProduct, V1 <: Data, V2 <: Data](
     implicit v1: DataView[T1, V1],
     v2:          DataView[T2, V2],
@@ -184,7 +184,7 @@ object DataView {
       }
     )
 
-  /** Provides implementations of [[DataView]] for `Tuple3` to [[HWTuple3]] */
+  /** Provides implementations of [[DataView]] for [[scala.Tuple3]] to [[HWTuple3]] */
   implicit def tuple3DataView[T1: DataProduct, T2: DataProduct, T3: DataProduct, V1 <: Data, V2 <: Data, V3 <: Data](
     implicit v1: DataView[T1, V1],
     v2:          DataView[T2, V2],
@@ -199,7 +199,7 @@ object DataView {
       }
     )
 
-  /** Provides implementations of [[DataView]] for `Tuple4` to [[HWTuple4]] */
+  /** Provides implementations of [[DataView]] for [[scala.Tuple4]] to [[HWTuple4]] */
   implicit def tuple4DataView[
     T1: DataProduct,
     T2: DataProduct,
@@ -227,7 +227,7 @@ object DataView {
       }
     )
 
-  /** Provides implementations of [[DataView]] for `Tuple5` to [[HWTuple5]] */
+  /** Provides implementations of [[DataView]] for [[scala.Tuple5]] to [[HWTuple5]] */
   implicit def tuple5DataView[
     T1: DataProduct,
     T2: DataProduct,
@@ -272,7 +272,7 @@ object DataView {
     )
   }
 
-  /** Provides implementations of [[DataView]] for `Tuple6` to [[HWTuple6]] */
+  /** Provides implementations of [[DataView]] for [[scala.Tuple6]] to [[HWTuple6]] */
   implicit def tuple6DataView[
     T1: DataProduct,
     T2: DataProduct,
@@ -320,7 +320,7 @@ object DataView {
       }
     )
 
-  /** Provides implementations of [[DataView]] for `Tuple7` to [[HWTuple7]] */
+  /** Provides implementations of [[DataView]] for [[scala.Tuple7]] to [[HWTuple7]] */
   implicit def tuple7DataView[
     T1: DataProduct,
     T2: DataProduct,
@@ -373,7 +373,7 @@ object DataView {
       }
     )
 
-  /** Provides implementations of [[DataView]] for `Tuple8` to [[HWTuple8]] */
+  /** Provides implementations of [[DataView]] for [[scala.Tuple8]] to [[HWTuple8]] */
   implicit def tuple8DataView[
     T1: DataProduct,
     T2: DataProduct,
@@ -431,7 +431,7 @@ object DataView {
       }
     )
 
-  /** Provides implementations of [[DataView]] for `Tuple9` to [[HWTuple9]] */
+  /** Provides implementations of [[DataView]] for [[scala.Tuple9]] to [[HWTuple9]] */
   implicit def tuple9DataView[
     T1: DataProduct,
     T2: DataProduct,
@@ -494,7 +494,7 @@ object DataView {
       }
     )
 
-  /** Provides implementations of [[DataView]] for `Tuple10` to [[HWTuple10]] */
+  /** Provides implementations of [[DataView]] for [[scala.Tuple10]] to [[HWTuple10]] */
   implicit def tuple10DataView[
     T1:  DataProduct,
     T2:  DataProduct,

--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/Definition.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/Definition.scala
@@ -14,7 +14,7 @@ import firrtl.annotations.{IsModule, ModuleTarget, NoTargetAnnotation}
 import scala.annotation.nowarn
 
 /** User-facing Definition type.
-  * Represents a definition of an object of type [[A]] which are marked as @instantiable
+  * Represents a definition of an object of type `A` which are marked as @instantiable
   * Can be created using Definition.apply method.
   *
   * These definitions are then used to create multiple [[Instance]]s.
@@ -26,7 +26,7 @@ final case class Definition[+A] private[chisel3] (private[chisel3] underlying: U
     with SealedHierarchy[A] {
 
   /** Used by Chisel's internal macros. DO NOT USE in your normal Chisel code!!!
-    * Instead, mark the field you are accessing with [[@public]]
+    * Instead, mark the field you are accessing with [[public]]
     *
     * Given a selector function (that) which selects a member from the original, return the
     *   corresponding member from the instance.

--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/Hierarchy.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/Hierarchy.scala
@@ -66,7 +66,7 @@ sealed trait Hierarchy[+A] {
   private def inBaseClasses(clz: String): Boolean = superClasses.contains(clz)
 
   /** Used by Chisel's internal macros. DO NOT USE in your normal Chisel code!!!
-    * Instead, mark the field you are accessing with [[@public]]
+    * Instead, mark the field you are accessing with [[public]]
     *
     * Given a selector function (that) which selects a member from the original, return the
     *   corresponding member from the hierarchy.

--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/Instance.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/Instance.scala
@@ -14,7 +14,7 @@ import firrtl.annotations.IsModule
 import scala.annotation.nowarn
 
 /** User-facing Instance type.
-  * Represents a unique instance of type [[A]] which are marked as @instantiable
+  * Represents a unique instance of type `A` which are marked as @instantiable
   * Can be created using Instance.apply method.
   *
   * @param underlying The internal representation of the instance, which may be either be directly the object, or a clone of an object
@@ -43,7 +43,7 @@ final case class Instance[+A] private[chisel3] (private[chisel3] underlying: Und
   }
 
   /** Used by Chisel's internal macros. DO NOT USE in your normal Chisel code!!!
-    * Instead, mark the field you are accessing with [[@public]]
+    * Instead, mark the field you are accessing with [[public]]
     *
     * Given a selector function (that) which selects a member from the original, return the
     *   corresponding member from the instance.

--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/IsInstantiable.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/IsInstantiable.scala
@@ -3,7 +3,7 @@
 package chisel3.experimental.hierarchy.core
 
 /** While this is public, it is not recommended for users to extend directly.
-  * Instead, use the [[@instantiable]] annotation on your trait or class.
+  * Instead, use the [[instantiable]] annotation on your trait or class.
   *
   * This trait indicates whether a class can be returned from an Instance.
   */

--- a/core/src/main/scala/chisel3/experimental/hierarchy/package.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/package.scala
@@ -3,7 +3,7 @@ package chisel3.experimental
 package object hierarchy {
 
   /** Classes or traits which will be used with the [[Definition]] + [[Instance]] api should be marked
-    * with the [[@instantiable]] annotation at the class/trait definition.
+    * with the [[instantiable]] annotation at the class/trait definition.
     *
     * @example {{{
     * @instantiable
@@ -18,10 +18,10 @@ package object hierarchy {
     */
   class instantiable extends chisel3.internal.instantiable
 
-  /** Classes marked with [[@instantiable]] can have their vals marked with the [[@public]] annotation to
+  /** Classes marked with [[instantiable]] can have their vals marked with the [[public]] annotation to
     * enable accessing these values from a [[Definition]] or [[Instance]] of the class.
     *
-    * Only vals of the the following types can be marked [[@public]]:
+    * Only vals of the the following types can be marked [[public]]:
     *   1. IsInstantiable
     *   2. IsLookupable
     *   3. Data

--- a/core/src/main/scala/chisel3/experimental/package.scala
+++ b/core/src/main/scala/chisel3/experimental/package.scala
@@ -160,6 +160,7 @@ package object experimental {
     *   // Name without AffectsChiselPrefix: "value_1"
     *   val nonData2 = new NotAData
     * }
+    * }}}
     */
   trait AffectsChiselPrefix
 
@@ -205,7 +206,7 @@ package object experimental {
   // ****************************** Hardware equivalents of Scala Tuples ******************************
   // These are intended to be used via DataView
 
-  /** [[Data]] equivalent of Scala's [[Tuple2]]
+  /** [[Data]] equivalent of Scala's [[scala.Tuple2]]
     *
     * Users may not instantiate this class directly. Instead they should use the implicit conversion from `Tuple2` in
     * `chisel3.experimental.conversions`
@@ -220,7 +221,7 @@ package object experimental {
     )
   }
 
-  /** [[Data]] equivalent of Scala's [[Tuple3]]
+  /** [[Data]] equivalent of Scala's [[scala.Tuple3]]
     *
     * Users may not instantiate this class directly. Instead they should use the implicit conversion from `Tuple3` in
     * `chisel3.experimental.conversions`
@@ -244,7 +245,7 @@ package object experimental {
     )
   }
 
-  /** [[Data]] equivalent of Scala's [[Tuple4]]
+  /** [[Data]] equivalent of Scala's [[scala.Tuple4]]
     *
     * Users may not instantiate this class directly. Instead they should use the implicit conversion from `Tuple4` in
     * `chisel3.experimental.conversions`
@@ -271,7 +272,7 @@ package object experimental {
     )
   }
 
-  /** [[Data]] equivalent of Scala's [[Tuple5]]
+  /** [[Data]] equivalent of Scala's [[scala.Tuple5]]
     *
     * Users may not instantiate this class directly. Instead they should use the implicit conversion from `Tuple5` in
     * `chisel3.experimental.conversions`
@@ -301,7 +302,7 @@ package object experimental {
     )
   }
 
-  /** [[Data]] equivalent of Scala's [[Tuple6]]
+  /** [[Data]] equivalent of Scala's [[scala.Tuple6]]
     *
     * Users may not instantiate this class directly. Instead they should use the implicit conversion from `Tuple6` in
     * `chisel3.experimental.conversions`
@@ -334,7 +335,7 @@ package object experimental {
     )
   }
 
-  /** [[Data]] equivalent of Scala's [[Tuple7]]
+  /** [[Data]] equivalent of Scala's [[scala.Tuple7]]
     *
     * Users may not instantiate this class directly. Instead they should use the implicit conversion from `Tuple7` in
     * `chisel3.experimental.conversions`
@@ -378,7 +379,7 @@ package object experimental {
     )
   }
 
-  /** [[Data]] equivalent of Scala's [[Tuple8]]
+  /** [[Data]] equivalent of Scala's [[scala.Tuple8]]
     *
     * Users may not instantiate this class directly. Instead they should use the implicit conversion from `Tuple8` in
     * `chisel3.experimental.conversions`
@@ -426,7 +427,7 @@ package object experimental {
     )
   }
 
-  /** [[Data]] equivalent of Scala's [[Tuple9]]
+  /** [[Data]] equivalent of Scala's [[scala.Tuple9]]
     *
     * Users may not instantiate this class directly. Instead they should use the implicit conversion from `Tuple9` in
     * `chisel3.experimental.conversions`
@@ -478,7 +479,7 @@ package object experimental {
     )
   }
 
-  /** [[Data]] equivalent of Scala's [[Tuple9]]
+  /** [[Data]] equivalent of Scala's [[scala.Tuple9]]
     *
     * Users may not instantiate this class directly. Instead they should use the implicit conversion from `Tuple9` in
     * `chisel3.experimental.conversions`

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -176,7 +176,7 @@ private[chisel3] trait HasId extends chisel3.InstanceId {
     * If the final computed name conflicts with another name, it may get uniquified by appending
     * a digit at the end.
     *
-    * Is a higher priority than [[autoSeed]], in that regardless of whether [[autoSeed]]
+    * Is a higher priority than `autoSeed`, in that regardless of whether `autoSeed`
     * was called, [[suggestName]] will always take precedence.
     *
     * @param seed The seed for the name of this component

--- a/core/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -770,7 +770,7 @@ sealed class IntervalRange(
   }
 
   /**
-    * Wrap the value of this [[Interval]] into the range of a different Interval with a presumably smaller range.
+    * Wrap the value of this `Interval` into the range of a different Interval with a presumably smaller range.
     * @param that
     * @return
     */
@@ -779,7 +779,7 @@ sealed class IntervalRange(
   }
 
   /**
-    * Clip the value of this [[Interval]] into the range of a different Interval with a presumably smaller range.
+    * Clip the value of this `Interval` into the range of a different Interval with a presumably smaller range.
     * @param that
     * @return
     */

--- a/core/src/main/scala/chisel3/package.scala
+++ b/core/src/main/scala/chisel3/package.scala
@@ -215,7 +215,7 @@ package object chisel3 {
       StringContext(t: _*).cf(args: _*)
     }
 
-    /** Custom string interpolator for generating formatted Printables : cf"..."
+    /** Custom string interpolator for generating formatted Printables : the cf interpolator
       *
       * Enhanced version of scala's `f` interpolator.
       * Each expression (argument) referenced within the string is
@@ -226,7 +226,7 @@ package object chisel3 {
       *
       *  - <code>%n</code> - Returns [[Name]] Printable.
       *  - <code>%N</code> - Returns [[FullName]] Printable.
-      *  - <code>%b,%d,%x,%c</code> - Only applicable for types of [[Bits]] or dreived from it. - returns ([[Binary]],[[Decimal]],
+      *  - <code>%b,%d,%x,%c</code> - Only applicable for types of [[Bits]] or derived from it. - returns ([[Binary]],[[Decimal]],
       * [[Hexadecimal]],[[Character]]) Printable respectively.
       *  - Default - If no specifier given call [[Data.toPrintable]] on the Chisel Type.
       *
@@ -250,23 +250,22 @@ package object chisel3 {
       * val f1 = 30.2 // Scala float type.
       * val pable = cf"w1 = $w1%x f1 = $f1%2.2f. This is 100%% clear"
       *
-      * // pable is as follows
+      * // the val `pable` is equivalent to the following
       * // Printables(List(PString(w1 = ), Hexadecimal(UInt<5>(20)), PString( f1 = ), PString(30.20), PString(. This is 100), Percent, PString( clear)))
       * }}}
-      *
-      * @throws UnknownFormatConversionException
+      * throws UnknownFormatConversionException
       *         if literal percent not escaped with % or if the format specifier is not supported
       *         for the specific type
       *
-      * @throws StringContext.InvalidEscapeException
+      * throws StringContext.InvalidEscapeException
       *         if a `parts` string contains a backslash (`\`) character
       *         that does not start a valid escape sequence.
       *
-      * @throws IllegalArgumentException
+      * throws IllegalArgumentException
       *         if the number of `parts` in the enclosing `StringContext` does not exceed
       *         the number of arguments `arg` by exactly 1.
       */
-    @nowarn("msg=checkLengths in class StringContext is deprecated")
+    @nowarn("msg=checkLengths in class StringContext is deprecated:s")
     def cf(args: Any*): Printable = {
 
       // Handle literal %

--- a/core/src/main/scala/chisel3/package.scala
+++ b/core/src/main/scala/chisel3/package.scala
@@ -215,7 +215,7 @@ package object chisel3 {
       StringContext(t: _*).cf(args: _*)
     }
 
-    /** Custom string interpolator for generating formatted Printables : the cf interpolator
+    /** Custom string interpolator for generating formatted Printables : cf"..."
       *
       * Enhanced version of scala's `f` interpolator.
       * Each expression (argument) referenced within the string is
@@ -265,7 +265,7 @@ package object chisel3 {
       *         if the number of `parts` in the enclosing `StringContext` does not exceed
       *         the number of arguments `arg` by exactly 1.
       */
-    @nowarn("msg=checkLengths in class StringContext is deprecated:s")
+    @nowarn("msg=checkLengths in class StringContext is deprecated")
     def cf(args: Any*): Printable = {
 
       // Handle literal %

--- a/plugin/src/main/scala/chisel3/internal/plugin/ChiselPlugin.scala
+++ b/plugin/src/main/scala/chisel3/internal/plugin/ChiselPlugin.scala
@@ -68,7 +68,6 @@ class ChiselPlugin(val global: Global) extends Plugin {
       } else if (option.startsWith(arguments.skipFilePluginOpt)) {
         val filename = option.stripPrefix(arguments.skipFilePluginOpt)
         arguments.skipFiles += filename
-        // Be annoying and warn because users are not supposed to use this
       } else if (option == arguments.genBundleElementsOpt) {
         val msg = s"'${arguments.genBundleElementsOpt}' is now default behavior, you can remove the scalacOption."
         global.reporter.warning(NoPosition, msg)

--- a/plugin/src/main/scala/chisel3/internal/plugin/ChiselPlugin.scala
+++ b/plugin/src/main/scala/chisel3/internal/plugin/ChiselPlugin.scala
@@ -69,8 +69,6 @@ class ChiselPlugin(val global: Global) extends Plugin {
         val filename = option.stripPrefix(arguments.skipFilePluginOpt)
         arguments.skipFiles += filename
         // Be annoying and warn because users are not supposed to use this
-        val msg = s"Option -P:${ChiselPlugin.name}:$option should only be used for internal chisel3 compiler purposes!"
-        global.reporter.warning(NoPosition, msg)
       } else if (option == arguments.genBundleElementsOpt) {
         val msg = s"'${arguments.genBundleElementsOpt}' is now default behavior, you can remove the scalacOption."
         global.reporter.warning(NoPosition, msg)

--- a/src/main/scala/chisel3/aop/Select.scala
+++ b/src/main/scala/chisel3/aop/Select.scala
@@ -316,7 +316,7 @@ object Select {
   }
 
   /** Selects a kind of arithmetic or logical operator directly instantiated within given module
-    * The kind of operators are contained in [[chisel3.internal.firrtl.PrimOp]]
+    * The kind of operators are contained in `chisel3.internal.firrtl.PrimOp`
     * @param opKind the kind of operator, e.g. "mux", "add", or "bits"
     * @param module
     */

--- a/src/main/scala/chisel3/aop/injecting/InjectStatement.scala
+++ b/src/main/scala/chisel3/aop/injecting/InjectStatement.scala
@@ -7,7 +7,7 @@ import firrtl.annotations.{Annotation, ModuleTarget, NoTargetAnnotation, SingleT
 
 /** Contains all information needed to inject statements into a module
   *
-  * Generated when a [[InjectingAspect]] is consumed by a [[AspectPhase]]
+  * Generated when a [[InjectingAspect]] is consumed by a `AspectPhase`
   * Consumed by [[InjectingPhase]]
   *
   * @param module Module to inject code into at the end of the module

--- a/src/main/scala/chisel3/stage/ChiselAnnotations.scala
+++ b/src/main/scala/chisel3/stage/ChiselAnnotations.scala
@@ -225,7 +225,7 @@ object CircuitSerializationAnnotation {
 
 import CircuitSerializationAnnotation._
 
-/** Wraps a [[Circuit]] for serialization via [[CustomFileEmission]]
+/** Wraps a `Circuit` for serialization via `CustomFileEmission`
   * @param circuit a Chisel Circuit
   * @param filename name of destination file (excludes file extension)
   * @param format serialization file format (sets file extension)

--- a/src/main/scala/chisel3/stage/ChiselStage.scala
+++ b/src/main/scala/chisel3/stage/ChiselStage.scala
@@ -176,8 +176,8 @@ object ChiselStage {
       .get
   }
 
-  /** Return a [[firrtl.ir.Circuit]] for a [[chisel3.internal.firrtl.Circuit]](aka chirrtl)
-    * @param chirrtl [[chisel3.internal.firrtl.Circuit]] which need to be converted to [[firrtl.ir.Circuit]]
+  /** Return a `firrtl.ir.Circuit` for a chisel3.internal.firrtl.Circuit` (aka chirrtl)
+    * @param chirrtl `chisel3.internal.firrtl.Circuit` which need to be converted to `firrtl.ir.Circuit`
     */
   def convert(chirrtl: cir.Circuit): fir.Circuit = {
     val phase = new ChiselPhase {

--- a/src/main/scala/chisel3/stage/phases/AspectPhase.scala
+++ b/src/main/scala/chisel3/stage/phases/AspectPhase.scala
@@ -12,7 +12,7 @@ import scala.collection.mutable
 
 /** Phase that consumes all Aspects and calls their toAnnotationSeq methods.
   *
-  * Consumes the [[chisel3.stage.DesignAnnotation]] and converts every [[Aspect]] into their annotations prior to executing FIRRTL
+  * Consumes the [[chisel3.stage.DesignAnnotation]] and converts every `Aspect` into their annotations prior to executing FIRRTL
   */
 class AspectPhase extends Phase {
   def transform(annotations: AnnotationSeq): AnnotationSeq = {

--- a/src/main/scala/chisel3/stage/phases/Checks.scala
+++ b/src/main/scala/chisel3/stage/phases/Checks.scala
@@ -8,7 +8,7 @@ import firrtl.AnnotationSeq
 import firrtl.annotations.Annotation
 import firrtl.options.{Dependency, OptionsException, Phase}
 
-/** Sanity checks an [[firrtl.AnnotationSeq!]] before running the main [[firrtl.options.Phase]]s of
+/** Sanity checks an [[firrtl.AnnotationSeq]] before running the main [[firrtl.options.Phase]]s of
   * `chisel3.stage.ChiselStage`.
   */
 class Checks extends Phase {

--- a/src/main/scala/chisel3/stage/phases/Checks.scala
+++ b/src/main/scala/chisel3/stage/phases/Checks.scala
@@ -8,8 +8,8 @@ import firrtl.AnnotationSeq
 import firrtl.annotations.Annotation
 import firrtl.options.{Dependency, OptionsException, Phase}
 
-/** Sanity checks an [[firrtl.AnnotationSeq]] before running the main [[firrtl.options.Phase]]s of
-  * [[chisel3.stage.ChiselStage]].
+/** Sanity checks an [[firrtl.AnnotationSeq!]] before running the main [[firrtl.options.Phase]]s of
+  * `chisel3.stage.ChiselStage`.
   */
 class Checks extends Phase {
 

--- a/src/main/scala/chisel3/stage/phases/Convert.scala
+++ b/src/main/scala/chisel3/stage/phases/Convert.scala
@@ -11,10 +11,10 @@ import firrtl.stage.{FirrtlCircuitAnnotation, RunFirrtlTransformAnnotation}
 
 import scala.annotation.nowarn
 
-/** This prepares a [[ChiselCircuitAnnotation]] for compilation with FIRRTL. This does three things:
-  *   - Uses [[chisel3.internal.firrtl.Converter]] to generate a [[FirrtlCircuitAnnotation]]
-  *   - Extracts all [[firrtl.annotations.Annotation]]s from the [[chisel3.internal.firrtl.Circuit]]
-  *   - Generates any needed [[RunFirrtlTransformAnnotation]]s from extracted [[firrtl.annotations.Annotation]]s
+/** This prepares a `ChiselCircuitAnnotation for compilation with FIRRTL. This does three things:
+  *   - Uses `chisel3.internal.firrtl.Converter` to generate a FirrtlCircuitAnnotation`
+  *   - Extracts all `firrtl.annotations.Annotation`s from the `chisel3.internal.firrtl.Circuit`
+  *   - Generates any needed `RunFirrtlTransformAnnotation`s from extracted `firrtl.annotations.Annotation`s
   */
 class Convert extends Phase {
 

--- a/src/main/scala/chisel3/stage/phases/MaybeInjectingPhase.scala
+++ b/src/main/scala/chisel3/stage/phases/MaybeInjectingPhase.scala
@@ -6,7 +6,7 @@ import chisel3.aop.injecting.{InjectStatement, InjectingPhase}
 import firrtl.AnnotationSeq
 import firrtl.options.Phase
 
-/** Run `InjectingPhase` if a `InjectStatement`` is present.
+/** Run `InjectingPhase` if a `InjectStatement` is present.
   */
 class MaybeInjectingPhase extends Phase {
   override def prerequisites = Seq.empty

--- a/src/main/scala/chisel3/stage/phases/MaybeInjectingPhase.scala
+++ b/src/main/scala/chisel3/stage/phases/MaybeInjectingPhase.scala
@@ -6,7 +6,7 @@ import chisel3.aop.injecting.{InjectStatement, InjectingPhase}
 import firrtl.AnnotationSeq
 import firrtl.options.Phase
 
-/** Run [[InjectingPhase]] if a [[InjectStatement]] is present.
+/** Run `InjectingPhase` if a `InjectStatement`` is present.
   */
 class MaybeInjectingPhase extends Phase {
   override def prerequisites = Seq.empty

--- a/src/main/scala/chisel3/util/BitPat.scala
+++ b/src/main/scala/chisel3/util/BitPat.scala
@@ -46,7 +46,7 @@ object BitPat {
     (bits, mask, count)
   }
 
-  /** Creates a [[BitPat]] literal from a string.
+  /** Creates a `BitPat` literal from a string.
     *
     * @param n the literal value as a string, in binary, prefixed with 'b'
     * @note legal characters are '0', '1', and '?', as well as '_' and white
@@ -57,7 +57,7 @@ object BitPat {
     new BitPat(bits, mask, width)
   }
 
-  /** Creates a [[BitPat]] of all don't cares of the specified bitwidth.
+  /** Creates a `BitPat` of all don't cares of the specified bitwidth.
     *
     * @example {{{
     * val myDontCare = BitPat.dontCare(4)  // equivalent to BitPat("b????")
@@ -65,7 +65,7 @@ object BitPat {
     */
   def dontCare(width: Int): BitPat = BitPat("b" + ("?" * width))
 
-  /** Creates a [[BitPat]] of all 1 of the specified bitwidth.
+  /** Creates a `BitPat` of all 1 of the specified bitwidth.
     *
     * @example {{{
     * val myY = BitPat.Y(4)  // equivalent to BitPat("b1111")
@@ -73,7 +73,7 @@ object BitPat {
     */
   def Y(width: Int = 1): BitPat = BitPat("b" + ("1" * width))
 
-  /** Creates a [[BitPat]] of all 0 of the specified bitwidth.
+  /** Creates a `BitPat` of all 0 of the specified bitwidth.
     *
     * @example {{{
     * val myN = BitPat.N(4)  // equivalent to BitPat("b0000")
@@ -120,8 +120,8 @@ object BitPat {
 package experimental {
   object BitSet {
 
-    /** Construct a [[BitSet]] from a sequence of [[BitPat]].
-      * All [[BitPat]] must have the same width.
+    /** Construct a `BitSet` from a sequence of BitPat`.
+      * All `BitPat` must have the same width.
       */
     def apply(bitpats: BitPat*): BitSet = {
       val bs = new BitSet { def terms = bitpats.flatMap(_.terms).toSet }
@@ -130,13 +130,13 @@ package experimental {
       bs
     }
 
-    /** Empty [[BitSet]]. */
+    /** Empty `BitSet`. */
     val empty: BitSet = new BitSet {
       def terms = Set()
     }
 
-    /** Construct a [[BitSet]] from String.
-      * each line should be a valid [[BitPat]] string with the same width.
+    /** Construct a `BitSet` from String.
+      * each line should be a valid `BitPat` string with the same width.
       */
     def fromString(str: String): BitSet = {
       val bs = new BitSet { def terms = str.split('\n').map(str => BitPat(str)).toSet }
@@ -145,24 +145,24 @@ package experimental {
       bs
     }
 
-    /** Construct a [[BitSet]] matching a range of value
+    /** Construct a `BitSet` matching a range of value
       * automatically infer width by the bit length of (start + length - 1)
       *
       * @param start The smallest matching value
       * @param length The length of the matching range
-      * @return A [[BitSet]] matching exactly all inputs in range [start, start + length)
+      * @return A `BitSet` matching exactly all inputs in range [start, start + length)
       */
     def fromRange(
       start:  BigInt,
       length: BigInt
     ): BitSet = fromRange(start, length, (start + length - 1).bitLength)
 
-    /** Construct a [[BitSet]] matching a range of value
+    /** Construct a `BitSet` matching a range of value
       *
       * @param start The smallest matching value
       * @param length The length of the matching range
-      * @param width The width of the constructed [[BitSet]]. If not given, the returned [[BitSet]] have the width of the maximum possible matching value.
-      * @return A [[BitSet]] matching exactly all inputs in range [start, start + length)
+      * @param width The width of the constructed `BitSet`. If not given, the returned `BitSet` have the width of the maximum possible matching value.
+      * @return A `BitSet` matcing exactly all inputs in range [start, start + length)
       */
     def fromRange(
       start:  BigInt,
@@ -207,10 +207,10 @@ package experimental {
     }
   }
 
-  /** A Set of [[BitPat]] represents a set of bit vector with mask. */
+  /** A Set of `BitPat` represents a set of bit vector with mask. */
   sealed trait BitSet { outer =>
 
-    /** all [[BitPat]] elements in [[terms]] make up this [[BitSet]].
+    /** all `BitPat` elements in [[terms]] make up this `BitSet`.
       * all [[terms]] should be have the same width.
       */
     def terms: Set[BitPat]
@@ -225,31 +225,31 @@ package experimental {
     import BitPat.bitPatOrder
     override def toString: String = terms.toSeq.sorted.mkString("\n")
 
-    /** whether this [[BitSet]] is empty (i.e. no value matches) */
+    /** whether this `BitSet` is empty (i.e. no value matches) */
     def isEmpty: Boolean = terms.forall(_.isEmpty)
 
     def matches(input: UInt) = VecInit(terms.map(_ === input).toSeq).asUInt.orR
 
-    /** Check whether this [[BitSet]] overlap with that [[BitSet]], i.e. !(intersect.isEmpty)
+    /** Check whether this `BitSet` overlap with that `BitSet`, i.e. !(intersect.isEmpty)
       *
-      * @param that [[BitSet]] to be checked.
-      * @return true if this and that [[BitSet]] have overlap.
+      * @param that `BitSet` to be checked.
+      * @return true if this and that `BitSet` have overlap.
       */
     def overlap(that: BitSet): Boolean =
       !terms.flatMap(a => that.terms.map(b => (a, b))).forall { case (a, b) => !a.overlap(b) }
 
-    /** Check whether this [[BitSet]] covers that (i.e. forall b matches that, b also matches this)
+    /** Check whether this `BitSet` covers that (i.e. forall b matches that, b also matches this)
       *
-      * @param that [[BitSet]] to be covered
-      * @return true if this [[BitSet]] can cover that [[BitSet]]
+      * @param that `BitSet` to b covered
+      * @return true if this `BitSet` can cover that `BitSet`
       */
     def cover(that: BitSet): Boolean =
       that.subtract(this).isEmpty
 
-    /** Intersect `this` and `that` [[BitSet]].
+    /** Intersect `this` and `that` `BitSet`.
       *
-      * @param that [[BitSet]] to be intersected.
-      * @return a [[BitSet]] containing all elements of `this` that also belong to `that`.
+      * @param that `BitSet` to be intersected.
+      * @return a `BitSet` containing all elements of `this` that also belong to `that`.
       */
     def intersect(that: BitSet): BitSet =
       terms
@@ -257,31 +257,31 @@ package experimental {
         .filterNot(_.isEmpty)
         .fold(BitSet.empty)(_.union(_))
 
-    /** Subtract that from this [[BitSet]].
+    /** Subtract that from this `BitSet`.
       *
-      * @param that subtrahend [[BitSet]].
-      * @return a [[BitSet]] containing elements of `this` which are not the elements of `that`.
+      * @param that subtrahend `BitSet`.
+      * @return a `BitSet` contining elements of `this` which are not the elements of `that`.
       */
     def subtract(that: BitSet): BitSet =
       terms.map { a =>
         that.terms.map(b => a.subtract(b)).fold(a)(_.intersect(_))
       }.filterNot(_.isEmpty).fold(BitSet.empty)(_.union(_))
 
-    /** Union this and that [[BitSet]]
+    /** Union this and that `BitSet`
       *
-      * @param that [[BitSet]] to union.
-      * @return a [[BitSet]] containing all elements of `this` and `that`.
+      * @param that `BitSet` to union.
+      * @return a `BitSet` containing all elements of `this` and `that`.
       */
     def union(that: BitSet): BitSet = new BitSet {
       def terms = outer.terms ++ that.terms
     }
 
-    /** Test whether two [[BitSet]] matches the same set of value
+    /** Test whether two `BitSet` matches the same set of value
       *
       * @note
       * This method can be very expensive compared to ordinary == operator between two Objects
       *
-      * @return true if two [[BitSet]] is same.
+      * @return true if two `BitSet` is same.
       */
     override def equals(obj: Any): Boolean = {
       obj match {
@@ -357,24 +357,24 @@ sealed class BitPat(val value: BigInt, val mask: BigInt, val width: Int)
     new BitPat((value << that.getWidth) + that.value, (mask << that.getWidth) + that.mask, this.width + that.getWidth)
   }
 
-  /** Check whether this [[BitPat]] overlap with that [[BitPat]], i.e. !(intersect.isEmpty)
+  /** Check whether this `BitPat` overlap with that `BitPat`, i.e. !(intersect.isEmpty)
     *
-    * @param that [[BitPat]] to be checked.
-    * @return true if this and that [[BitPat]] have overlap.
+    * @param that `BitPat` to be checked.
+    * @return true if this and that `BitPat` have overlap.
     */
   def overlap(that: BitPat): Boolean = ((mask & that.mask) & (value ^ that.value)) == 0
 
-  /** Check whether this [[BitSet]] covers that (i.e. forall b matches that, b also matches this)
+  /** Check whether this `BitSet` covers that (i.e. forall b matches that, b also matches this)
     *
-    * @param that [[BitPat]] to be covered
-    * @return true if this [[BitSet]] can cover that [[BitSet]]
+    * @param that `BitPat` to be covered
+    * @return true if this `BitSet` can cover that `BitSet`
     */
   def cover(that: BitPat): Boolean = (mask & (~that.mask | (value ^ that.value))) == 0
 
-  /** Intersect `this` and `that` [[BitPat]].
+  /** Intersect `this` and `that` `BitPat`.
     *
-    * @param that [[BitPat]] to be intersected.
-    * @return a [[BitSet]] containing all elements of `this` that also belong to `that`.
+    * @param that `BitPat` to be intersected.
+    * @return a `BitSet` containing all elements of `this` that also belong to `that`.
     */
   def intersect(that: BitPat): BitSet = {
     if (!overlap(that)) {
@@ -384,10 +384,10 @@ sealed class BitPat(val value: BigInt, val mask: BigInt, val width: Int)
     }
   }
 
-  /** Subtract a [[BitPat]] from this.
+  /** Subtract a `BitPat` from this.
     *
-    * @param that subtrahend [[BitPat]].
-    * @return a [[BitSet]] containing elements of `this` which are not the elements of `that`.
+    * @param that subtrahend `BitPat`.
+    * @return a `BitSet` containing elements of `this` which are not the elements of `that`.
     */
   def subtract(that: BitPat): BitSet = {
     require(width == that.width)
@@ -424,7 +424,7 @@ sealed class BitPat(val value: BigInt, val mask: BigInt, val width: Int)
 
   override def isEmpty: Boolean = false
 
-  /** Generate raw string of a [[BitPat]]. */
+  /** Generate raw string of a `BitPat`. */
   def rawString: String = _rawString
 
   // This is micro-optimized and memoized because it is used for lots of BitPat operations

--- a/src/main/scala/chisel3/util/Valid.scala
+++ b/src/main/scala/chisel3/util/Valid.scala
@@ -55,8 +55,8 @@ class Valid[+T <: Data](gen: T) extends Bundle {
   *   }
   * }}}
   *
-  * To convert this to a "valid" interface, you wrap it with a call to the [[Valid$.apply `Valid` companion object's
-  * apply method]]:
+  * To convert this to a `valid`` interface, you wrap it with a call to the `Valid`.apply `Valid` companion object's
+  * apply method:
   * {{{
   *   val bar = Valid(new MyBundle)
   * }}}
@@ -69,7 +69,8 @@ class Valid[+T <: Data](gen: T) extends Bundle {
   *   }
   * }}}
   *
-  * In addition to adding the `valid` bit, a [[Valid.fire]] method is also added that returns the `valid` bit. This
+  * In addition to adding the `valid` bit, a `Valid.fire` method is also added that returns the `valid` bit. This
+  *
   * provides a similarly named interface to [[DecoupledIO]]'s fire.
   *
   * @see [[Decoupled$ DecoupledIO Factory]]

--- a/src/main/scala/chisel3/util/Valid.scala
+++ b/src/main/scala/chisel3/util/Valid.scala
@@ -55,8 +55,7 @@ class Valid[+T <: Data](gen: T) extends Bundle {
   *   }
   * }}}
   *
-  * To convert this to a `valid`` interface, you wrap it with a call to the `Valid`.apply `Valid` companion object's
-  * apply method:
+  * To convert this to a `valid` interface, you wrap it with a call to the `Valid` companion object's apply method:
   * {{{
   *   val bar = Valid(new MyBundle)
   * }}}

--- a/src/main/scala/chisel3/util/experimental/ForceNames.scala
+++ b/src/main/scala/chisel3/util/experimental/ForceNames.scala
@@ -82,7 +82,7 @@ object forceName {
 
 /** Links the user-specified name to force to, with the signal/instance in the FIRRTL design
   *
-  * @throws CustomTransformException when the signal is renamed to >1 target
+  * @throws firrtl.CustomTransformException when the signal is renamed to >1 target
   * @param target signal/instance to force the name
   * @param name name to force it to be
   */

--- a/src/main/scala/chisel3/util/experimental/LoadMemoryTransform.scala
+++ b/src/main/scala/chisel3/util/experimental/LoadMemoryTransform.scala
@@ -117,10 +117,10 @@ object loadMemoryFromFile {
 /** [[loadMemoryFromFileInline]] is an annotation generator that helps with loading a memory from a text file inlined in
   * the Verilog module. This relies on Verilator and Verilog's `\$readmemh` or `\$readmemb`.
   *
-  * This annotation, when the FIRRTL compiler runs, triggers the [[MemoryFileInlineAnnotation]] that will add Verilog
+  * This annotation, when the FIRRTL compiler runs, triggers the `MemoryFileInlineAnnotation` that will add Verilog
   * directives inlined to the module enabling the specified memories to be initialized from files.
-  * The module supports both `hex` and `bin` files by passing the appropriate [[MemoryLoadFileType.FileType]] argument with
-  * [[MemoryLoadFileType.Hex]] or [[MemoryLoadFileType.Binary]]. Hex is the default.
+  * The module supports both `hex` and `bin` files by passing the appropriate `MemoryLoadFileType.FileType`` argument with
+  * `MemoryLoadFileType.Hex` or `MemoryLoadFileType.Binary`. Hex is the default.
   *
   * ==Example module==
   *

--- a/src/main/scala/chisel3/util/experimental/decode/DecoderBundle.scala
+++ b/src/main/scala/chisel3/util/experimental/decode/DecoderBundle.scala
@@ -64,8 +64,8 @@ class DecodeBundle(fields: Seq[DecodeField[_, _]]) extends Record {
 /**
   * A structured way of generating large decode tables, often found in CPU instruction decoders
   *
-  * Each field is a [[DecoderPattern]], its genTable method will be called for each possible pattern and gives expected
-  * output for this field as a [[BitPat]].
+  * Each field is a `DecoderPattern`, its genTable method will be called for each possible pattern and gives expected
+  * output for this field as a `BitPat`.
   *
   * @param patterns all possible input patterns, should implement trait DecoderPattern
   * @param fields   all fields as decoded output

--- a/src/main/scala/chisel3/util/experimental/decode/QMCMinimizer.scala
+++ b/src/main/scala/chisel3/util/experimental/decode/QMCMinimizer.scala
@@ -171,32 +171,32 @@ object QMCMinimizer extends Minimizer {
   private def getCover(implicants: Seq[Implicant], minterms: Seq[Implicant]): Seq[Implicant] = {
 
     /* Calculate the implementation cost (using comparators) of a list of implicants, more don't cares is cheaper
-      *
-      * @param cover Implicant list
-      * @return How many comparators need to implement this list of implicants
-      */
+     *
+     * @param cover Implicant list
+     * @return How many comparators need to implement this list of implicants
+     */
     def getCost(cover: Seq[Implicant]): Int = cover.map(_.bp.mask.bitCount).sum
 
     /* Determine if one combination of prime implicants is cheaper when implementing as comparators.
-      * Shorter term list is cheaper, term list with more don't cares is cheaper (less comparators)
-      *
-      * @param a    Operand a
-      * @param b    Operand b
-      * @return `a` < `b`
-      */
+     * Shorter term list is cheaper, term list with more don't cares is cheaper (less comparators)
+     *
+     * @param a    Operand a
+     * @param b    Operand b
+     * @return `a` < `b`
+     */
     def cheaper(a: Seq[Implicant], b: Seq[Implicant]): Boolean = {
       val ca = getCost(a)
       val cb = getCost(b)
 
       /* If `a` < `b`
-        *
-        * Like comparing the dictionary order of two strings.
-        * Define `a` < `b` if both `a` and `b` are empty.
-        *
-        * @param a Operand a
-        * @param b Operand b
-        * @return `a` < `b`
-        */
+       *
+       * Like comparing the dictionary order of two strings.
+       * Define `a` < `b` if both `a` and `b` are empty.
+       *
+       * @param a Operand a
+       * @param b Operand b
+       * @return `a` < `b`
+       */
       @tailrec
       def listLess(a: Seq[Implicant], b: Seq[Implicant]): Boolean =
         b.nonEmpty && (a.isEmpty || a.head < b.head || a.head == b.head && listLess(a.tail, b.tail))

--- a/src/main/scala/chisel3/util/experimental/decode/QMCMinimizer.scala
+++ b/src/main/scala/chisel3/util/experimental/decode/QMCMinimizer.scala
@@ -170,14 +170,14 @@ object QMCMinimizer extends Minimizer {
     */
   private def getCover(implicants: Seq[Implicant], minterms: Seq[Implicant]): Seq[Implicant] = {
 
-    /** Calculate the implementation cost (using comparators) of a list of implicants, more don't cares is cheaper
+    /* Calculate the implementation cost (using comparators) of a list of implicants, more don't cares is cheaper
       *
       * @param cover Implicant list
       * @return How many comparators need to implement this list of implicants
       */
     def getCost(cover: Seq[Implicant]): Int = cover.map(_.bp.mask.bitCount).sum
 
-    /** Determine if one combination of prime implicants is cheaper when implementing as comparators.
+    /* Determine if one combination of prime implicants is cheaper when implementing as comparators.
       * Shorter term list is cheaper, term list with more don't cares is cheaper (less comparators)
       *
       * @param a    Operand a
@@ -188,7 +188,7 @@ object QMCMinimizer extends Minimizer {
       val ca = getCost(a)
       val cb = getCost(b)
 
-      /** If `a` < `b`
+      /* If `a` < `b`
         *
         * Like comparing the dictionary order of two strings.
         * Define `a` < `b` if both `a` and `b` are empty.

--- a/src/main/scala/chisel3/util/pla.scala
+++ b/src/main/scala/chisel3/util/pla.scala
@@ -31,7 +31,7 @@ object pla {
     * This behavior is formally described as: if product terms that make one function value to `1` is solely consisted
     * of don't-cares (`?`s), then this function is implemented as a constant `1`.
     *
-    * @param table A [[Seq]] of inputs -> outputs mapping
+    * @param table A `Seq` of inputs -> outputs mapping
     * @param invert A [[BitPat]] specify which bit of the output should be inverted. `1` means the correspond position
     *               of the output should be inverted in the PLA, a `0` or a `?` means direct output from the OR matrix.
     * @return the (input, output) [[Wire]] of [[UInt]] of the constructed pla.

--- a/src/main/scala/circt/stage/phases/CIRCT.scala
+++ b/src/main/scala/circt/stage/phases/CIRCT.scala
@@ -115,7 +115,7 @@ private[this] object Exceptions {
 
 }
 
-/** A phase that calls and runs CIRCT, specifically `firtool`, while preserving an [[AnnotationSeq]] API.
+/** A phase that calls and runs CIRCT, specifically `firtool`, while preserving an `AnnotationSeq` API.
   *
   * This is analogous to [[firrtl.stage.phases.Compiler]].
   */

--- a/src/main/scala/circt/stage/phases/Checks.scala
+++ b/src/main/scala/circt/stage/phases/Checks.scala
@@ -9,7 +9,7 @@ import firrtl.annotations.Annotation
 import firrtl.options.{Dependency, OptionsException, Phase, TargetDirAnnotation}
 import firrtl.stage.OutputFileAnnotation
 
-/** Check properties of an [[AnnotationSeq]] to look for errors before running CIRCT. */
+/** Check properties of an [[firrtl.AnnotationSeq!]] to look for errors before running CIRCT. */
 class Checks extends Phase {
 
   override def prerequisites = Seq.empty


### PR DESCRIPTION
Get rid of warnings in / doc build
Many `[[...]]` fixed but a large of class of these warnings
did not work no matter what I did. So changed these cases to just replace with back-ticks
Printable docs are very problematic, use Warning suppression for those 2
