### PR TITLE
Bump firtool-resolver to 2.1.0

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -88,7 +88,7 @@ object v extends Module {
   val jmhVersion = "1.37"
   val osLib = mvn"com.lihaoyi::os-lib:0.10.7" // 0.11 requires Java 11
   val upickle = mvn"com.lihaoyi::upickle:3.3.1" // upickle 4.0 requires Scala 3.4 (we target Scala 3.3 LTS)
-  val firtoolResolver = mvn"org.chipsalliance::firtool-resolver:2.0.1"
+  val firtoolResolver = mvn"org.chipsalliance::firtool-resolver:2.1.0"
   val scalatest = mvn"org.scalatest::scalatest:3.2.20"
   val scalacheck = mvn"org.scalatestplus::scalacheck-1-18:3.2.19.0"
   val json4s = mvn"io.github.json4s::json4s-native:4.1.0"


### PR DESCRIPTION
Currently failing because Maven is being slow at publishing [firtool-resolver v2.1.0](https://github.com/chipsalliance/firtool-resolver/releases/tag/v2.1.0).

#### Type of Improvement
- Dependency update


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

This will enable use of arm64 builds on macos for the next firtool release (but not for 1.144.0).

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
