### PR TITLE
Empty prefixes should be ignored in emission

### DIFF
--- a/core/src/main/scala/chisel3/experimental/prefix.scala
+++ b/core/src/main/scala/chisel3/experimental/prefix.scala
@@ -20,8 +20,9 @@ import chisel3.internal.{Builder, HasId}
   */
 object prefix {
 
-  /** Use to add a prefix to any components generated in the provided scope
-    * The prefix is the name of the provided which, which may not be known yet.
+  /** Use to add a prefix to any components generated in the provided scope.
+    *
+    * The prefix is the name of the provided `HasId`, which may not be known yet.
     *
     * @param name The signal/instance whose name will be the prefix
     * @param f a function for which any generated components are given the prefix
@@ -37,10 +38,11 @@ object prefix {
     ret
   }
 
-  /** Use to add a prefix to any components generated in the provided scope
+  /** Use to add a prefix to any components generated in the provided scope.
+    *
     * The prefix is a string, which must be known when this function is used.
     *
-    * @param name The name which will be the prefix
+    * @param name The name which will be the prefix (and empty name is ignored)
     * @param f a function for which any generated components are given the prefix
     * @tparam T The return type of the provided function
     * @return The return value of the provided function
@@ -60,12 +62,7 @@ object prefix {
   // TODO(adkian-sifive) This is factored out because the Scala 3
   // compiler fails to diambiguate the apply overloads using the type
   // parameter
-  private[chisel3] def applyString[T](name: String)(f: => T): T = {
-    Builder.pushPrefix(name)
-    val ret = f
-    if (Builder.getPrefix.nonEmpty) Builder.popPrefix()
-    ret
-  }
+  private[chisel3] def applyString[T](name: String)(f: => T): T = apply(name)(f)
 }
 
 /** Use to eliminate any existing prefixes within the provided scope.

--- a/core/src/main/scala/chisel3/internal/package.scala
+++ b/core/src/main/scala/chisel3/internal/package.scala
@@ -44,8 +44,11 @@ package object internal {
         builder.append('_')
       }
       prefix.foreach { p =>
-        builder.append(p)
-        builder.append('_')
+        // Don't append _ if the prefix is empty
+        if (p.nonEmpty) {
+          builder.append(p)
+          builder.append('_')
+        }
       }
       if (temp) {
         // We've moved the leading _ to the front, drop it here


### PR DESCRIPTION


### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement


- Backend code generation


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash
#### Release Notes

Previously they would result in an extra '_' in the same of the signal.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
