### PR TITLE
[Scala3] Update BundlePhase to handle Bundles with type parameters

### DIFF
--- a/plugin/src/main/scala-3/chisel3/internal/plugin/BundlePhase.scala
+++ b/plugin/src/main/scala-3/chisel3/internal/plugin/BundlePhase.scala
@@ -38,10 +38,16 @@ object BundleHelpers {
     thiz:    tpd.This,
     conArgs: List[List[tpd.Tree]]
   )(using Context): tpd.DefDef = {
+    val typeParams = record.symbol.typeParams
+    val classType = if (typeParams.isEmpty) {
+      record.symbol.typeRef
+    } else {
+      record.symbol.typeRef.appliedTo(typeParams.map(_.typeRef))
+    }
     val newExpr: tpd.Tree = conArgs match {
-      case Nil => tpd.New(record.symbol.typeRef, Nil)
+      case Nil => tpd.New(classType, Nil)
       case head :: tail =>
-        val headApp = tpd.New(record.symbol.typeRef, head)
+        val headApp = tpd.New(classType, head)
         tail.foldLeft(headApp: tpd.Tree) { (fun, args) =>
           tpd.Apply(fun, args)
         }


### PR DESCRIPTION
Adds type parameter handling in `AutoCloneType` generation in BundlePhase

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [ ] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [ ] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Internal or build-related (includes code refactoring/cleanup)


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
