### PR TITLE
Fix name prefixing from views on rhs of connection

### DIFF
--- a/src/test/scala-2/chiselTests/naming/NamePluginSpec.scala
+++ b/src/test/scala-2/chiselTests/naming/NamePluginSpec.scala
@@ -485,6 +485,27 @@ class NamePluginSpec extends AnyFlatSpec with Matchers with FileCheck {
     )
   }
 
+  "FlatIOs" should "forward names to their targets" in {
+    ChiselStage.emitCHIRRTL {
+      new Module {
+        val io = FlatIO(new Bundle {
+          val in = Input(UInt(3.W))
+          val out = Output(UInt(3.W))
+        })
+        io.out := {
+          val w = Wire(UInt(3.W))
+          w := io.in + 1.U
+          w
+        }
+      }
+    }.fileCheck()(
+      """|CHECK: input in :
+         |CHECK: output out :
+         |CHECK: wire out_w :
+         |""".stripMargin
+    )
+  }
+
   "AffectsChiselName" should "name the user-defined type" in {
     case class SomeClass(d: UInt) extends AffectsChiselName
     class Test extends Module {


### PR DESCRIPTION
### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Backend Code Generation


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

Previously views when used on the LHS of a connection operator, views would provide the prefix `view_`. Now, at least for 1-1 views, the prefix is derived from the name of the target of the view. This is a common issue when using `FlatIO`.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
