### PR TITLE
[ci] Update all github actions

### DIFF
--- a/.github/workflows/backport-fixup.yml
+++ b/.github/workflows/backport-fixup.yml
@@ -28,7 +28,7 @@ jobs:
         original_pr: ${{ steps.original.outputs.pr }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Figure out backport PR number
         id: backport
         run: |
@@ -57,7 +57,7 @@ jobs:
     if: ${{ needs.resolve_prs.outputs.original_pr }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Copy over labels
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/build-scala-cli-example.yml
+++ b/.github/workflows/build-scala-cli-example.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         # Need to fetch full history for deriving version
         with:
           fetch-depth: 0
@@ -32,9 +32,9 @@ jobs:
           dir=$(dirname $(which firtool))
           echo "CHISEL_FIRTOOL_PATH=$dir" >> "$GITHUB_ENV"
       - name: Cache Scala-CLI
-        uses: coursier/cache-action@142d2738bd29f0eb9d44610828acb3a19809feab # v6.4.6
+        uses: coursier/cache-action@bebeeb0e6f48ebad66d3783946588ecf43114433 # v7.0.0
       - name: Setup Scala-CLI
-        uses: VirtusLab/scala-cli-setup@28971dc5a5d4e155d2e410220ab21948383baaf9 # v1.7.0
+        uses: VirtusLab/scala-cli-setup@77834b5926f3eb70869d8009530c65585f7a039b # v1.9.1
         with:
           jvm: adoptium:17
       - name: Generate Chisel Scala CLI Example
@@ -52,7 +52,7 @@ jobs:
         shell: bash
         run: scala-cli chisel-example.scala
       - name: Upload Example
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: chisel-example.scala
           path: chisel-example.scala

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,13 +75,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Cache Scala
-        uses: coursier/cache-action@142d2738bd29f0eb9d44610828acb3a19809feab # v6.4.6
+        uses: coursier/cache-action@bebeeb0e6f48ebad66d3783946588ecf43114433 # v7.0.0
       - name: Setup Scala
-        uses: VirtusLab/scala-cli-setup@28971dc5a5d4e155d2e410220ab21948383baaf9 # v1.7.0
+        uses: VirtusLab/scala-cli-setup@77834b5926f3eb70869d8009530c65585f7a039b # v1.9.1
         with:
           jvm: temurin:11
       - name: Publish
@@ -106,7 +106,7 @@ jobs:
     if: (github.event_name == 'push') && (github.ref_name == 'main')
     steps:
       - name: Download built website
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: website
       - name: Untar built website

--- a/.github/workflows/enable-bincompat-checking.yml
+++ b/.github/workflows/enable-bincompat-checking.yml
@@ -37,7 +37,7 @@ jobs:
       branches: ${{ steps.determine-branches.outputs.branches }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Check Valid
@@ -70,7 +70,7 @@ jobs:
         branch: ${{ fromJson(needs.determine_branches.outputs.branches) }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Create file
         run: |
           VERSION=${{ needs.determine_version.outputs.version }}

--- a/.github/workflows/install-filecheck/action.yml
+++ b/.github/workflows/install-filecheck/action.yml
@@ -10,7 +10,7 @@ runs:
   using: composite
   steps:
     - id: cache-filecheck
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: FileCheck
         key: filecheck-${{ runner.os }}-${{ inputs.version }}

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Build Release Notes
         id: release-notes
         uses: mikepenz/release-changelog-builder-action@5f3409748e2230350e149a7f7b5b8e9bcd785d44 # v4.1.1
@@ -43,7 +43,7 @@ jobs:
         run: echo "$CHANGELOG" >> $GITHUB_STEP_SUMMARY
       - name: Upload Release Notes (on release)
         if: github.event_name == 'release'
-        uses: softprops/action-gh-release@01570a1f39cb168c169c802c3bceb9e93fb10974 # v2.1.0
+        uses: softprops/action-gh-release@6da8fa9354ddfdc4aeace5fc48d7f679b5214090 # 2.4.1
         with:
           body: ${{ steps.release-notes.outputs.changelog }}
       - name: Error on uncategorized PRs

--- a/.github/workflows/scala-cli-example.yml
+++ b/.github/workflows/scala-cli-example.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Download Generated CLI Example
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: chisel-example.scala
       - name: Display Example
@@ -29,6 +29,6 @@ jobs:
           echo '```' >> $GITHUB_STEP_SUMMARY
       - name: Upload To Release Page
         if: github.event_name == 'release'
-        uses: softprops/action-gh-release@01570a1f39cb168c169c802c3bceb9e93fb10974 # v2.1.0
+        uses: softprops/action-gh-release@6da8fa9354ddfdc4aeace5fc48d7f679b5214090 # 2.4.1
         with:
           files: chisel-example.scala

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ inputs.ref }}
       - name: Install Tabby OSS Cad Suite
@@ -64,7 +64,7 @@ jobs:
           sudo apt install llvm-19-tools
           echo "/usr/lib/llvm-19/bin" >> $GITHUB_PATH
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'adopt'
           java-version: ${{ inputs.jvm }}
@@ -97,11 +97,11 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ inputs.ref }}
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'adopt'
           java-version: ${{ inputs.jvm }}
@@ -113,11 +113,11 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ inputs.ref }}
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'adopt'
           java-version: ${{ inputs.jvm }}
@@ -151,11 +151,11 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ inputs.ref }}
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'adopt'
           java-version: ${{ inputs.jvm }}
@@ -169,7 +169,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ inputs.ref }}
       - name: Install Tabby OSS Cad Suite
@@ -177,7 +177,7 @@ jobs:
       - name: Install Espresso
         uses: ./.github/workflows/install-espresso
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'adopt'
           java-version: ${{ inputs.jvm }}
@@ -203,11 +203,11 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ inputs.ref }}
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'adopt'
           java-version: ${{ inputs.jvm }}
@@ -222,13 +222,13 @@ jobs:
         scala: ["2.13.17"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ inputs.ref }}
       - name: Install Tabby OSS Cad Suite
         uses: ./.github/workflows/setup-oss-cad-suite
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'adopt'
           java-version: ${{ inputs.jvm }}
@@ -241,7 +241,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ inputs.ref }}
           # Need full history to correctly determine SNAPSHOT version
@@ -249,9 +249,9 @@ jobs:
       - name: Install Tabby OSS Cad Suite
         uses: ./.github/workflows/setup-oss-cad-suite
       - name: Cache Scala
-        uses: coursier/cache-action@142d2738bd29f0eb9d44610828acb3a19809feab # v6.4.6
+        uses: coursier/cache-action@bebeeb0e6f48ebad66d3783946588ecf43114433 # v7.0.0
       - name: Setup Scala
-        uses: VirtusLab/scala-cli-setup@28971dc5a5d4e155d2e410220ab21948383baaf9 # v1.7.0
+        uses: VirtusLab/scala-cli-setup@77834b5926f3eb70869d8009530c65585f7a039b # v1.9.1
         with:
           jvm: adoptium:17
       - name: Setup Node
@@ -279,7 +279,7 @@ jobs:
       - name: Tar built website
         run: tar zcf website.tar.gz website/build
       - name: Share Built Website
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: website
           path: website.tar.gz


### PR DESCRIPTION

#### Type of Improvement


- Documentation or website-related



#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

Caching has been broken for ages, this should fix that. It also updates all actions to Node 24 released versions if they exist yet. Everything must be moved to Node 25 by April [[1]](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
