### PR TITLE
Ensure that OverrideSerializationClass supports multiple annotations

### DIFF
--- a/firrtl/src/main/scala/firrtl/annotations/JsonProtocol.scala
+++ b/firrtl/src/main/scala/firrtl/annotations/JsonProtocol.scala
@@ -198,7 +198,7 @@ object JsonProtocol extends LazyLogging {
       anno match {
         case anno: OverrideSerializationClass =>
           val existing = tagOverride.put(anno.getClass, anno.serializationClassOverride)
-          if (existing.isDefined) {
+          if (existing.isDefined && existing.get != anno.serializationClassOverride) {
             throw new Exception(
               s"Class ${anno.getClass.getName} has multiple serialization class overrides: ${existing.get}, ${anno.serializationClassOverride}"
             )

--- a/firrtl/src/test/scala/firrtl/JsonProtocolSpec.scala
+++ b/firrtl/src/test/scala/firrtl/JsonProtocolSpec.scala
@@ -129,6 +129,11 @@ class JsonProtocolSpec extends AnyFlatSpec with Matchers {
     res should include(""""class":"a.b.c.d.Foo"""")
   }
 
+  it should "work for the same class if it has the same override" in {
+    val annos = AnnotationWithOverride("foo") :: AnnotationWithOverride("foo") :: Nil
+    JsonProtocol.serialize(annos)
+  }
+
   it should "error if inconsistent overrides are used" in {
     val annos = AnnotationWithOverride("foo") :: AnnotationWithOverride("bar") :: Nil
     val e = the[Exception] thrownBy JsonProtocol.serialize(annos)


### PR DESCRIPTION
Goofed in https://github.com/chipsalliance/chisel/pull/4953, it only supports 1 instance of the annotation at the moment lol.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Bugfix (unreleased)


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
