### PR TITLE
Add LTL past operator

### DIFF
--- a/src/main/scala-2/chisel3/ltl/LTLIntf.scala
+++ b/src/main/scala-2/chisel3/ltl/LTLIntf.scala
@@ -16,6 +16,15 @@ private[chisel3] trait SequenceIntf { self: Sequence =>
   /** See `Sequence.delayAtLeast`. */
   def delayAtLeast(delay: Int)(implicit sourceInfo: SourceInfo): Sequence = _delayAtLeastImpl(delay)
 
+  /** See [[Sequence.past]]. */
+  def past(delay: Int = 1)(implicit sourceInfo: SourceInfo): Sequence = _pastImpl(delay)
+
+  /** See [[Sequence.past]]. */
+  def past(clock: Clock)(implicit sourceInfo: SourceInfo): Sequence = _pastClockImpl(clock)
+
+  /** See [[Sequence.past]]. */
+  def past(delay: Int, clock: Clock)(implicit sourceInfo: SourceInfo): Sequence = _pastDelayClockImpl(delay, clock)
+
   /** See `Sequence.concat`. */
   def concat(other: Sequence)(implicit sourceInfo: SourceInfo): Sequence = _concatImpl(other)
 
@@ -116,6 +125,26 @@ private[chisel3] trait Sequence$Intf { self: Sequence.type =>
     * `##[delay:$]` in SVA.
     */
   def delayAtLeast(seq: Sequence, delay: Int)(implicit sourceInfo: SourceInfo): Sequence = _delayAtLeast(seq, delay)
+
+  /** Observe a sequence from a previous clock cycle.
+    *
+    * Equivalent to `$past(seq, delay)` in SVA.
+    */
+  def past(seq: Sequence, delay: Int = 1)(implicit sourceInfo: SourceInfo): Sequence = _past(seq, delay)
+
+  /** Observe a sequence from the previous clock cycle with an explicit clock.
+    *
+    * Equivalent to `$past(seq, 1, , @(posedge clock))` in SVA.
+    */
+  def past(seq: Sequence, clock: Clock)(implicit sourceInfo: SourceInfo): Sequence =
+    _pastClock(seq, 1, clock)
+
+  /** Observe a sequence from a previous clock cycle with an explicit clock.
+    *
+    * Equivalent to `$past(seq, delay, , @(posedge clock))` in SVA.
+    */
+  def past(seq: Sequence, delay: Int, clock: Clock)(implicit sourceInfo: SourceInfo): Sequence =
+    _pastClock(seq, delay, clock)
 
   /** Concatenate multiple sequences. Equivalent to
     * `arg0 ##0 arg1 ##0 ... ##0 argN` in SVA.

--- a/src/main/scala-3/chisel3/ltl/LTLIntf.scala
+++ b/src/main/scala-3/chisel3/ltl/LTLIntf.scala
@@ -16,6 +16,15 @@ private[chisel3] trait SequenceIntf { self: Sequence =>
   /** See `Sequence.delayAtLeast`. */
   def delayAtLeast(delay: Int)(using SourceInfo): Sequence = _delayAtLeastImpl(delay)
 
+  /** See [[Sequence.past]]. */
+  def past(delay: Int = 1)(using SourceInfo): Sequence = _pastImpl(delay)
+
+  /** See [[Sequence.past]]. */
+  def past(clock: Clock)(using SourceInfo): Sequence = _pastClockImpl(clock)
+
+  /** See [[Sequence.past]]. */
+  def past(delay: Int, clock: Clock)(using SourceInfo): Sequence = _pastDelayClockImpl(delay, clock)
+
   /** See `Sequence.concat`. */
   def concat(other: Sequence)(using SourceInfo): Sequence = _concatImpl(other)
 
@@ -116,6 +125,26 @@ private[chisel3] trait Sequence$Intf { self: Sequence.type =>
     * `##[delay:$]` in SVA.
     */
   def delayAtLeast(seq: Sequence, delay: Int)(using SourceInfo): Sequence = _delayAtLeast(seq, delay)
+
+  /** Observe a sequence from a previous clock cycle.
+    *
+    * Equivalent to `$past(seq, delay)` in SVA.
+    */
+  def past(seq: Sequence, delay: Int = 1)(using SourceInfo): Sequence = _past(seq, delay)
+
+  /** Observe a sequence from the previous clock cycle with an explicit clock.
+    *
+    * Equivalent to `$past(seq, 1, , @(posedge clock))` in SVA.
+    */
+  def past(seq: Sequence, clock: Clock)(using SourceInfo): Sequence =
+    _pastClock(seq, 1, clock)
+
+  /** Observe a sequence from a previous clock cycle with an explicit clock.
+    *
+    * Equivalent to `$past(seq, delay, , @(posedge clock))` in SVA.
+    */
+  def past(seq: Sequence, delay: Int, clock: Clock)(using SourceInfo): Sequence =
+    _pastClock(seq, delay, clock)
 
   /** Concatenate multiple sequences. Equivalent to
     * `arg0 ##0 arg1 ##0 ... ##0 argN` in SVA.

--- a/src/main/scala/chisel3/ltl/LTL.scala
+++ b/src/main/scala/chisel3/ltl/LTL.scala
@@ -56,6 +56,15 @@ sealed trait Sequence extends Property with SequenceIntf {
   protected def _delayAtLeastImpl(delay: Int)(implicit sourceInfo: SourceInfo): Sequence =
     Sequence._delayAtLeast(this, delay)
 
+  protected def _pastImpl(delay: Int)(implicit sourceInfo: SourceInfo): Sequence =
+    Sequence._past(this, delay)
+
+  protected def _pastClockImpl(clock: Clock)(implicit sourceInfo: SourceInfo): Sequence =
+    Sequence._pastClock(this, 1, clock)
+
+  protected def _pastDelayClockImpl(delay: Int, clock: Clock)(implicit sourceInfo: SourceInfo): Sequence =
+    Sequence._pastClock(this, delay, clock)
+
   protected def _concatImpl(other: Sequence)(implicit sourceInfo: SourceInfo): Sequence = Sequence._concat(this, other)
 
   protected def _repeatImpl(n: Int = 1)(implicit sourceInfo: SourceInfo): Sequence = Sequence._repeat(this, n)
@@ -125,6 +134,12 @@ object Sequence extends Sequence$Intf {
 
   protected def _delayAtLeast(seq: Sequence, delay: Int)(implicit sourceInfo: SourceInfo): Sequence =
     OpaqueSequence(LTLDelayIntrinsic(delay, None)(seq.inner))
+
+  protected def _past(seq: Sequence, delay: Int)(implicit sourceInfo: SourceInfo): Sequence =
+    OpaqueSequence(LTLPastIntrinsic(delay)(seq.inner))
+
+  protected def _pastClock(seq: Sequence, delay: Int, clock: Clock)(implicit sourceInfo: SourceInfo): Sequence =
+    OpaqueSequence(LTLPastIntrinsic(delay, Some(clock))(seq.inner))
 
   protected def _concat(arg0: Sequence, argN: Sequence*)(implicit sourceInfo: SourceInfo): Sequence = {
     var lhs = arg0

--- a/src/main/scala/chisel3/util/circt/LTLIntrinsics.scala
+++ b/src/main/scala/chisel3/util/circt/LTLIntrinsics.scala
@@ -81,6 +81,18 @@ private[chisel3] object LTLDelayIntrinsic {
   }
 }
 
+/** A wrapper intrinsic for the CIRCT `ltl.past` operation. */
+private[chisel3] object LTLPastIntrinsic {
+
+  def apply(delay: Int, clock: Option[Clock] = None)(_in: Bool)(implicit sourceInfo: SourceInfo) = {
+    val params = Seq("delay" -> IntParam(delay))
+    clock match {
+      case None      => UnaryLTLIntrinsic("past", params)(_in)
+      case Some(clk) => BinaryLTLIntrinsic("past", params)(_in, clk)
+    }
+  }
+}
+
 /** A wrapper intrinsic for the CIRCT `ltl.repeat` operation. */
 private[chisel3] object LTLRepeatIntrinsic {
 

--- a/src/test/scala/chiselTests/LTLSpec.scala
+++ b/src/test/scala/chiselTests/LTLSpec.scala
@@ -68,6 +68,32 @@ class LTLSpec extends AnyFlatSpec with Matchers with ChiselSim {
     ChiselStage.emitSystemVerilog(new DelaysMod)
   }
 
+  class PastMod extends RawModule {
+    implicit val info: SourceInfo = SourceLine("Foo.scala", 1, 2)
+    val a, b = IO(Input(Bool()))
+    val clock = IO(Input(Clock()))
+    val s0: Sequence = a.past()
+    val s1: Sequence = a.past(3)
+    val s2: Sequence = Sequence.past(b, 2)
+    val s3: Sequence = a.past(clock)
+    val s4: Sequence = a.past(2, clock)
+  }
+  it should "support sequence past operations" in {
+    val chirrtl = ChiselStage.emitCHIRRTL(new PastMod)
+    val sourceLoc = "@[Foo.scala 1:2]"
+    chirrtl should include("input a : UInt<1>")
+    chirrtl should include("input b : UInt<1>")
+    chirrtl should include("input clock : Clock")
+    chirrtl should include(s"node ltl_past = intrinsic(circt_ltl_past<delay = 1> : UInt<1>, a) $sourceLoc")
+    chirrtl should include(s"node ltl_past_1 = intrinsic(circt_ltl_past<delay = 3> : UInt<1>, a) $sourceLoc")
+    chirrtl should include(s"node ltl_past_2 = intrinsic(circt_ltl_past<delay = 2> : UInt<1>, b) $sourceLoc")
+    chirrtl should include(s"node ltl_past_3 = intrinsic(circt_ltl_past<delay = 1> : UInt<1>, a, clock) $sourceLoc")
+    chirrtl should include(s"node ltl_past_4 = intrinsic(circt_ltl_past<delay = 2> : UInt<1>, a, clock) $sourceLoc")
+  }
+  it should "compile sequence past operations" in {
+    ChiselStage.emitSystemVerilog(new PastMod)
+  }
+
   class ConcatMod extends RawModule {
     implicit val info: SourceInfo = SourceLine("Foo.scala", 1, 2)
     val a, b, c, d, e = IO(Input(Bool()))


### PR DESCRIPTION
CIRCT has recently gained the `circt.ltl.past` FIRRTL intrinsic which allows us to emit `$past` expressions in SystemVerilog assertions. Add a corresponding `Sequence.past(...)` operator, which allows the user to refer to past values of a sequence, optionally with a cycle delay != 1, and optionally with an explicit clock instead of the one inferred for the sequence.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

- Feature (or new API)

#### Desired Merge Strategy

- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
