### PR TITLE
Bump firtool to 1.31.0

### DIFF
--- a/.github/workflows/install-circt/action.yml
+++ b/.github/workflows/install-circt/action.yml
@@ -4,7 +4,7 @@ inputs:
   version:
     description: 'version to install'
     required: false
-    default: 'firtool-1.30.0'
+    default: 'firtool-1.31.0'
 
 runs:
   using: composite

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
         jvm: ["8"]
         scala: ["2.13.10", "2.12.17"]
         espresso: ["2.4"]
-        circt: ["firtool-1.30.0"]
+        circt: ["firtool-1.31.0"]
     runs-on: ${{ matrix.system }}
 
     steps:


### PR DESCRIPTION
We [can't use 1.32.0](https://github.com/chipsalliance/chisel3/pull/3040#issuecomment-1447238681) so just bump to 1.31.0 for Chisel 3.6.0-RC2.