### PR TITLE
[core] Synchronous, Rational Clock Domains

### DIFF
--- a/core/src/main/scala/chisel3/domains/ClockDomain.scala
+++ b/core/src/main/scala/chisel3/domains/ClockDomain.scala
@@ -63,7 +63,7 @@ object ClockDomain extends Domain()(sourceInfo = UnlocatableSourceInfo) {
     */
   @deprecated(
     message = "use the more exact `synchronous` or `rational` to create a derived clock",
-    since = "Chisel 7.11.0"
+    since = "Chisel 7.12.0"
   )
   def derived(synchronousTo: chisel3.domain.Type, suffix: String): chisel3.domain.Type =
     synchronous(synchronousTo, suffix)

--- a/core/src/main/scala/chisel3/domains/ClockDomain.scala
+++ b/core/src/main/scala/chisel3/domains/ClockDomain.scala
@@ -15,9 +15,37 @@ import chisel3.properties.Property
   */
 object ClockDomain extends Domain()(sourceInfo = UnlocatableSourceInfo) {
 
+  /** Types of clock relationships */
+  object Relationship {
+
+    /** A clock relationship */
+    sealed trait Type {
+      override final def toString: String = this.getClass.getSimpleName.stripSuffix("$").toLowerCase
+    }
+
+    /** A synchronous relationship
+      *
+      * This indicates that two clocks have a deterministic phase relationship
+      * and an integer frequency ratio, e.g., `1:1`, `2:1`, or `1:4`.  Both
+      * clocks must be derived from the same source via integer multiplication
+      * or division, e.g., using a clock divider.
+      */
+    object Synchronous extends Type
+
+    /** A rational relationship
+      *
+      * This indicates that two clocks have a deterministic phase relationship
+      * and a non-integer rational frequency ratio, e.g., `2:3`.  Both clocks
+      * must be derived from a common source clock, e.g., with a
+      * phase-locked-loop (PLL).
+      */
+    object Rational extends Type
+  }
+
   override def fields: Seq[(String, Field.Type)] = Seq(
     "name" -> Field.String,
-    "synchronousTo" -> Field.String
+    "source" -> Field.String,
+    "relationship" -> Field.String
   )
 
   /** Create a new clock domain that is asynchronous to all other domains.
@@ -25,19 +53,43 @@ object ClockDomain extends Domain()(sourceInfo = UnlocatableSourceInfo) {
     *
     * @param name the name of this domain
     */
-  def apply(name: String): chisel3.domain.Type = ClockDomain(Property(name), Property(""))
+  def apply(name: String): chisel3.domain.Type = ClockDomain(Property(name), Property(""), Property(""))
 
-  /** Create a new clock domain that is derived from another clock domain.
+  /** Create a derived clock domain.
     *
-    * This implies that this new domain is synchronous to the other other.
+    * @param synchronousTo the source domain from which this clock domain is derived
+    * @param suffix a naming suffix to apply to this domain
+    * @see [[synchronous]]
+    */
+  @deprecated(
+    message = "use the more exact `synchronous` or `rational` to create a derived clock",
+    since = "Chisel 7.11.0"
+  )
+  def derived(synchronousTo: chisel3.domain.Type, suffix: String): chisel3.domain.Type =
+    synchronous(synchronousTo, suffix)
+
+  /** Create a new clock domain with a synchronous relationship to another clock domain.
     *
-    * @param synchronousTo the domain that this clock domain is derived from
+    * @param source the domain with which the new domain has a synchronous relationship
     * @param suffix a naming suffix to apply to this domain
     */
-  def derived(synchronousTo: chisel3.domain.Type, suffix: String): chisel3.domain.Type =
+  def synchronous(source: chisel3.domain.Type, suffix: String): chisel3.domain.Type =
     ClockDomain(
-      Property.concat(synchronousTo.field.name.asInstanceOf[Property[String]], Property("_div2")),
-      synchronousTo.field.name
+      Property.concat(source.field.name.asInstanceOf[Property[String]], Property(suffix)),
+      source.field.name,
+      Property(Relationship.Synchronous.toString)
+    )
+
+  /** Create a new clock domain with a rational relationship to another clock domain.
+    *
+    * @param source the domain with which the new domain has a rational relationship
+    * @param suffix a naming suffix to apply to this domain
+    */
+  def rational(source: chisel3.domain.Type, suffix: String): chisel3.domain.Type =
+    ClockDomain(
+      Property.concat(source.field.name.asInstanceOf[Property[String]], Property(suffix)),
+      source.field.name,
+      Property(Relationship.Rational.toString)
     )
 
 }

--- a/src/test/scala/chiselTests/DomainSpec.scala
+++ b/src/test/scala/chiselTests/DomainSpec.scala
@@ -45,7 +45,8 @@ class DomainSpec extends AnyFlatSpec with Matchers with FileCheck {
       """|CHECK:      circuit Foo :
          |CHECK:        domain ClockDomain :
          |CHECK-NEXT:     name : String
-         |CHECK-NEXT:     synchronousTo : String
+         |CHECK-NEXT:     source : String
+         |CHECK-NEXT:     relationship : String
          |
          |CHECK:        domain PowerDomain :
          |CHECK-NEXT:     name : String
@@ -222,19 +223,19 @@ class DomainSpec extends AnyFlatSpec with Matchers with FileCheck {
     class Foo extends RawModule {
       val A = IO(Input(ClockDomain.Type()))
       val nameOut = IO(Output(Property[String]()))
-      val syncOut = IO(Output(Property[String]()))
+      val sourceOut = IO(Output(Property[String]()))
 
       nameOut := A.field.name
-      syncOut := A.field.synchronousTo
+      sourceOut := A.field.source
     }
 
     ChiselStage.emitCHIRRTL(new Foo).fileCheck() {
       """|CHECK: module Foo :
          |CHECK:   input A : Domain of ClockDomain
          |CHECK:   output nameOut : String
-         |CHECK:   output syncOut : String
+         |CHECK:   output sourceOut : String
          |CHECK:   propassign nameOut, A.name
-         |CHECK:   propassign syncOut, A.synchronousTo
+         |CHECK:   propassign sourceOut, A.source
          |""".stripMargin
     }
 
@@ -242,13 +243,13 @@ class DomainSpec extends AnyFlatSpec with Matchers with FileCheck {
 
   behavior of "domain instantiation"
 
-  it should "allow instantiating a domain with property literals" in {
+  it should "allow instantiating a synchronous domain" in {
 
     class Foo extends RawModule {
       val A = IO(Input(ClockDomain.Type()))
       val B = IO(Output(ClockDomain.Type()))
 
-      val b = ClockDomain.derived(A, "_div2")
+      val b = ClockDomain.synchronous(A, "_1to4")
       domain.define(B, b)
     }
 
@@ -257,8 +258,31 @@ class DomainSpec extends AnyFlatSpec with Matchers with FileCheck {
          |CHECK:   input A : Domain of ClockDomain
          |CHECK:   output B : Domain of ClockDomain
          |CHECK:   wire [[name:.+]] : String
-         |CHECK:   propassign [[name]], string_concat(A.name, String("_div2"))
-         |CHECK:   domain [[b:.*]] of ClockDomain([[name]], A.name)
+         |CHECK:   propassign [[name]], string_concat(A.name, String("_1to4"))
+         |CHECK:   domain [[b:.*]] of ClockDomain([[name]], A.name, String("synchronous"))
+         |CHECK:   domain_define B = [[b]]
+         |""".stripMargin
+    }
+
+  }
+
+  it should "allow instantiating a rational domain" in {
+
+    class Foo extends RawModule {
+      val A = IO(Input(ClockDomain.Type()))
+      val B = IO(Output(ClockDomain.Type()))
+
+      val b = ClockDomain.rational(A, "_2to3")
+      domain.define(B, b)
+    }
+
+    ChiselStage.emitCHIRRTL(new Foo).fileCheck() {
+      """|CHECK: module Foo :
+         |CHECK:   input A : Domain of ClockDomain
+         |CHECK:   output B : Domain of ClockDomain
+         |CHECK:   wire [[name:.+]] : String
+         |CHECK:   propassign [[name]], string_concat(A.name, String("_2to3"))
+         |CHECK:   domain [[b:.*]] of ClockDomain([[name]], A.name, String("rational"))
          |CHECK:   domain_define B = [[b]]
          |""".stripMargin
     }


### PR DESCRIPTION
Add new APIs for describing synchronous and rational clock domains.  These
deprecate and replace the old `derived` API for creating a synchronous
clock domain derived from another.

This change is necessary to, when coupled with property assertions, error
when weaker synchronizers are used in places where stronger synchronizers
are needed.  E.g., this will allow us to error if a synchronous
synchronizer is used to cross between clock domains which are asynchronous
or rational.

Assisted-by: Claude:claude-sonnet-4-6
