### PR TITLE
[core] Add property equality API/operation

### DIFF
--- a/core/src/main/scala/chisel3/properties/Property.scala
+++ b/core/src/main/scala/chisel3/properties/Property.scala
@@ -384,7 +384,7 @@ private[chisel3] object ClassTypeProvider {
 /** Helpers for building Property expressions.
   */
 private object PropertyExpressionHelpers {
-  import chisel3.internal.binding.{WireBinding, ClassBinding}
+  import chisel3.internal.binding.{ClassBinding, WireBinding}
 
   // Helper to create a Property wire that works in RawModule contexts.  Class
   // contexts don't support intermediate wires for property expressions.
@@ -401,7 +401,9 @@ private object PropertyExpressionHelpers {
         wire.asInstanceOf[Property[T]]
       }
       case _: Class =>
-        Builder.exception("Property expressions are currently only supported in RawModules (not yet supported in Classes)")
+        Builder.exception(
+          "Property expressions are currently only supported in RawModules (not yet supported in Classes)"
+        )
       case _ =>
         Builder.exception("Property expressions are currently only supported in RawModules")
     }

--- a/core/src/main/scala/chisel3/properties/Property.scala
+++ b/core/src/main/scala/chisel3/properties/Property.scala
@@ -352,6 +352,20 @@ sealed trait Property[T] extends Element { self =>
   ): Unit = {
     PropertyBooleanOps.assert(this.asInstanceOf[Property[Boolean]], message)
   }
+
+  /** Property equality comparison
+    *
+    * Compares two properties of the same type and returns a Property[Boolean].
+    *
+    * @param that the property to compare with
+    * @return Property[Boolean] indicating whether the two properties are equal
+    */
+  final def ===(that: Property[T])(
+    implicit ev: PropertyEqualityOps[Property[T]],
+    sourceInfo:  SourceInfo
+  ): Property[Boolean] = {
+    ev.propEq(this, that)
+  }
 }
 
 private[chisel3] sealed trait ClassTypeProvider[A] {
@@ -370,6 +384,29 @@ private[chisel3] object ClassTypeProvider {
 /** Helpers for building Property expressions.
   */
 private object PropertyExpressionHelpers {
+  import chisel3.internal.binding.{WireBinding, ClassBinding}
+
+  // Helper to create a Property wire that works in RawModule contexts.  Class
+  // contexts don't support intermediate wires for property expressions.
+  private def createPropertyWire[T](template: Property[T])(
+    implicit sourceInfo: SourceInfo
+  ): Property[T] = {
+    val contextMod = Builder.referenceUserContainer
+    contextMod match {
+      case mod: RawModule => {
+        val wire = Property.makeWithValueOpt(template.tpe)
+        wire.autoSeed("_propExpr")
+        wire.bind(WireBinding(mod, Builder.currentBlock))
+        mod.addCommand(ir.DefWire(sourceInfo, wire))
+        wire.asInstanceOf[Property[T]]
+      }
+      case _: Class =>
+        Builder.exception("Property expressions are currently only supported in RawModules (not yet supported in Classes)")
+      case _ =>
+        Builder.exception("Property expressions are currently only supported in RawModules")
+    }
+  }
+
   // Helper function to create Property expression IR.
   def binOp[T](
     sourceInfo: SourceInfo,
@@ -379,26 +416,42 @@ private object PropertyExpressionHelpers {
   ): Property[T] = {
     implicit val info = sourceInfo
 
-    // Get the containing RawModule, or throw an error. We can only use the temporary Wire approach in RawModule, so at
-    // least give a decent error explaining this current shortcoming.
-    val currentModule = Builder.referenceUserContainer match {
-      case mod: RawModule => mod
-      case other =>
-        Builder.exception("Property expressions are currently only supported in RawModules")
-    }
-
-    // Create a temporary Wire to assign the expression to. We currently don't support Nodes for Property types.
-    val wire = Wire(chiselTypeOf(lhs))
-    wire.autoSeed("_propExpr")
+    // Create a temporary Wire to assign the expression to (validates we're in a RawModule).
+    val wire = createPropertyWire(lhs)(sourceInfo)
 
     // Create a PropExpr with the correct type, operation, and operands.
     val propExpr = ir.PropExpr(sourceInfo, lhs.tpe.getPropertyType(), op, List(lhs.ref, rhs.ref))
 
-    // Directly add a PropAssign command assigning the PropExpr to the Wire.
-    currentModule.addCommand(ir.PropAssign(sourceInfo, wire.lref, propExpr))
+    // Add the PropAssign command.
+    val mod = Builder.referenceUserContainer.asInstanceOf[RawModule]
+    mod.addCommand(ir.PropAssign(sourceInfo, wire.lref, propExpr))
 
     // Return the temporary Wire as the result.
     wire.asInstanceOf[Property[T]]
+  }
+
+  // Helper function for comparison operations that return Property[Boolean].
+  def cmpOp[T](
+    sourceInfo: SourceInfo,
+    op:         fir.PropPrimOp,
+    lhs:        Property[T],
+    rhs:        Property[T]
+  ): Property[Boolean] = {
+    implicit val info = sourceInfo
+
+    // Create a temporary Wire for the Boolean result (validates we're in a RawModule).
+    val boolTemplate = Property[Boolean]()
+    val wire = createPropertyWire(boolTemplate)(sourceInfo)
+
+    // Create a PropExpr with Boolean type, operation, and operands.
+    val propExpr = ir.PropExpr(sourceInfo, fir.BooleanPropertyType, op, List(lhs.ref, rhs.ref))
+
+    // Add the PropAssign command.
+    val mod = Builder.referenceUserContainer.asInstanceOf[RawModule]
+    mod.addCommand(ir.PropAssign(sourceInfo, wire.lref, propExpr))
+
+    // Return the temporary Wire as the result.
+    wire.asInstanceOf[Property[Boolean]]
   }
 
   // Helper function to create variadic Property expression IR.
@@ -410,23 +463,15 @@ private object PropertyExpressionHelpers {
     require(operands.nonEmpty, "variadicOp requires at least one operand")
     implicit val info = sourceInfo
 
-    // Get the containing RawModule, or throw an error. We can only use the temporary Wire approach in RawModule, so at
-    // least give a decent error explaining this current shortcoming.
-    val currentModule = Builder.referenceUserContainer match {
-      case mod: RawModule => mod
-      case other =>
-        Builder.exception("Property expressions are currently only supported in RawModules")
-    }
-
-    // Create a temporary Wire to assign the expression to. We currently don't support Nodes for Property types.
-    val wire = Wire(chiselTypeOf(operands.head))
-    wire.autoSeed("_propExpr")
+    // Create a temporary Wire to assign the expression to (validates we're in a RawModule).
+    val wire = createPropertyWire(operands.head)(sourceInfo)
 
     // Create a PropExpr with the correct type, operation, and operands.
     val propExpr = ir.PropExpr(sourceInfo, operands.head.tpe.getPropertyType(), op, operands.map(_.ref).toList)
 
-    // Directly add a PropAssign command assigning the PropExpr to the Wire.
-    currentModule.addCommand(ir.PropAssign(sourceInfo, wire.lref, propExpr))
+    // Add the PropAssign command.
+    val mod = Builder.referenceUserContainer.asInstanceOf[RawModule]
+    mod.addCommand(ir.PropAssign(sourceInfo, wire.lref, propExpr))
 
     // Return the temporary Wire as the result.
     wire.asInstanceOf[Property[T]]
@@ -519,6 +564,50 @@ object PropertyStringOps {
   }
 
   implicit val stringOps: PropertyStringOps[Property[String]] = new StringOpsImpl
+}
+
+/** Typeclass for Property equality operations.
+  */
+@implicitNotFound("equality operations are not supported on Property type ${T}")
+sealed trait PropertyEqualityOps[T] {
+  def propEq(lhs: T, rhs: T)(implicit sourceInfo: SourceInfo): Property[Boolean]
+}
+
+object PropertyEqualityOps {
+  import PropertyExpressionHelpers._
+
+  // Type class instances for Property equality operations.
+  implicit val boolEqualityOps: PropertyEqualityOps[Property[Boolean]] =
+    new PropertyEqualityOps[Property[Boolean]] {
+      def propEq(lhs: Property[Boolean], rhs: Property[Boolean])(
+        implicit sourceInfo: SourceInfo
+      ): Property[Boolean] =
+        cmpOp(sourceInfo, fir.PropEqOp, lhs, rhs)
+    }
+
+  implicit val intEqualityOps: PropertyEqualityOps[Property[Int]] =
+    new PropertyEqualityOps[Property[Int]] {
+      def propEq(lhs: Property[Int], rhs: Property[Int])(implicit sourceInfo: SourceInfo): Property[Boolean] =
+        cmpOp(sourceInfo, fir.PropEqOp, lhs, rhs)
+    }
+
+  implicit val longEqualityOps: PropertyEqualityOps[Property[Long]] =
+    new PropertyEqualityOps[Property[Long]] {
+      def propEq(lhs: Property[Long], rhs: Property[Long])(implicit sourceInfo: SourceInfo): Property[Boolean] =
+        cmpOp(sourceInfo, fir.PropEqOp, lhs, rhs)
+    }
+
+  implicit val bigIntEqualityOps: PropertyEqualityOps[Property[BigInt]] =
+    new PropertyEqualityOps[Property[BigInt]] {
+      def propEq(lhs: Property[BigInt], rhs: Property[BigInt])(implicit sourceInfo: SourceInfo): Property[Boolean] =
+        cmpOp(sourceInfo, fir.PropEqOp, lhs, rhs)
+    }
+
+  implicit val stringEqualityOps: PropertyEqualityOps[Property[String]] =
+    new PropertyEqualityOps[Property[String]] {
+      def propEq(lhs: Property[String], rhs: Property[String])(implicit sourceInfo: SourceInfo): Property[Boolean] =
+        cmpOp(sourceInfo, fir.PropEqOp, lhs, rhs)
+    }
 }
 
 /** Operations for Property[Boolean].

--- a/firrtl/src/main/scala/firrtl/ir/IR.scala
+++ b/firrtl/src/main/scala/firrtl/ir/IR.scala
@@ -303,6 +303,8 @@ case object IntegerShlOp extends PropPrimOp("integer_shl")
 case object ListConcatOp extends PropPrimOp("list_concat")
 @deprecated("All APIs in package firrtl are deprecated.", "Chisel 7.0.0")
 case object StringConcatOp extends PropPrimOp("string_concat")
+@deprecated("All APIs in package firrtl are deprecated.", "Chisel 7.0.0")
+case object PropEqOp extends PropPrimOp("prop_eq")
 
 /** Property expressions.
   *

--- a/src/test/scala-2/chiselTests/properties/PropertyEqualitySpec.scala
+++ b/src/test/scala-2/chiselTests/properties/PropertyEqualitySpec.scala
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiselTests.properties
+
+import chisel3._
+import chisel3.experimental.hierarchy.Definition
+import chisel3.properties.{Class, Property}
+import chisel3.testing.scalatest.FileCheck
+import circt.stage.ChiselStage
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class PropertyEqualitySpec extends AnyFlatSpec with Matchers with FileCheck {
+  behavior.of("PropertyEquality")
+
+  it should "work with Property[Boolean]" in {
+    ChiselStage
+      .emitCHIRRTL(new RawModule {
+        val a = IO(Input(Property[Boolean]()))
+        val b = IO(Input(Property[Boolean]()))
+        val eq = IO(Output(Property[Boolean]()))
+        eq := a === b
+      })
+      .fileCheck() {
+        """|CHECK: input a : Bool
+           |CHECK: input b : Bool
+           |CHECK: output eq : Bool
+           |CHECK: wire {{.+}} : Bool
+           |CHECK: propassign {{.+}}, prop_eq(a, b)
+           |CHECK: propassign eq, {{.+}}
+           |""".stripMargin
+      }
+  }
+
+  it should "work with Property[Int]" in {
+    ChiselStage
+      .emitCHIRRTL(new RawModule {
+        val a = IO(Input(Property[Int]()))
+        val b = IO(Input(Property[Int]()))
+        val eq = IO(Output(Property[Boolean]()))
+        eq := a === b
+      })
+      .fileCheck() {
+        """|CHECK: input a : Integer
+           |CHECK: input b : Integer
+           |CHECK: output eq : Bool
+           |CHECK: wire {{.+}} : Bool
+           |CHECK: propassign {{.+}}, prop_eq(a, b)
+           |CHECK: propassign eq, {{.+}}
+           |""".stripMargin
+      }
+  }
+
+  it should "work with Property[String]" in {
+    ChiselStage
+      .emitCHIRRTL(new RawModule {
+        val a = IO(Input(Property[String]()))
+        val b = IO(Input(Property[String]()))
+        val eq = IO(Output(Property[Boolean]()))
+        eq := a === b
+      })
+      .fileCheck() {
+        """|CHECK: input a : String
+           |CHECK: input b : String
+           |CHECK: output eq : Bool
+           |CHECK: wire {{.+}} : Bool
+           |CHECK: propassign {{.+}}, prop_eq(a, b)
+           |CHECK: propassign eq, {{.+}}
+           |""".stripMargin
+      }
+  }
+
+  it should "compile to SystemVerilog with latest CIRCT" in{
+    // This test requires CIRCT with commit 9a9621f3e or later
+    // Set CHISEL_FIRTOOL_PATH to point to your local CIRCT build
+    val sv = ChiselStage.emitSystemVerilog(new RawModule {
+      val a = IO(Input(Property[String]()))
+      val b = IO(Input(Property[String]()))
+      val eq = IO(Output(Property[Boolean]()))
+      eq := a === b
+    })
+    // If this doesn't throw an exception, CIRCT supports property equality
+    sv should not be empty
+  }
+}

--- a/src/test/scala-2/chiselTests/properties/PropertyEqualitySpec.scala
+++ b/src/test/scala-2/chiselTests/properties/PropertyEqualitySpec.scala
@@ -70,7 +70,7 @@ class PropertyEqualitySpec extends AnyFlatSpec with Matchers with FileCheck {
       }
   }
 
-  it should "compile to SystemVerilog with latest CIRCT" in{
+  it should "compile to SystemVerilog with latest CIRCT" in {
     // This test requires CIRCT with commit 9a9621f3e or later
     // Set CHISEL_FIRTOOL_PATH to point to your local CIRCT build
     val sv = ChiselStage.emitSystemVerilog(new RawModule {

--- a/src/test/scala/chiselTests/properties/PropertyEqualitySpec.scala
+++ b/src/test/scala/chiselTests/properties/PropertyEqualitySpec.scala
@@ -70,16 +70,12 @@ class PropertyEqualitySpec extends AnyFlatSpec with Matchers with FileCheck {
       }
   }
 
-  it should "compile to SystemVerilog with latest CIRCT" in {
-    // This test requires CIRCT with commit 9a9621f3e or later
-    // Set CHISEL_FIRTOOL_PATH to point to your local CIRCT build
-    val sv = ChiselStage.emitSystemVerilog(new RawModule {
+  it should "compile to SystemVerilog" in {
+    ChiselStage.emitSystemVerilog(new RawModule {
       val a = IO(Input(Property[String]()))
       val b = IO(Input(Property[String]()))
       val eq = IO(Output(Property[Boolean]()))
       eq := a === b
     })
-    // If this doesn't throw an exception, CIRCT supports property equality
-    sv should not be empty
   }
 }


### PR DESCRIPTION
Add a new API for doing equality checks between properties.  Support is
added for integers, booleans, and strings.

This is intended to be used for domains to tighten up unsafe domain casts,
e.g., to write a synchronous domain crossing and disallow its use for
asynchronous crossings.  At present, the unsafe domain cast operation is
too maximally weak and will allow any crossing to occur.

Assisted-by: Claude:claude-sonnet-4-6

#### Release Notes

Add property equality API to allow for users to test for the equality of
integer, boolean, or string properties.  When compiled to Verilog, this will
error during compilation if an equality is known false.  Alternative, this will
error at run-time when that property is evaluated, e.g., by the OM evaluator or
`domaintool`.
