### PR TITLE
Deprecate Convert phase

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -118,6 +118,7 @@ object v extends Module {
     "cat=deprecation&origin=chisel3\\.experimental\\.IntrinsicModule:s",
     "cat=deprecation&origin=chisel3\\.ltl.*:s",
     "cat=deprecation&origin=chisel3\\.InstanceId:s",
+    "cat=deprecation&origin=chisel3\\.stage\\.phases\\.Convert:s",
     // Deprecated for external users, will eventually be removed.
     "cat=deprecation&msg=Looking up Modules is deprecated:s",
     // Only for testing of deprecated APIs

--- a/src/main/scala/chisel3/stage/phases/Convert.scala
+++ b/src/main/scala/chisel3/stage/phases/Convert.scala
@@ -13,6 +13,7 @@ import firrtl.stage.FirrtlCircuitAnnotation
   *   - Extracts all `firrtl.annotations.Annotation`s from the `chisel3.internal.firrtl.Circuit`
   *   - Generates any needed `RunFirrtlTransformAnnotation`s from extracted `firrtl.annotations.Annotation`s
   */
+@deprecated("Converting to FIRRTL IR is deprecated, use ElaboratedCircuit instead.", "Chisel 7.11.0")
 class Convert extends Phase {
 
   override def prerequisites = Seq(Dependency[Elaborate])


### PR DESCRIPTION
It was already deprecated to use the converted FIRRTL IR, but users could avoid the deprecation message in some circumstances by using the phase directly.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- API deprecation


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

Use ElaboratedCircuit instead.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
