### PR TITLE
Add runpath option to UnitTests main

### DIFF
--- a/release.mill
+++ b/release.mill
@@ -60,7 +60,11 @@ trait Unipublish extends ScalaModule with ChiselPublishModule with Mima {
     ProblemFilter.exclude[DirectMissingMethodProblem]("firrtl.ir*"),
     ProblemFilter.exclude[IncompatibleResultTypeProblem]("firrtl.ir*"),
     ProblemFilter.exclude[MissingTypesProblem]("firrtl.ir*"),
-    ProblemFilter.exclude[MissingClassProblem]("firrtl.ir*")
+    ProblemFilter.exclude[MissingClassProblem]("firrtl.ir*"),
+    // chisel3.UnitTests.Config should never have been public and was unused in public APIs
+    ProblemFilter.exclude[DirectMissingMethodProblem]("chisel3.UnitTests#Config*"),
+    ProblemFilter.exclude[IncompatibleResultTypeProblem]("chisel3.UnitTests#Config*"),
+    ProblemFilter.exclude[MissingTypesProblem]("chisel3.UnitTests$Config*")
   )
 
   /** Publish both this project and the plugin (for the default Scala version) */

--- a/src/test/scala-2/chiselTests/UnitTestMainSpec.scala
+++ b/src/test/scala-2/chiselTests/UnitTestMainSpec.scala
@@ -61,6 +61,22 @@ class UnitTestMainSpec extends AnyFlatSpec with Matchers with FileCheck {
       // CHECK: module ModuleTest :
       """)
   }
+
+  it should "support custom runpaths" in {
+    val runpathArgs = System
+      .getProperty("java.class.path")
+      .split(java.io.File.pathSeparator)
+      .map(s => if (s.trim.length == 0) "." else s)
+      .flatMap(s => Seq("-R", s))
+    val args = Seq("-l", "-f", "^chiselTests\\.sampleTests\\.") ++ runpathArgs
+    checkOut(args: _*)(
+      """
+      // CHECK-DAG: chiselTests.sampleTests.ClassTest
+      // CHECK-DAG: chiselTests.sampleTests.ObjectTest
+      // CHECK-DAG: chiselTests.sampleTests.ModuleTest
+      """
+    )
+  }
 }
 
 package sampleTests {


### PR DESCRIPTION
Add a `-R` option to the `chisel3.UnitTests` main class which mirrors the same option in scalatest's runner. This option allows the user to supply a reduced classpath to be searched for Chisel unit test classes. This allows discovery to be much faster in larger projects with many dependencies, since the classpath contains all dependencies, but the runpath can be limited to discover only test of the current project.

#### Type of Improvement

- Feature (or new API)


#### Desired Merge Strategy

- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
