### PR TITLE
[website] Fix Snapshot API docs by hosting locally

### DIFF
--- a/docs/Releases.mill
+++ b/docs/Releases.mill
@@ -120,7 +120,7 @@ def generateMarkdown(logger: Logger)(snapshot: String): String = {
     // pathname is needed by Docusaurus to correctly handle internal links in the static folder,
     // see https://docusaurus.io/docs/advanced/routing#escaping-from-spa-redirects
     s"- [Latest (${latest.serialize})](pathname:///api/latest/index.html)",
-    s"- [Snapshot](${sonatype(snapshot)})"
+    s"- [Snapshot (${snapshot})](pathname:///api/snapshot/index.html)"
   ) ++ major.reverse.map { v =>
     s"- [${v.serialize}](${javadocIO(v)})"
   }).mkString("\n")

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -11,6 +11,7 @@
 /docs
 generated
 /static/api/latest
+/static/api/snapshot
 /static/releases
 
 # Misc

--- a/website/Makefile
+++ b/website/Makefile
@@ -1,6 +1,7 @@
 
 this_dir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 chisel_dir := $(realpath $(this_dir)/..)
+mill_out := $(chisel_dir)/out
 relative_to_this_dir := $(notdir $(this_dir))
 PORT ?= 8000
 
@@ -9,6 +10,8 @@ mdoc_out := $(chisel_dir)/docs/generated
 buildDir ?= build
 website_docs_dir = $(this_dir)/docs
 latest_scaladoc_dir = $(this_dir)/static/api/latest
+snapshot_scaladoc_dir = $(this_dir)/static/api/snapshot
+snapshot_scaladoc_jar = $(mill_out)/unipublish/docJar.dest/out.jar
 generate_scala_cli = $(chisel_dir)/.github/scripts/generate-scala-cli-example.sh
 latest_chisel_download = $(this_dir)/static/releases/latest/download
 snapshot_chisel_download = $(this_dir)/static/releases/snapshot/download
@@ -53,6 +56,9 @@ $(latest_version): $(chisel-non-website)
 $(latest_scaladoc_dir):
 	mkdir -p $@
 
+$(snapshot_scaladoc_dir):
+	mkdir -p $@
+
 # Must touch target because it was built when the latest release was made
 # unzip doesn't support operating on stdin so we need a temp file
 $(latest_scaladoc_dir)/index.html: $(latest_version) | $(latest_scaladoc_dir)
@@ -63,6 +69,14 @@ $(latest_scaladoc_dir)/index.html: $(latest_version) | $(latest_scaladoc_dir)
 	  wget -q -O temp.jar $(URL) && \
 	  unzip -q temp.jar && \
 	  rm -rf temp.jar
+	touch $@
+
+$(snapshot_scaladoc_jar): $(chisel-non-website)
+	cd $(chisel_dir) && ./mill unipublish.docJar
+
+$(snapshot_scaladoc_dir)/index.html: $(snapshot_scaladoc_jar) | $(snapshot_scaladoc_dir)
+	rm -rf $(snapshot_scaladoc_dir)/*
+	cd $(snapshot_scaladoc_dir) && unzip -q $<
 	touch $@
 
 $(latest_chisel_download):
@@ -99,7 +113,7 @@ $(install_timestamp): $(this_dir)/package.json
 
 install: $(install_timestamp)
 
-$(build_timestamp): $(this_dir)/docs/index.md $(latest_scaladoc_dir)/index.html $(contributors) $(scaladoc_links) $(install_timestamp) $(chisel-website-only) $(latest_chisel_download)/chisel-example.scala $(snapshot_chisel_download)/chisel-example.scala
+$(build_timestamp): $(this_dir)/docs/index.md $(latest_scaladoc_dir)/index.html $(snapshot_scaladoc_dir)/index.html $(contributors) $(scaladoc_links) $(install_timestamp) $(chisel-website-only) $(latest_chisel_download)/chisel-example.scala $(snapshot_chisel_download)/chisel-example.scala
 	cd $(this_dir) && npm run build
 	touch $@
 
@@ -120,6 +134,8 @@ clean:
 
 mrproper: clean
 	rm -rf $(this_dir)/node_modules \
-		$(chisel_dir)/out
+		$(chisel_dir)/out \
+		$(latest_scaladoc_dir) \
+		$(snapshot_scaladoc_dir)
 
 .PHONY: clean mrproper serve install build

--- a/website/static/robots.txt
+++ b/website/static/robots.txt
@@ -2,4 +2,5 @@
 
 User-agent: *
 Allow: /
+Disallow: /api/snapshot/
 Sitemap: https://www.chisel-lang.org/sitemap.xml


### PR DESCRIPTION
I've also asked webcrawlers not to index the snapshot API docs, although they still will if elsewhere on the internet links to them.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [ ] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [ ] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement


- Documentation or website-related


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

Previously, we linked to s01.sonatype which allowed rendering doc jars in the browser. As Sonatype has been sunset and Maven Central does not appear to support this, we will have to host the latest snapshot ourselves.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
