### PR TITLE
[Scala3] [bugfix] BundlePhase: Skip implicit parameters in Bundle constructor argument extraction

### DIFF
--- a/plugin/src/main/scala-3/chisel3/internal/plugin/BundlePhase.scala
+++ b/plugin/src/main/scala-3/chisel3/internal/plugin/BundlePhase.scala
@@ -86,7 +86,9 @@ object BundleHelpers {
       case _ =>
     })
 
-    Some(constructor.termParamss.map(_.map { case vp =>
+    def isImplicit(x: tpd.ValDef): Boolean = x.symbol.flags.is(Flags.Implicit)
+
+    Some(constructor.termParamss.map(_.filterNot(isImplicit(_)).map { case vp =>
       val p: Symbol = paramLookup(vp.name.toString)
       val select = tpd.Select(thiz, p.name)
       val cloned: tpd.Tree =


### PR DESCRIPTION
In the Scala 3 BundlePhase, implicit constructor parameters were being extracted like regular parameters, causing compiler failures while the compilation phase. This change adds filtering on implicit parameters to skip them in constructor argument extraction.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Internal or build-related (includes code refactoring/cleanup)
- Bugfix

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->
Scala3 BundlePhase: constructor argument extraction now correctly skips implicit parameters

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
