### PR TITLE
[core] Deprecate ExtModule, Params in experimental

### DIFF
--- a/core/src/main/scala/chisel3/experimental/ExtModule.scala
+++ b/core/src/main/scala/chisel3/experimental/ExtModule.scala
@@ -8,16 +8,29 @@ import chisel3.internal.BaseBlackBox
 import chisel3.internal.firrtl.ir.{Component, DefBlackBox, Port}
 import chisel3.layer.Layer
 
+private object ExtModule {
+  final val deprecatedCaseClass =
+    "this has moved from `chisel3.experimental` to `chisel3` and all `case class` methods are deprecated. This will be made a `class` in Chisel 8."
+  final val since = "7.5.0"
+}
+import ExtModule._
+
 /** Parameters for BlackBoxes */
+@deprecated(deprecatedCaseClass, since)
 abstract class Param
+@deprecated(deprecatedCaseClass, since)
 case class IntParam(value: BigInt) extends Param
+@deprecated(deprecatedCaseClass, since)
 case class DoubleParam(value: Double) extends Param
+@deprecated(deprecatedCaseClass, since)
 case class StringParam(value: String) extends Param
 
 /** Creates a parameter from the Printable's resulting format String */
+@deprecated(deprecatedCaseClass, since)
 case class PrintableParam(value: chisel3.Printable, context: BaseModule) extends Param
 
 /** Unquoted String */
+@deprecated(deprecatedCaseClass, since)
 case class RawParam(value: String) extends Param
 
 /** Defines a black box, which is a module that can be referenced from within
@@ -55,6 +68,7 @@ case class RawParam(value: String) extends Param
   * }}}
   * @note The parameters API is experimental and may change
   */
+@deprecated("this has moved from `chisel3.experimental` to `chisel3`", since)
 abstract class ExtModule(
   val params:                               Map[String, Param] = Map.empty[String, Param],
   override protected final val knownLayers: Seq[Layer] = Seq.empty[Layer]

--- a/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
@@ -410,15 +410,15 @@ private[chisel3] object Converter {
   }
 
   def convert(name: String, param: Param): fir.Param = param match {
-    case IntParam(value)    => fir.IntParam(name, value)
-    case DoubleParam(value) => fir.DoubleParam(name, value)
-    case StringParam(value) => fir.StringParam(name, fir.StringLit(value))
-    case PrintableParam(value, id) => {
-      val ctx = id._component.get
-      val (fmt, _) = unpack(value, ctx, UnlocatableSourceInfo)
+    case p: IntParam    => fir.IntParam(name, p.value)
+    case p: DoubleParam => fir.DoubleParam(name, p.value)
+    case p: StringParam => fir.StringParam(name, fir.StringLit(p.value))
+    case p: PrintableParam => {
+      val ctx = p.context._component.get
+      val (fmt, _) = unpack(p.value, ctx, UnlocatableSourceInfo)
       fir.StringParam(name, fir.StringLit(fmt))
     }
-    case RawParam(value) => fir.RawStringParam(name, value)
+    case p: RawParam => fir.RawStringParam(name, p.value)
   }
 
   def convert(param: TestParam): fir.TestParam = param match {

--- a/core/src/main/scala/chisel3/internal/firrtl/Serializer.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/Serializer.scala
@@ -533,17 +533,17 @@ private[chisel3] object Serializer {
   }
 
   private def serialize(name: String, param: Param)(implicit b: StringBuilder): Unit = param match {
-    case IntParam(value)    => b ++= name; b ++= " = "; b ++= value.toString
-    case DoubleParam(value) => b ++= name; b ++= " = "; b ++= value.toString
-    case StringParam(value) => b ++= name; b ++= " = "; b ++= firrtl.ir.StringLit(value).escape
-    case PrintableParam(value, id) => {
-      val ctx = id._component.get
-      val (fmt, _) = unpack(value, ctx, UnlocatableSourceInfo)
+    case p: IntParam    => b ++= name; b ++= " = "; b ++= p.value.toString
+    case p: DoubleParam => b ++= name; b ++= " = "; b ++= p.value.toString
+    case p: StringParam => b ++= name; b ++= " = "; b ++= firrtl.ir.StringLit(p.value).escape
+    case p: PrintableParam => {
+      val ctx = p.context._component.get
+      val (fmt, _) = unpack(p.value, ctx, UnlocatableSourceInfo)
       b ++= name; b ++= " = "; b ++= firrtl.ir.StringLit(fmt).escape
     }
-    case RawParam(value) =>
+    case p: RawParam =>
       b ++= name; b ++= " = "
-      b += '\''; b ++= value.replace("'", "\\'"); b += '\''
+      b += '\''; b ++= p.value.replace("'", "\\'"); b += '\''
   }
 
   private def serialize(param: TestParam)(implicit b: StringBuilder, indent: Int): Unit = param match {


### PR DESCRIPTION
Deprecate all `Param`s and `ExtModule` inside experimental as this is
moving into chisel3 proper in Chisel 8.  This is insanely difficult to do
with `case class`es, but I think we can just deprecate these as so and the
result is that all `case class` methods are deprecated and we can just
make all these `case class`es normal `class`es in Chisel 8.


#### Release Notes

Deprecate experimental ExtModule and Params.  Also, deprecate the `case class`
variants of the Params.  These will be made classes in Chisel 8.
