### PR TITLE
Add FlattenInstanceAllowDedup

### DIFF
--- a/core/src/main/scala/chisel3/Annotation.scala
+++ b/core/src/main/scala/chisel3/Annotation.scala
@@ -10,7 +10,7 @@ import chisel3.experimental.AnyTargetable
 import firrtl.annotations._
 import firrtl.options.Unserializable
 import firrtl.passes.InlineAnnotation
-import firrtl.transforms.{DedupGroupAnnotation, NoDedupAnnotation}
+import firrtl.transforms.{DedupGroupAnnotation, FlattenAnnotation, NoDedupAnnotation}
 
 object annotate {
 
@@ -123,5 +123,29 @@ object inlineInstanceAllowDedup {
     */
   def apply[T <: RawModule](module: T): Unit = {
     annotate(module)(Seq(InlineAnnotation(module.toNamed)))
+  }
+}
+
+object flattenInstance {
+
+  /** Marks a module instance to be flattened. This module is excluded from deduplication, so any other instances of this
+    * same module won't be flattened.
+    *
+    * @param module The module instance to be marked
+    */
+  def apply[T <: RawModule](module: T): Unit = {
+    annotate(module)(Seq(FlattenAnnotation(module.toNamed), NoDedupAnnotation(module.toNamed)))
+  }
+}
+
+object flattenInstanceAllowDedup {
+
+  /** Marks a module instance to be flattened. If this module dedups with any other module, instances of that other
+    * module will also be flattened.
+    *
+    * @param module The module to be marked
+    */
+  def apply[T <: RawModule](module: T): Unit = {
+    annotate(module)(Seq(FlattenAnnotation(module.toNamed)))
   }
 }

--- a/src/main/scala/chisel3/util/experimental/Inline.scala
+++ b/src/main/scala/chisel3/util/experimental/Inline.scala
@@ -78,3 +78,10 @@ trait InlineInstanceAllowDedup { self: BaseModule =>
 trait FlattenInstance { self: BaseModule =>
   chisel3.experimental.annotate(self)(Seq(FlattenAnnotation(self.toNamed), NoDedupAnnotation(self.toNamed)))
 }
+
+/** Flattens all instances of a module. If this module dedups with any other
+  * module, instances of that other module will also be flattened.
+  */
+trait FlattenInstanceAllowDedup { self: BaseModule =>
+  chisel3.experimental.annotate(self)(Seq(FlattenAnnotation(self.toNamed)))
+}

--- a/src/test/scala/chiselTests/FlattenSpec.scala
+++ b/src/test/scala/chiselTests/FlattenSpec.scala
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiselTests
+
+import chisel3._
+import chisel3.experimental.dedupGroup
+import chisel3.testing.FileCheck
+import chisel3.util.experimental.{FlattenInstance, FlattenInstanceAllowDedup}
+import circt.stage.ChiselStage
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+object FlattenSpec {
+  trait SimpleIO {
+    val a = IO(Input(Bool()))
+    val b = IO(Output(Bool()))
+  }
+
+  class Leaf extends RawModule with SimpleIO {
+    b := ~a
+  }
+
+  class Middle extends RawModule with SimpleIO {
+    val leaf = Module(new Leaf)
+    leaf.a := a
+    b := leaf.b
+  }
+
+  class Parent extends RawModule with SimpleIO {
+    // Workaround for bug in anonymous module naming.
+    override def desiredName: String = "Parent"
+    val middle = Module(new Middle)
+    middle.a := a
+    b := middle.b
+  }
+}
+
+class FlattenSpec extends AnyFlatSpec with Matchers with FileCheck {
+  import FlattenSpec._
+
+  "FlattenInstance" should "Flatten only the instance marked with FlattenInstance and its children" in {
+    class Top extends RawModule with SimpleIO {
+      val notFlat = Module(new Parent)
+      val flat = Module(new Parent with FlattenInstance)
+      notFlat.a := a
+      flat.a := a
+      b := notFlat.b ^ flat.b
+    }
+    ChiselStage
+      .emitSystemVerilog(new Top)
+      .fileCheck("--implicit-check-not=module")(
+        """|CHECK: module Leaf
+           |CHECK: endmodule
+           |CHECK: module Middle
+           |CHECK: endmodule
+           |CHECK: module Parent
+           |CHECK: endmodule
+           |CHECK: module Parent_1
+           |CHECK: endmodule
+           |CHECK: module Top
+           |CHECK: endmodule
+           |""".stripMargin
+      )
+  }
+
+  "FlattenInstanceAllowDedup" should "Flatten any module that dedups with a module marked flatten" in {
+    class Top extends RawModule with SimpleIO {
+      val notFlat = Module(new Parent)
+      val flat = Module(new Parent with FlattenInstanceAllowDedup)
+      notFlat.a := a
+      flat.a := a
+      b := notFlat.b ^ flat.b
+    }
+    ChiselStage
+      .emitSystemVerilog(new Top)
+      .fileCheck("--implicit-check-not=module")(
+        """|CHECK: module Parent
+           |CHECK: endmodule
+           |CHECK: module Top
+           |CHECK: endmodule
+           |""".stripMargin
+      )
+  }
+}


### PR DESCRIPTION
We ought to make the normal inline and flattening APIs allow dedup as the reasons they blocked dedup are now better handled by prefixing + dedup groups, but within the current API this is still useful.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Feature (or new API)


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
