### PR TITLE
[svsim] Fix FSDB generation for VCS 2024+

### DIFF
--- a/svsim/src/main/scala/vcs/Backend.scala
+++ b/svsim/src/main/scala/vcs/Backend.scala
@@ -62,15 +62,12 @@ object Backend {
         case None    => false
       }
       private[vcs] def compileFlags = Seq(
-        if (enableVpd || fsdbEnabled) Seq("-debug_acc+pp+dmptf") else Seq(),
+        if (enableVpd || fsdbEnabled) Seq("-debug_access+pp+dmptf") else Seq(),
         fsdbSettings match {
           case None => Seq()
-          case Some(TraceSettings.FsdbSettings(verdiHome)) =>
+          case Some(_) =>
             Seq(
-              "-kdb",
-              "-P",
-              s"$verdiHome/share/PLI/VCS/LINUX64/novas.tab",
-              s"$verdiHome/share/PLI/VCS/LINUX64/pli.a"
+              "-kdb"
             )
         }
       ).flatten

--- a/svsim/src/test/scala/BackendSpec.scala
+++ b/svsim/src/test/scala/BackendSpec.scala
@@ -120,6 +120,49 @@ class VCSSpec extends BackendSpec {
         }
 
       }
+
+      describe("VCS FSDB support") {
+
+        it("should work for the version of VCS available on the PATH") {
+          val workspace = new svsim.Workspace(path = s"test_run_dir/${getClass().getSimpleName()}/FSDB")
+
+          import Resources._
+          workspace.reset()
+          workspace.elaborateGCD()
+          workspace.generateAdditionalSources(None)
+          val simulation = workspace.compile(
+            backend
+          )(
+            workingDirectoryTag = "vcs",
+            commonSettings = CommonCompilationSettings(),
+            backendSpecificSettings = compilationSettings.copy(traceSettings =
+              TraceSettings(fsdbSettings =
+                Some(
+                  TraceSettings.FsdbSettings(
+                    sys.env.getOrElse(
+                      "VERDI_HOME",
+                      throw new RuntimeException(
+                        "Cannot enable FSDB support as the environment variable 'VERDI_HOME' was not set."
+                      )
+                    )
+                  )
+                )
+              )
+            ),
+            customSimulationWorkingDirectory = None,
+            verbose = false
+          )
+
+          simulation.run(
+            executionScriptLimit = None,
+            traceEnabled = true
+          ) { _ => }
+
+          info("an FSDB file was created")
+          Paths.get(workspace.absolutePath, "workdir-vcs", "trace.fsdb").toFile must (exist)
+        }
+
+      }
   }
 }
 


### PR DESCRIPTION
VCS changed how FSDB enablement works.  This now manages the Verdi stuff
for you and will throw a silent error and not crash if you do this in VCS
2025 (and possible in earlier 2024 where this was deprecated).

#### Release Notes

Fix svsim FSDB generation for VCS 2024+.
