### PR TITLE
[testing] Move D/I Mem tests to MemorySpec

### DIFF
--- a/src/test/scala-2/chiselTests/Mem.scala
+++ b/src/test/scala-2/chiselTests/Mem.scala
@@ -3,8 +3,10 @@
 package chiselTests
 
 import chisel3._
+import chisel3.experimental.hierarchy.{instantiable, public, Definition, Instance}
 import chisel3.simulator.scalatest.ChiselSim
 import chisel3.simulator.stimulus.RunUntilFinished
+import chisel3.testing.scalatest.FileCheck
 import chisel3.util.{is, switch, Counter, SRAM}
 import circt.stage.ChiselStage
 import org.scalatest.propspec.AnyPropSpec
@@ -342,7 +344,13 @@ class MemMaskedReadWriteTester extends Module {
   }
 }
 
-class MemorySpec extends AnyPropSpec with Matchers with ChiselSim {
+@instantiable
+class HasMems() extends Module {
+  @public val mem = Mem(8, UInt(32.W))
+  @public val syncReadMem = SyncReadMem(8, UInt(32.W))
+}
+
+class MemorySpec extends AnyPropSpec with Matchers with ChiselSim with FileCheck {
   property("Mem of Vec should work") {
     simulate(new MemVecTester)(RunUntilFinished(3))
   }
@@ -450,8 +458,38 @@ class MemorySpec extends AnyPropSpec with Matchers with ChiselSim {
     }
     ChiselStage.emitSystemVerilog(new TestModule)
   }
-}
 
+  property("Definition/Instance should work with Mems/SyncReadMems") {
+    import chiselTests.experimental.hierarchy.Annotations._
+    class Top() extends Module {
+      val i = Definition(new HasMems())
+      mark(i.mem, "Mem")
+      mark(i.syncReadMem, "SyncReadMem")
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~|HasMems>mem"
+             |CHECK-NEXT: "tag":"Mem"
+             |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~|HasMems>syncReadMem"
+             |CHECK-NEXT: "tag":"SyncReadMem"
+             |""".stripMargin
+        )
+    }
+  }
+  property("Definition/Instance with Mems should not create memory ports") {
+    class Top() extends Module {
+      val i = Definition(new HasMems())
+      i.mem(0) := 100.U // should be illegal!
+    }
+    intercept[ChiselException] {
+      ChiselStage.elaborate(new Top)
+    }.getMessage should include(
+      "Cannot create a memory port in a different module (Top) than where the memory is (HasMems)."
+    )
+  }
+}
 class SRAMSpec extends AnyFunSpec with Matchers {
   describe("SRAM") {
     val portCombos: Seq[(Int, Int, Int)] =

--- a/src/test/scala-2/chiselTests/experimental/hierarchy/DefinitionSpec.scala
+++ b/src/test/scala-2/chiselTests/experimental/hierarchy/DefinitionSpec.scala
@@ -569,36 +569,8 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
              |""".stripMargin
         )
     }
-    it("(3.n): should work on Mems/SyncReadMems") {
-      class Top() extends Module {
-        val i = Definition(new HasMems())
-        mark(i.mem, "Mem")
-        mark(i.syncReadMem, "SyncReadMem")
-      }
-      ChiselStage
-        .emitCHIRRTL(new Top)
-        .fileCheck()(
-          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~|HasMems>mem"
-             |CHECK-NEXT: "tag":"Mem"
-             |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~|HasMems>syncReadMem"
-             |CHECK-NEXT: "tag":"SyncReadMem"
-             |""".stripMargin
-        )
-    }
-    it("(3.o): should not create memory ports") {
-      class Top() extends Module {
-        val i = Definition(new HasMems())
-        i.mem(0) := 100.U // should be illegal!
-      }
-      intercept[ChiselException] {
-        ChiselStage.elaborate(new Top)
-      }.getMessage should include(
-        "Cannot create a memory port in a different module (Top) than where the memory is (HasMems)."
-      )
-    }
-    it("(3.p): should work on HasTarget") {
+
+    it("(3.n): should work on HasTarget") {
       class Top() extends Module {
         val i = Definition(new HasHasTarget)
         mark(i.x, "x")
@@ -612,7 +584,7 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
              |""".stripMargin
         )
     }
-    it("(3.q): should work on Tuple5 with a Module in it") {
+    it("(3.o): should work on Tuple5 with a Module in it") {
       class Top() extends Module {
         val defn = Definition(new HasTuple5())
         val (3, w: UInt, "hi", inst: Instance[AddOne], l) = defn.tup

--- a/src/test/scala-2/chiselTests/experimental/hierarchy/Examples.scala
+++ b/src/test/scala-2/chiselTests/experimental/hierarchy/Examples.scala
@@ -289,12 +289,6 @@ object Examples {
   }
 
   @instantiable
-  class HasMems() extends Module {
-    @public val mem = Mem(8, UInt(32.W))
-    @public val syncReadMem = SyncReadMem(8, UInt(32.W))
-  }
-
-  @instantiable
   class LeafInstantiable(val bundle: Data) {
     @public val bundle = bundle
   }

--- a/src/test/scala/chiselTests/experimental/hierarchy/Annotations.scala
+++ b/src/test/scala/chiselTests/experimental/hierarchy/Annotations.scala
@@ -8,7 +8,7 @@ import chisel3.{Data, HasTarget, MemBase}
 import chisel3.experimental.hierarchy.{Definition, Hierarchy, Instance}
 
 // These annotations exist purely for testing purposes
-private[hierarchy] object Annotations {
+object Annotations {
   case class MarkAnnotation(target: IsMember, tag: String) extends SingleTargetAnnotation[IsMember] {
     def duplicate(n: IsMember): Annotation = this.copy(target = n)
   }


### PR DESCRIPTION
In anticipation of Scala 3 D/I
### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [ ] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [ ] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Internal or build-related (includes code refactoring/cleanup)


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
