### PR TITLE
[core] Add associate method for Seq of ports

### DIFF
--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -617,7 +617,7 @@ package experimental {
 
     protected def portsSize: Int = _ports.size
 
-    /* Associate a port of this module with one or more domains. */
+    /** Associate a port of this module with one or more domains. */
     final def associate(port: Data, domains: domain.Type*)(implicit si: SourceInfo): Unit = {
       require(domains.nonEmpty, "cannot associate a port with zero domains")
       val portx = dataview.reifySingleTarget(port).getOrElse(port)
@@ -636,6 +636,11 @@ package experimental {
         case Some(acc) => Some(acc ++= domains)
         case None      => Some(LinkedHashSet.empty[domain.Type] ++= domains)
       }
+    }
+
+    /** Associate multiple ports of this module with one or more domains. */
+    final def associate(port: Seq[Data], domains: domain.Type*)(implicit si: SourceInfo): Unit = {
+      port.foreach(associate(_, domains: _*))
     }
 
     /** Generates the FIRRTL Component (Module or Blackbox) of this Module.

--- a/src/test/scala-2/chiselTests/DomainSpec.scala
+++ b/src/test/scala-2/chiselTests/DomainSpec.scala
@@ -170,6 +170,20 @@ class DomainSpec extends AnyFlatSpec with Matchers with FileCheck {
     }
   }
 
+  it should "allow for multiple ports" in {
+    class Foo extends RawModule {
+      val A = IO(Input(ClockDomain.Type()))
+      val a, b = IO(Input(Bool()))
+      associate(Seq(a, b), A)
+    }
+
+    ChiselStage.emitCHIRRTL(new Foo).fileCheck() {
+      """|CHECK:   input a : UInt<1> domains [A]
+         |CHECK:   input b : UInt<1> domains [A]
+         |""".stripMargin
+    }
+  }
+
   behavior of "unsafe_domain_cast"
 
   it should "work for zero, one, and two casts" in {


### PR DESCRIPTION
Add an additional `associate` method that can be used for multiple ports.
I'm finding myself frequently writing the following and this avoids it:

``` scala
Seq(x, y, z).foreach(associate(_, A))
```

#### Release Notes

Add additional domain `associate` method that accepts a sequence of ports.
