### PR TITLE
(draft) Change signature of macro-based `chisel3.Bits.unary_~` to fix IntelliJ highlighting issue

### DIFF
--- a/core/src/main/scala-2/chisel3/Bits.scala
+++ b/core/src/main/scala-2/chisel3/Bits.scala
@@ -37,6 +37,8 @@ private[chisel3] sealed trait ToBoolable extends Element {
   */
 sealed abstract class Bits(private[chisel3] val width: Width) extends BitsImpl with ToBoolable {
 
+  type Self <: Bits
+
   /** Tail operator
     *
     * @param n the number of bits to remove
@@ -170,7 +172,7 @@ sealed abstract class Bits(private[chisel3] val width: Width) extends BitsImpl w
     * @return this $coll with each bit inverted
     * @group Bitwise
     */
-  final def unary_~ : Bits = macro SourceInfoWhiteboxTransform.noArg
+  final def unary_~ : Self = macro SourceInfoWhiteboxTransform.noArg
 
   /** @group SourceInfoTransformMacro */
   def do_unary_~(implicit sourceInfo: SourceInfo): Bits = _impl_unary_~
@@ -293,6 +295,7 @@ object Bits extends UIntFactory
   * @define constantWidth  @note The width of the returned $coll is unchanged, i.e., `width of this`.
   */
 sealed class UInt private[chisel3] (width: Width) extends Bits(width) with UIntImpl {
+  type Self = UInt
 
   // TODO: refactor to share documentation with Num or add independent scaladoc
   /** Unary negation (expanding width)
@@ -566,6 +569,7 @@ object UInt extends UIntFactory
   * @define constantWidth  @note The width of the returned $coll is unchanged, i.e., `width of this`.
   */
 sealed class SInt private[chisel3] (width: Width) extends Bits(width) with SIntImpl {
+  override type Self = SInt
 
   /** Unary negation (constant width)
     *
@@ -807,6 +811,8 @@ sealed class AsyncReset(private[chisel3] val width: Width = Width(1)) extends As
   * @define numType $coll
   */
 sealed class Bool() extends UInt(1.W) with BoolImpl with Reset {
+  //Compiler fails with error
+  //override type Self = Bool
 
   // REVIEW TODO: Why does this need to exist and have different conventions
   // than Bits?


### PR DESCRIPTION
Hello, I am from the IntelliJ Scala Plugin team
We have an error report about `~` method not being resolved in IntelliJ with Scala Plugin:
https://youtrack.jetbrains.com/issue/SCL-15350/Operators-not-recognized-chisel3-library

The method is macro-based.
It declares to return `Bits`, but the macro substitutes it with `UInt`/ `Boolean` / `SInt`.
IntelliJ can't detect it because it knows nothing of the macro logic.

As I mentioned in the [comment](https://youtrack.jetbrains.com/issue/SCL-15350/Operators-not-recognized-chisel3-library#focus=Comments-27-11368838.0-0)
There is a chance that this particular issue could be partially fixed by improving the method return type to use abstract type `type Self <: Bits`.

JFTR I know nothing about chisel details
It's a draft proposal, more for a discussion initiation...
