### PR TITLE
fix: firtool lowering options CLI flag

### DIFF
--- a/docs/src/explanations/testing.md
+++ b/docs/src/explanations/testing.md
@@ -444,12 +444,12 @@ SystemVerilog may be difficult for you to use FileCheck with due to the default
 SystemVerilog lowering, emission, and pretty printing used by `firtool`.  To
 make it easier to write your tests, we suggest using the following options:
 
-- `-loweringOptions=emittedLineLength=160` to increase the allowable line
+- `--lowering-options=emittedLineLength=160` to increase the allowable line
   length.  By default, `firtool` will wrap lines that exceed 80 characters.  You
   may consider using a _very long_ line length (e.g., 8192) to avoid this
   problem altogether.
 
-- `-loweringOptions=disallowLocalVariables` to disable generation of `automatic
+- `--lowering-options=disallowLocalVariables` to disable generation of `automatic
   logic` temporaries in always blocks.  This can cause temporaries to spill
   within an always block which may be slightly unexpected.
 


### PR DESCRIPTION
As of `firtool` 1.62.0 the format is `--lowering-options=...`

#### Type of Improvement

Documentation or website-related

#### Desired Merge Strategy

Squash

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
