### PR TITLE
[core] Propagate elideBlocks state in D/I

### DIFF
--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/Definition.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/Definition.scala
@@ -121,7 +121,8 @@ object Definition extends SourceInfoDoc {
         context.contextCache,
         context.layerMap,
         context.inlineTestIncluder,
-        context.suppressSourceInfo
+        context.suppressSourceInfo,
+        context.elideLayerBlocks
       )
     }
     dynamicContext.inDefinition = true

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -477,7 +477,8 @@ private[chisel3] class DynamicContext(
   val contextCache:       BuilderContextCache,
   val layerMap:           Map[layer.Layer, layer.Layer],
   val inlineTestIncluder: InlineTestIncluder,
-  val suppressSourceInfo: Boolean
+  val suppressSourceInfo: Boolean,
+  var elideLayerBlocks:   Boolean
 ) {
   val importedDefinitionAnnos = annotationSeq.collect { case a: ImportDefinitionAnnotation[_] => a }
 
@@ -545,12 +546,11 @@ private[chisel3] class DynamicContext(
   var blockStack:           List[Block] = Nil
   // Clock and Reset are "Delayed" because ImplicitClock and ImplicitReset need to set these values,
   // But the clock or reset defined by the user won't yet be initialized
-  var currentClock:     Option[Delayed[Clock]] = None
-  var currentReset:     Option[Delayed[Reset]] = None
-  var currentDisable:   Disable.Type = Disable.BeforeReset
-  var enabledLayers:    mutable.LinkedHashSet[layer.Layer] = mutable.LinkedHashSet.empty
-  var layerStack:       List[layer.Layer] = layer.Layer.root :: Nil
-  var elideLayerBlocks: Boolean = false
+  var currentClock:   Option[Delayed[Clock]] = None
+  var currentReset:   Option[Delayed[Reset]] = None
+  var currentDisable: Disable.Type = Disable.BeforeReset
+  var enabledLayers:  mutable.LinkedHashSet[layer.Layer] = mutable.LinkedHashSet.empty
+  var layerStack:     List[layer.Layer] = layer.Layer.root :: Nil
   val errors = new ErrorLog(warningFilters, sourceRoots, throwOnFirstError)
   val namingStack = new NamingStack
 

--- a/src/main/scala/chisel3/stage/phases/Elaborate.scala
+++ b/src/main/scala/chisel3/stage/phases/Elaborate.scala
@@ -55,7 +55,8 @@ class Elaborate extends Phase {
             BuilderContextCache.empty,
             chiselOptions.layerMap,
             chiselOptions.inlineTestIncluder,
-            chiselOptions.suppressSourceInfo
+            chiselOptions.suppressSourceInfo,
+            false
           )
         val (elaboratedCircuit, dut) = {
           Builder.build(Module(gen()), context)

--- a/src/test/scala-2/chiselTests/experimental/hierarchy/DefinitionSpec.scala
+++ b/src/test/scala-2/chiselTests/experimental/hierarchy/DefinitionSpec.scala
@@ -924,4 +924,25 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         )
     }
   }
+  describe("(8): A Definition under an elideBlock scope") {
+    it("(8.a): should elide layer blocks") {
+      class Bar extends RawModule {
+        layer.block(layers.Verification) {
+          val a = WireInit(false.B)
+        }
+      }
+      class Foo extends RawModule {
+        layer.elideBlocks {
+          val barDef = Definition(new Bar)
+        }
+      }
+      ChiselStage
+        .emitCHIRRTL(new Foo)
+        .fileCheck()(
+          """|CHECK: module Bar :
+             |CHECK-NOT: layerblock
+             |""".stripMargin
+        )
+    }
+  }
 }

--- a/src/test/scala-2/chiselTests/experimental/hierarchy/InstantiateSpec.scala
+++ b/src/test/scala-2/chiselTests/experimental/hierarchy/InstantiateSpec.scala
@@ -535,8 +535,14 @@ class InstantiateSpec extends AnyFunSpec with Matchers with FileCheck {
       }
 
       emitCHIRRTL(new Foo).fileCheck()(
-        """|CHECK-COUNT-3: module
-           |CHECK-NOT:     module
+        """|CHECK:     module HasLayer :
+           |CHECK-NOT: module
+           |CHECK:       layerblock
+           |
+           |CHECK:     module HasLayer{{.*}} :
+           |CHECK-NOT:   layerblock
+           |
+           |CHECK:     module Foo :
            |""".stripMargin
       )
     }
@@ -551,9 +557,12 @@ class InstantiateSpec extends AnyFunSpec with Matchers with FileCheck {
         }
       }
 
-      emitCHIRRTL(new Foo).fileCheck()(
-        """|CHECK-COUNT-2: module
-           |CHECK-NOT:     module
+      emitCHIRRTL(new Foo).fileCheck("--implicit-check-not=module")(
+        """|CHECK:     module HasLayer :
+           |CHECK-NOT:   layerblock
+           |
+           |CHECK:     module Foo :
+           |CHECK-NOT:   layerblock
            |""".stripMargin
       )
     }


### PR DESCRIPTION
Fully fix a partially fixed bug where D/I (and Instantiate) would not
respect the `elideBlocks` API.  Specifically, for a Definition created in
an `elideBlocks` would still have layerblocks when these were supposed to
be fully inlined.

There was an incomplete fix [[1]] which landed previously which fixed the
problem of needing to include the `elideBlocks` state in the `Instantiate`
cache.  However, this failed to actually generate the module without the
layer blocks.

Fixes #5138.

[1]: a31363d87d72281b47df254989a429a033297892

#### Release Notes

Fix bug where `elideBlocks` would not inline all layer blocks inside a `Definition`.