### PR TITLE
Fix boring taps of views of ExtModule ports

### DIFF
--- a/core/src/main/scala/chisel3/RawModule.scala
+++ b/core/src/main/scala/chisel3/RawModule.scala
@@ -193,13 +193,7 @@ abstract class RawModule extends BaseModule {
     _component
   }
 
-  private[chisel3] def secretConnection(left: Data, _right: Data)(implicit si: SourceInfo): Unit = {
-    val (right: Data, _) = chisel3.experimental.dataview
-      .reifyIdentityView(_right)
-      .getOrElse(
-        throwException(s"BoringUtils currently only support identity views, ${_right} has multiple targets.")
-      )
-
+  private[chisel3] def secretConnection(left: Data, right: Data)(implicit si: SourceInfo): Unit = {
     def computeConnection(left: Data, right: Data): Command = {
       (left.probeInfo.nonEmpty, right.probeInfo.nonEmpty) match {
         case (true, true)                                 => ProbeDefine(si, left.lref, Node(right))


### PR DESCRIPTION
The approach was to move reification (which happened late) to happen earlier. Doing it earlier also makes sense for dealing with non 1-1 views which is definitely possible but will require larger changes so still punting on that (there is a test that it doesn't work that already exists immediately after the test I added).

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Bugfix


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

This is a common issue when using `FlatIO` with `ExtModules`.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
