### PR TITLE
Add source locators to more module kinds

### DIFF
--- a/core/src/main/scala/chisel3/BlackBox.scala
+++ b/core/src/main/scala/chisel3/BlackBox.scala
@@ -96,8 +96,12 @@ abstract class BlackBox(
     // support associations because associations require having multiple ports.
     // If this restriction is lifted, then this code should be updated.
     require(!hasAsssociations, "BlackBoxes cannot support associations at this time, use an ExtModule")
+    // Get the source info for the io bundle to use for all flattened ports.
+    val ioSourceInfo = getModulePortsAndLocators.collectFirst {
+      case (port, sourceInfo, _) if port == io => sourceInfo
+    }.getOrElse(UnlocatableSourceInfo)
     val firrtlPorts = namedPorts.map { namedPort =>
-      Port(namedPort._2, namedPort._2.specifiedDirection, Seq.empty, UnlocatableSourceInfo)
+      Port(namedPort._2, namedPort._2.specifiedDirection, Seq.empty, ioSourceInfo)
     }
 
     val component = DefBlackBox(this, name, firrtlPorts, io.specifiedDirection, params, getKnownLayers)

--- a/core/src/main/scala/chisel3/experimental/ExtModule.scala
+++ b/core/src/main/scala/chisel3/experimental/ExtModule.scala
@@ -109,8 +109,8 @@ abstract class ExtModule(
     // Ports are named in the same way as regular Modules
     namePorts()
 
-    val firrtlPorts = getModulePortsAndLocators.map { case (port, _, associations) =>
-      Port(port, port.specifiedDirection, associations, UnlocatableSourceInfo)
+    val firrtlPorts = getModulePortsAndLocators.map { case (port, sourceInfo, associations) =>
+      Port(port, port.specifiedDirection, associations, sourceInfo)
     }
     val component = DefBlackBox(this, name, firrtlPorts, SpecifiedDirection.Unspecified, params, getKnownLayers)
     _component = Some(component)

--- a/core/src/main/scala/chisel3/experimental/IntrinsicModule.scala
+++ b/core/src/main/scala/chisel3/experimental/IntrinsicModule.scala
@@ -23,8 +23,8 @@ abstract class IntrinsicModule(intrinsicName: String, val params: Map[String, Pa
     // Ports are named in the same way as regular Modules
     namePorts()
 
-    val firrtlPorts = getModulePortsAndLocators.map { case (port, _, associations) =>
-      Port(port, port.specifiedDirection, associations, UnlocatableSourceInfo)
+    val firrtlPorts = getModulePortsAndLocators.map { case (port, sourceInfo, associations) =>
+      Port(port, port.specifiedDirection, associations, sourceInfo)
     }
     val component = DefIntrinsicModule(this, name, firrtlPorts, SpecifiedDirection.Unspecified, params)
     _component = Some(component)

--- a/src/test/scala-2/chiselTests/ExtModule.scala
+++ b/src/test/scala-2/chiselTests/ExtModule.scala
@@ -279,4 +279,26 @@ class ExtModuleSpec extends AnyFlatSpec with Matchers with ChiselSim with FileCh
       )
 
   }
+
+  it should "have source locator information on ports" in {
+    class Bar extends ExtModule {
+      val a = IO(Output(Bool()))
+    }
+
+    class Foo extends Module {
+      val a = IO(Output(Bool()))
+
+      private val bar = Module(new Bar)
+      a :<= bar.a
+    }
+
+    ChiselStage
+      .emitCHIRRTL(new Foo)
+      .fileCheck()(
+        """|CHECK: extmodule Bar :
+           |CHECK:   output a : UInt<1> @[{{.+}}ExtModule.scala {{[0-9]+}}:{{[0-9]+}}]
+           |""".stripMargin
+      )
+  }
+
 }

--- a/src/test/scala-2/chiselTests/IntrinsicModule.scala
+++ b/src/test/scala-2/chiselTests/IntrinsicModule.scala
@@ -4,10 +4,11 @@ package chiselTests
 
 import chisel3._
 import chisel3.experimental._
-import circt.stage.ChiselStage
+import chisel3.testing.scalatest.FileCheck
 import circt.stage.ChiselStage
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import scala.annotation.nowarn
 
 class IntModuleTest extends IntrinsicModule("TestIntrinsic") {
   val foo = IO(new Bundle() {
@@ -27,7 +28,7 @@ class IntModuleTester extends Module {
   val intM4 = Module(new IntModuleGenName("someIntName"))
 }
 
-class IntrinsicModuleSpec extends AnyFlatSpec with Matchers {
+class IntrinsicModuleSpec extends AnyFlatSpec with Matchers with FileCheck {
   (ChiselStage
     .emitCHIRRTL(new IntModuleTester)
     .split('\n')
@@ -42,4 +43,28 @@ class IntrinsicModuleSpec extends AnyFlatSpec with Matchers {
     "intmodule IntModuleGenName : ",
     "intrinsic = someIntName"
   )
+
+  behavior.of("IntrinsicModule ports")
+
+  they should "have source locator information" in {
+    @nowarn("cat=deprecation")
+    class IntModWithPort extends IntrinsicModule("TestIntrinsic") {
+      val a = IO(Output(Bool()))
+    }
+
+    class Foo extends Module {
+      val a = IO(Output(Bool()))
+
+      private val intMod = Module(new IntModWithPort)
+      a :<= intMod.a
+    }
+
+    ChiselStage
+      .emitCHIRRTL(new Foo)
+      .fileCheck()(
+        """|CHECK: intmodule IntModWithPort :
+           |CHECK:   output a : UInt<1> @[{{.+}}IntrinsicModule.scala {{[0-9]+}}:{{[0-9]+}}]
+           |""".stripMargin
+      )
+  }
 }


### PR DESCRIPTION
Add missing source locators to:

  - BlackBox
  - ExtModule
  - IntrinsicModule

Previously, this information would be just dropped which resulted in
sub-par error messages for errors generated by `firtool`.  Concretely,
this helps with error messages generated by the `InferDomains` pass where
a frequent problem is missing domain information on external modules.

Fixes #5115.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>

#### Release Notes

Add source locators to BlackBox, ExtModule, and IntrinsicModule.
