### PR TITLE
Support absolute path source locators

### DIFF
--- a/core/src/main/scala-2/chisel3/internal/SourceInfoFileResolver.scala
+++ b/core/src/main/scala-2/chisel3/internal/SourceInfoFileResolver.scala
@@ -5,6 +5,8 @@ package chisel3.internal.sourceinfo
 import scala.language.experimental.macros
 import scala.reflect.macros.blackbox.Context
 
+import java.io.File.separatorChar
+
 ///////////////////////////////////////////////////////
 //                     WARNING!!                     //
 // This file is soft-linked into the compiler plugin //
@@ -13,13 +15,18 @@ import scala.reflect.macros.blackbox.Context
 
 /** Scala compile-time function for determine the String used to represent a source file path in SourceInfos */
 private[internal] object SourceInfoFileResolver {
+  // Ensure non-empty paths end in a slash
+  def sanitizePath(path: String): String = {
+    if (path.isEmpty) path
+    else if (path.last != separatorChar) path + separatorChar
+    else path
+  }
+
   def resolve(source: scala.reflect.internal.util.SourceFile): String = {
     val userDir = sys.props.get("user.dir") // Figure out what to do if not provided
     val projectRoot = sys.props.get("chisel.project.root")
-    val root = projectRoot.orElse(userDir)
+    val root = projectRoot.orElse(userDir).map(sanitizePath)
 
-    val path = root.map(r => source.file.canonicalPath.stripPrefix(r)).getOrElse(source.file.name)
-    val pathNoStartingSlash = if (path(0) == '/') path.tail else path
-    pathNoStartingSlash
+    root.map(r => source.file.canonicalPath.stripPrefix(r)).getOrElse(source.file.name)
   }
 }

--- a/core/src/main/scala/chisel3/internal/Error.scala
+++ b/core/src/main/scala/chisel3/internal/Error.scala
@@ -32,7 +32,12 @@ object ExceptionHelpers {
   private[chisel3] def getErrorLineInFile(sourceRoots: Seq[File], sl: SourceLine): List[String] = {
     def tryFileInSourceRoot(sourceRoot: File): Option[List[String]] = {
       try {
-        val file = new File(sourceRoot, sl.filename)
+        val file = {
+          val f = new File(sl.filename)
+          // Absolute paths are not relative to sourceRoot.
+          if (f.isAbsolute) f
+          else new File(sourceRoot, sl.filename)
+        }
         val lines = Source.fromFile(file).getLines()
         var i = 0
         while (i < (sl.line - 1) && lines.hasNext) {

--- a/lit/tests/ErrorCarat.sc
+++ b/lit/tests/ErrorCarat.sc
@@ -1,0 +1,17 @@
+// RUN: JDK_JAVA_OPTIONS='-Dchisel.project.root=' not scala-cli --server=false --java-home=%JAVAHOME --extra-jars=%RUNCLASSPATH --scala-version=%SCALAVERSION --scala-option="-Xplugin:%SCALAPLUGINJARS" %s | FileCheck %s
+// SPDX-License-Identifier: Apache-2.0
+
+import chisel3._
+
+class ModuleWithError extends Module {
+  val in = IO(Input(UInt(8.W)))
+  val out = IO(Output(UInt(16.W)))
+
+  // Check behavior of absolute path source locators due to chisel.project.root set to empty above.
+  // CHECK:      High index 15 is out of range [0, 7]
+  // CHECK-NEXT: out := in(15, 0)
+  // CHECK-NEXT:          ^
+  out := in(15, 0)
+}
+
+circt.stage.ChiselStage.emitCHIRRTL(new ModuleWithError)


### PR DESCRIPTION
I tried really hard to write a test for this, but I could not get it to work, even in our lit tests due to Mill sandboxing. I would like to revisit this at some point but I have spent too long on this at the moment.

Proof this works, try:
```scala
//> using scala 2.13.18
//> using dep org.chipsalliance::chisel:7.4.0
//> using plugin org.chipsalliance:::chisel-plugin:7.4.0

import chisel3._
import circt.stage.ChiselStage

class Foo extends Module {
  val foo, bar = IO(Input(UInt(8.W)))
  val out = IO(Output(UInt(8.W)))

  out := foo + bar(10, 0)
}

object Main extends App {
  println(ChiselStage.emitCHIRRTL(new Foo))
}
```
Output is:
```
[error] Users/koenig/work/chisel/tt/chisel-example.scala 12:19: High index 10 is out of range [0, 7]
[error] There were 1 error(s) during hardware elaboration.
```

Note the missing leading `/`, because we were stripping it in `SourceInfoFileResolver.scala`.

With publish local of this branch (`7.4.0+18-4e05e9fc-SNAPSHOT`):
```
[error] /Users/koenig/work/chisel/tt/chisel-example.scala 12:19: High index 10 is out of range [0, 7]
[error]   out := foo + bar(10, 0)
[error]                   ^
[error] There were 1 error(s) during hardware elaboration.
```

It might be worth simplifying `/Users/koenig/work/chisel/tt/chisel-example.scala` at error report time as well since scala-cli may compile in `/`, but it actually runs in the users current working directory.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Bugfix

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

The default behavior of Scala-cli is to use a Bloop server running in the root directory for compilation. This results in absolute paths in for source locators at compile time, but our logic had assumed we always had relative paths and was manually stripping the leading forward slash in source locator paths. Instead, we strip the leading forward slash for relative paths by including it in the path prefix we remove, and then in error reporting we add support for paths that are already absolute.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
