### PR TITLE
[core] Add Property Assert API

### DIFF
--- a/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
@@ -192,6 +192,8 @@ private[chisel3] object Converter {
       fir.Connect(convert(info), convert(loc, ctx, info), convert(exp, ctx, info))
     case PropAssign(info, loc, exp) =>
       fir.PropAssign(convert(info), convert(loc, ctx, info), convert(exp, ctx, info))
+    case PropertyAssert(info, cond, msg) =>
+      fir.PropertyAssert(convert(info), convert(cond, ctx, info), msg)
     case Attach(info, locs) =>
       fir.Attach(convert(info), locs.map(l => convert(l, ctx, info)))
     case DefInvalid(info, arg) =>

--- a/core/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -482,6 +482,7 @@ private[chisel3] object ir {
 
   case class Connect(sourceInfo: SourceInfo, loc: Arg, exp: Arg) extends Command
   case class PropAssign(sourceInfo: SourceInfo, loc: Node, exp: Arg) extends Command
+  case class PropertyAssert(sourceInfo: SourceInfo, condition: Arg, message: String) extends Command
   case class Attach(sourceInfo: SourceInfo, locs: Seq[Node]) extends Command
   case class Stop(id: stop.Stop, sourceInfo: SourceInfo, clock: Arg, ret: Int) extends Definition
 

--- a/core/src/main/scala/chisel3/internal/firrtl/Serializer.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/Serializer.scala
@@ -273,6 +273,8 @@ private[chisel3] object Serializer {
       b ++= "connect "; serialize(loc, ctx, info); b ++= ", "; serialize(exp, ctx, info); serialize(info)
     case PropAssign(info, loc, exp) =>
       b ++= "propassign "; serialize(loc, ctx, info); b ++= ", "; serialize(exp, ctx, info); serialize(info)
+    case PropertyAssert(info, cond, msg) =>
+      b ++= "propassert "; serialize(cond, ctx, info); b ++= ", \""; b ++= msg; b += '"'; serialize(info)
     case Attach(info, locs) =>
       b ++= "attach ("
       serializeArgs(locs, ctx, info)

--- a/core/src/main/scala/chisel3/properties/Class.scala
+++ b/core/src/main/scala/chisel3/properties/Class.scala
@@ -8,7 +8,18 @@ import chisel3.experimental.{BaseModule, SourceInfo}
 import chisel3.experimental.hierarchy.{Definition, Instance, ModuleClone}
 import chisel3.internal.{throwException, Builder}
 import chisel3.internal.binding.{ClassBinding, OpBinding}
-import chisel3.internal.firrtl.ir.{Arg, Block, Command, Component, DefClass, DefObject, ModuleIO, Port, PropAssign}
+import chisel3.internal.firrtl.ir.{
+  Arg,
+  Block,
+  Command,
+  Component,
+  DefClass,
+  DefObject,
+  ModuleIO,
+  Port,
+  PropAssign,
+  PropertyAssert
+}
 import chisel3.internal.firrtl.Converter
 import chisel3.layer.Layer
 
@@ -84,6 +95,12 @@ class Class extends BaseModule {
     * Most commands are unsupported in Class, so the internal addCommand API explicitly supports certain commands.
     */
   private[chisel3] def addCommand(c: PropAssign): Unit = addCommandImpl(c)
+
+  /** Add a PropertyAssert command to the Class
+    *
+    * Most commands are unsupported in Class, so the internal addCommand API explicitly supports certain commands.
+    */
+  private[chisel3] def addCommand(c: PropertyAssert): Unit = addCommandImpl(c)
 
   /** Add a DefObject command to the Class
     *

--- a/core/src/main/scala/chisel3/properties/Property.scala
+++ b/core/src/main/scala/chisel3/properties/Property.scala
@@ -5,6 +5,7 @@ package properties
 
 import firrtl.{ir => fir}
 import firrtl.annotations.{InstanceTarget, IsMember, ModuleTarget, ReferenceTarget, Target}
+import chisel3.RawModule
 import chisel3.internal._
 import chisel3.internal.binding._
 import chisel3.internal.firrtl.{ir, Converter}
@@ -340,6 +341,17 @@ sealed trait Property[T] extends Element { self =>
   ): Property[T] = {
     ev.concat(this, that)
   }
+
+  /** Assert that this boolean property holds (only available for Property[Boolean])
+    *
+    * @param message the assertion message
+    */
+  final def assert(message: String)(
+    implicit ev: T =:= Boolean,
+    sourceInfo:  SourceInfo
+  ): Unit = {
+    PropertyBooleanOps.assert(this.asInstanceOf[Property[Boolean]], message)
+  }
 }
 
 private[chisel3] sealed trait ClassTypeProvider[A] {
@@ -507,6 +519,26 @@ object PropertyStringOps {
   }
 
   implicit val stringOps: PropertyStringOps[Property[String]] = new StringOpsImpl
+}
+
+/** Operations for Property[Boolean].
+  *
+  * Property assertions do not have names or labels - just a condition and message.
+  */
+object PropertyBooleanOps {
+
+  /** Assert that a boolean property holds
+    *
+    * @param cond the boolean property condition
+    * @param message the assertion message to display if the assertion fails
+    */
+  def assert(cond: Property[Boolean], message: String)(implicit sourceInfo: SourceInfo): Unit =
+    Builder.referenceUserContainer match {
+      case rm: RawModule =>
+        rm.addCommand(firrtl.ir.PropertyAssert(sourceInfo, cond.ref, message))
+      case cls: Class =>
+        cls.addCommand(firrtl.ir.PropertyAssert(sourceInfo, cond.ref, message))
+    }
 }
 
 /** Companion object for Property.

--- a/firrtl/src/main/scala/firrtl/ir/IR.scala
+++ b/firrtl/src/main/scala/firrtl/ir/IR.scala
@@ -413,6 +413,11 @@ case class Connect(info: Info, loc: Expression, expr: Expression) extends Statem
 @deprecated("All APIs in package firrtl are deprecated.", "Chisel 7.0.0")
 case class PropAssign(info: Info, loc: Expression, expr: Expression) extends Statement with HasInfo with UseSerializer
 @deprecated("All APIs in package firrtl are deprecated.", "Chisel 7.0.0")
+case class PropertyAssert(info: Info, condition: Expression, message: String)
+    extends Statement
+    with HasInfo
+    with UseSerializer
+@deprecated("All APIs in package firrtl are deprecated.", "Chisel 7.0.0")
 case class IsInvalid(info: Info, expr: Expression) extends Statement with HasInfo with UseSerializer
 @deprecated("All APIs in package firrtl are deprecated.", "Chisel 7.0.0")
 case class Attach(info: Info, exprs: Seq[Expression]) extends Statement with HasInfo with UseSerializer

--- a/src/test/scala-2/chiselTests/properties/PropertyAssertSpec.scala
+++ b/src/test/scala-2/chiselTests/properties/PropertyAssertSpec.scala
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiselTests.properties
+
+import chisel3._
+import chisel3.experimental.hierarchy.Definition
+import chisel3.properties.{Class, Property}
+import chisel3.testing.scalatest.FileCheck
+import circt.stage.ChiselStage
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class PropertyAssertSpec extends AnyFlatSpec with Matchers with FileCheck {
+  behavior.of("PropertyAssert")
+
+  it should "work in a RawModule" in {
+    ChiselStage
+      .emitCHIRRTL(new RawModule {
+        val prop = IO(Input(Property[Boolean]()))
+        prop.assert("must be true")
+      })
+      .fileCheck() {
+        """|CHECK: input prop : Bool
+           |CHECK: propassert prop, "must be true"
+           |""".stripMargin
+      }
+  }
+
+  it should "work in a Class" in {
+    ChiselStage
+      .emitCHIRRTL(new RawModule {
+        Definition(new Class {
+          override def desiredName = "TestClass"
+          val prop = IO(Input(Property[Boolean]()))
+          prop.assert("must be true")
+        })
+      })
+      .fileCheck() {
+        """|CHECK: class TestClass :
+           |CHECK: input prop : Bool
+           |CHECK: propassert prop, "must be true"
+           |""".stripMargin
+      }
+  }
+
+  it should "fail to compile to SystemVerilog (not yet supported in CIRCT)" in {
+    val exception = intercept[Exception] {
+      ChiselStage.emitSystemVerilog(new RawModule {
+        val prop = IO(Input(Property[Boolean]()))
+        prop.assert("must be true")
+      })
+    }
+    exception.getMessage should include("use of unknown declaration 'propassert'")
+    // This test documents that PropertyAssert is not yet supported in CIRCT's SystemVerilog emission
+    // When CIRCT support is added, this test should be updated or removed
+  }
+}

--- a/src/test/scala/chiselTests/properties/PropertyAssertSpec.scala
+++ b/src/test/scala/chiselTests/properties/PropertyAssertSpec.scala
@@ -43,15 +43,10 @@ class PropertyAssertSpec extends AnyFlatSpec with Matchers with FileCheck {
       }
   }
 
-  it should "fail to compile to SystemVerilog (not yet supported in CIRCT)" in {
-    val exception = intercept[Exception] {
-      ChiselStage.emitSystemVerilog(new RawModule {
-        val prop = IO(Input(Property[Boolean]()))
-        prop.assert("must be true")
-      })
-    }
-    exception.getMessage should include("use of unknown declaration 'propassert'")
-    // This test documents that PropertyAssert is not yet supported in CIRCT's SystemVerilog emission
-    // When CIRCT support is added, this test should be updated or removed
+  it should "compile to SystemVerilog" in {
+    ChiselStage.emitSystemVerilog(new RawModule {
+      val prop = IO(Input(Property[Boolean]()))
+      prop.assert("must be true")
+    })
   }
 }


### PR DESCRIPTION
Add a new API for generating FIRRTL property assertions.  These are
assertions that will trigger at compile time (if known to be constant) or
runtime during OM evaluation (or domaintool evaluation).

This is intended to be used for things like restricting unsafe domain
casts for rational clock crossings to require a rational relationship
between the underlying clocks (as expressed using property asserts against
the domain fields).

There is more necessary to make this usable, specifically, additional
operations for doing comparisons of properties.  This will happen in a
follow-on.

AI-assisted-by: Claude Code (Claude Sonnet 4.6)

#### Release Notes

Add property assert API.
