### PR TITLE
[core] Add Wire association support

### DIFF
--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -599,6 +599,13 @@ package experimental {
       }
     }
 
+    /** Get domain associations for any Data (port or wire) in this module.
+      * This is called during serialization to emit domain associations.
+      */
+    private[chisel3] def getAssociations(data: Data): Seq[domain.Type] = {
+      _associations.get(data).fold(Seq.empty[domain.Type])(_.toSeq)
+    }
+
     /** Get IOs that are currently bound to this module.
       */
     private[chisel3] def getIOs: Seq[Data] = {
@@ -619,30 +626,36 @@ package experimental {
 
     protected def portsSize: Int = _ports.size
 
-    /** Associate a port of this module with one or more domains. */
-    final def associate(port: Data, domains: domain.Type*)(implicit si: SourceInfo): Unit = {
-      require(domains.nonEmpty, "cannot associate a port with zero domains")
-      val portx = dataview.reifySingleTarget(port).getOrElse(port)
-      if (dataview.isView(portx)) {
-        Builder.error(s"Cannot associate a non 1-1 view ($portx) with domains")
+    /** Check if the given Data is a wire in this module. */
+    private def isWire(data: Data): Boolean = data.topBindingOpt match {
+      case Some(WireBinding(m, _)) if m == this => true
+      case _                                     => false
+    }
+
+    /** Associate a port or wire of this module with one or more domains. */
+    final def associate(data: Data, domains: domain.Type*)(implicit si: SourceInfo): Unit = {
+      require(domains.nonEmpty, "cannot associate a port or wire with zero domains")
+      val datax = dataview.reifySingleTarget(data).getOrElse(data)
+      if (dataview.isView(datax)) {
+        Builder.error(s"Cannot associate a non 1-1 view ($datax) with domains")
         return
       }
-      if (!portsContains(portx)) {
+      if (!portsContains(datax) && !isWire(datax)) {
         val domainsString = domains.mkString(", ")
         Builder.error(
-          s"""Unable to associate port '$portx' to domains '$domainsString' because the port does not exist in this module"""
+          s"""Unable to associate data '$datax' to domains '$domainsString' because it is not a port or wire in this module"""
         )(si)
         return
       }
-      _associations.updateWith(portx) {
+      _associations.updateWith(datax) {
         case Some(acc) => Some(acc ++= domains)
         case None      => Some(LinkedHashSet.empty[domain.Type] ++= domains)
       }
     }
 
-    /** Associate multiple ports of this module with one or more domains. */
-    final def associate(port: Seq[Data], domains: domain.Type*)(implicit si: SourceInfo): Unit = {
-      port.foreach(associate(_, domains: _*))
+    /** Associate multiple ports or wires of this module with one or more domains. */
+    final def associate(data: Seq[Data], domains: domain.Type*)(implicit si: SourceInfo): Unit = {
+      data.foreach(associate(_, domains: _*))
     }
 
     /** Generates the FIRRTL Component (Module or Blackbox) of this Module.

--- a/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
@@ -134,7 +134,7 @@ private[chisel3] object Converter {
     case e: DefPrim[_] =>
       val expr = convertPrim(e.op, e.args, e.sourceInfo, ctx)
       fir.DefNode(convert(e.sourceInfo), e.name, expr)
-    case e @ DefWire(info, id) =>
+    case e @ DefWire(info, id, _) =>
       fir.DefWire(convert(info), e.name, extractType(id, info, typeAliases))
     case e @ DefReg(info, id, clock) =>
       fir.DefRegister(

--- a/core/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -323,7 +323,8 @@ private[chisel3] object ir {
 
   case class DefInvalid(sourceInfo: SourceInfo, arg: Arg) extends Command
 
-  case class DefWire(sourceInfo: SourceInfo, id: Data) extends Definition
+  case class DefWire(sourceInfo: SourceInfo, id: Data, associations: Seq[domain.Type] = Seq.empty)
+      extends Definition
 
   case class DefReg(sourceInfo: SourceInfo, id: Data, clock: Arg) extends Definition
 

--- a/core/src/main/scala/chisel3/internal/firrtl/Serializer.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/Serializer.scala
@@ -210,8 +210,22 @@ private[chisel3] object Serializer {
       b ++= "node "; b ++= legalize(e.name); b ++= " = ";
       serializePrim(e.op, e.args, e.sourceInfo, ctx)
       serialize(e.sourceInfo)
-    case e @ DefWire(info, id) =>
-      b ++= "wire "; b ++= legalize(e.name); b ++= " : "; serializeType(id, info, typeAliases); serialize(e.sourceInfo)
+    case e @ DefWire(info, id, _) =>
+      b ++= "wire "; b ++= legalize(e.name); b ++= " : "; serializeType(id, info, typeAliases)
+      // Look up and emit domain associations
+      val associations = ctx.id match {
+        case rm: RawModule => rm.getAssociations(id)
+        case _             => Seq.empty[domain.Type]
+      }
+      if (associations.nonEmpty) {
+        b ++= " domains ["
+        associations.zipWithIndex.foreach { case (assoc, i) =>
+          if (i > 0) b ++= ", "
+          b ++= legalize(getRef(assoc, UnlocatableSourceInfo).name)
+        }
+        b ++= "]"
+      }
+      serialize(e.sourceInfo)
     case e @ DefReg(info, id, clock) =>
       b ++= "reg "; b ++= legalize(e.name); b ++= " : "; serializeType(id, info, typeAliases);
       b ++= ", "; serialize(clock, ctx, info)

--- a/src/test/scala/chiselTests/DomainSpec.scala
+++ b/src/test/scala/chiselTests/DomainSpec.scala
@@ -84,7 +84,7 @@ class DomainSpec extends AnyFlatSpec with Matchers with FileCheck {
 
     intercept[ChiselException] {
       ChiselStage.elaborate(new Foo, Array("--throw-on-first-error"))
-    }.getMessage should include("Unable to associate port")
+    }.getMessage should include("Unable to associate")
 
   }
 
@@ -137,7 +137,7 @@ class DomainSpec extends AnyFlatSpec with Matchers with FileCheck {
 
     intercept[IllegalArgumentException] {
       ChiselStage.elaborate(new Foo)
-    }.getMessage should include("cannot associate a port with zero domains")
+    }.getMessage should include("cannot associate a port or wire with zero domains")
 
   }
 
@@ -309,6 +309,104 @@ class DomainSpec extends AnyFlatSpec with Matchers with FileCheck {
     }
     exception.getMessage should include("requires 3 properties but got 1")
 
+  }
+
+  behavior of "Wire domain associations"
+
+  it should "allow associating a wire with a domain" in {
+    class Foo extends RawModule {
+      val A = IO(Input(ClockDomain.Type()))
+      val w = Wire(UInt(8.W))
+      associate(w, A)
+    }
+
+    ChiselStage.emitCHIRRTL(new Foo).fileCheck() {
+      """|CHECK: module Foo :
+         |CHECK:   input A : Domain of ClockDomain
+         |CHECK:   wire w : UInt<8> domains [A]
+         |""".stripMargin
+    }
+  }
+
+  it should "allow associating a wire with multiple domains" in {
+    object PowerDomain extends Domain {
+      override def fields = Seq(
+        ("name", Field.String),
+        ("voltage", Field.Integer)
+      )
+    }
+
+    class Foo extends RawModule {
+      val A = IO(Input(ClockDomain.Type()))
+      val B = IO(Input(PowerDomain.Type()))
+      val w = Wire(UInt(16.W))
+      associate(w, A, B)
+    }
+
+    ChiselStage.emitCHIRRTL(new Foo).fileCheck() {
+      """|CHECK: module Foo :
+         |CHECK:   wire w : UInt<16> domains [A, B]
+         |""".stripMargin
+    }
+  }
+
+  it should "error if associating a wire from another module" in {
+    class Bar extends RawModule {
+      val A = IO(Input(ClockDomain.Type()))
+      val w = Wire(UInt(8.W))
+    }
+
+    class Foo extends RawModule {
+      val bar = Module(new Bar)
+      val A = IO(Input(ClockDomain.Type()))
+      // Try to associate a wire from another module
+      associate(bar.w, A)
+    }
+
+    intercept[ChiselException] {
+      ChiselStage.elaborate(new Foo, Array("--throw-on-first-error"))
+    }.getMessage should include("Unable to associate")
+  }
+
+  it should "work with multiple wires" in {
+    class Foo extends RawModule {
+      val A = IO(Input(ClockDomain.Type()))
+      val w1 = Wire(UInt(8.W))
+      val w2 = Wire(UInt(8.W))
+      associate(Seq(w1, w2), A)
+    }
+
+    ChiselStage.emitCHIRRTL(new Foo).fileCheck() {
+      """|CHECK:   wire w1 : UInt<8> domains [A]
+         |CHECK:   wire w2 : UInt<8> domains [A]
+         |""".stripMargin
+    }
+  }
+
+  it should "error if given zero domains" in {
+    class Foo extends RawModule {
+      val w = Wire(UInt(8.W))
+      associate(w)
+    }
+
+    intercept[IllegalArgumentException] {
+      ChiselStage.elaborate(new Foo)
+    }.getMessage should include("cannot associate a port or wire with zero domains")
+  }
+
+  it should "fail to compile to SystemVerilog with current firtool (XFAIL until CIRCT support merged)" in {
+    class Foo extends RawModule {
+      val A = IO(Input(ClockDomain.Type()))
+      val w = Wire(UInt(8.W))
+      associate(w, A)
+    }
+
+    // This should fail with current firtool that doesn't support wire domain associations.
+    // Once CIRCT changes are merged and firtool is updated, this test should be changed
+    // to verify successful compilation.
+    intercept[RuntimeException] {
+      ChiselStage.emitSystemVerilog(new Foo)
+    }.getMessage should include("firtool returned a non-zero exit code")
   }
 
 }


### PR DESCRIPTION
Extend the current `associate` API to also allow specifying domain associations on wires.  This is necessary for certain libraries that eschew the existence of ports and use wires everywhere (e.g., diplomacy).

This introduces new FIRRTL syntax like the following to represent this:

    wire w: UInt<1> domains [A, B]

This syntax is not currently supported, but an outstanding PR adds support for it [[1]].  In the interim, this commit includes an XFAIL test that will start passing once CIRCT support lands.

[1]: https://github.com/llvm/circt/pull/10065

AI-assisted-by: Auggie (Claude Sonnet 4.5)

#### Release Notes

Extend `associate` API to allow specifying domain associations on wires.