### PR TITLE
layer: add requireNotElideBlocksContext.

### DIFF
--- a/core/src/main/scala/chisel3/Layer.scala
+++ b/core/src/main/scala/chisel3/Layer.scala
@@ -2,6 +2,7 @@
 
 package chisel3
 
+import chisel3.ChiselException
 import chisel3.Data.ProbeInfo
 import chisel3.experimental.{requireIsHardware, SourceInfo, UnlocatableSourceInfo}
 import chisel3.internal.{Builder, HasId}
@@ -417,6 +418,18 @@ object layer {
     Builder.elideLayerBlocks = oldElideLayerBlocks
     return result
   }
+
+  case class ExpectedNotElideBlocks(message: String) extends ChiselException(message)
+
+  /** Throw exception if elideBlocks is active.
+    *
+    * @param msg when non-empty, prefixes (with ": ") message used in thrown exception.
+    */
+  def requireNotElideBlocksContext(msg: String = ""): Unit =
+    if (Builder.elideLayerBlocks) {
+      val prefix = if (msg.nonEmpty) s"$msg: " else ""
+      throw ExpectedNotElideBlocks(prefix + "must not be under elideBlocks context")
+    }
 
   /** Call this function from within a `Module` body to enable this layer globally for that module. */
   final def enable(layer: Layer): Unit = layer match {


### PR DESCRIPTION
This can be used to avoid layers being elided,
when generating under a layer is /required/.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [ ] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Feature (or new API)

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
