### PR TITLE
[svsim] Improve error message on illegal poke

### DIFF
--- a/src/test/scala-2/chiselTests/simulator/scalatest/ChiselSimSpec.scala
+++ b/src/test/scala-2/chiselTests/simulator/scalatest/ChiselSimSpec.scala
@@ -551,4 +551,20 @@ class ChiselSimSpec extends AnyFunSpec with Matchers with ChiselSim with FileChe
 
   }
 
+  describe("ChiselSim user errors") {
+
+    it("should provide a sane error message if a user pokes an output port") {
+      class Foo extends RawModule {
+        val a = IO(Output(Bool()))
+        a :<= DontCare
+      }
+      intercept[java.lang.IllegalArgumentException] {
+        simulateRaw(new Foo) { dut =>
+          dut.a.poke(false.B)
+        }
+      }.getMessage.fileCheck() { "CHECK: cannot set port 'a' (id: '0') because it is not settable" }
+    }
+
+  }
+
 }

--- a/svsim/src/main/scala/Simulation.scala
+++ b/svsim/src/main/scala/Simulation.scala
@@ -392,12 +392,20 @@ object Simulation {
   final case class Port private[Simulation] (controller: Simulation.Controller, id: String, info: ModuleInfo.Port) {
 
     def set(value: BigInt) = {
+      require(
+        info.isSettable,
+        s"cannot set port '${info.name}' (id: '$id') because it is not settable.  (Did you try to poke an output port?)"
+      )
       controller.sendCommand(Simulation.Command.SetBits(id, value))
       controller.expectNextMessage { case Simulation.Message.Ack =>
       }
     }
 
     def get(isSigned: Boolean = false): Value = {
+      require(
+        info.isGettable,
+        s"cannot get port '${info.name}' (id: '$id') because it is not gettable"
+      )
       controller.sendCommand(Simulation.Command.GetBits(id, isSigned))
       controller.processNextMessage { case Simulation.Message.Bits(bitCount, value) =>
         Value(bitCount, value)


### PR DESCRIPTION
Fix a bad error message in svsim that would occur if a user tries to poke
an output port.  Test that a set is only being done on a "settable" port
and that a get is only being done on a "gettable" port.  Note: all ports
are "gettable", so I am unable to test the latter require.

Fixes #5123.

#### Release Notes

Improve error message in `svsim` / `ChiselSim` when a user tries to poke an
output port.
