### PR TITLE
Rename all object interface traits, $ => Obj

### DIFF
--- a/core/src/main/scala-2/chisel3/AggregateIntf.scala
+++ b/core/src/main/scala-2/chisel3/AggregateIntf.scala
@@ -38,7 +38,7 @@ private[chisel3] trait VecIntf[T <: Data] { self: Vec[T] =>
   ): T = _reduceTreeImpl(redOp, layerOp)
 }
 
-private[chisel3] trait VecInit$Intf extends SourceInfoDoc { self: VecInit.type =>
+private[chisel3] trait VecInitObjIntf extends SourceInfoDoc { self: VecInit.type =>
 
   /** Creates a new [[Vec]] composed of elements of the input Seq of [[Data]]
     * nodes.

--- a/core/src/main/scala-2/chisel3/FormalContractIntf.scala
+++ b/core/src/main/scala-2/chisel3/FormalContractIntf.scala
@@ -6,7 +6,7 @@ import chisel3.experimental.SourceInfo
 import scala.language.experimental.macros
 import scala.reflect.macros.whitebox
 
-private[chisel3] trait FormalContract$Intf { self: FormalContract.type =>
+private[chisel3] trait FormalContractObjIntf { self: FormalContract.type =>
 
   /** Create a `contract` block with one or more arguments and results. */
   def apply(head: Data, tail: Data*): (Any => Unit) => Any =

--- a/core/src/main/scala-2/chisel3/MemIntf.scala
+++ b/core/src/main/scala-2/chisel3/MemIntf.scala
@@ -8,7 +8,7 @@ import chisel3.internal.sourceinfo.{MemTransform, SourceInfoTransform}
 import chisel3.experimental.SourceInfo
 import chisel3.Mem.HasVecDataType
 
-private[chisel3] trait Mem$Intf extends SourceInfoDoc { self: Mem.type =>
+private[chisel3] trait MemObjIntf extends SourceInfoDoc { self: Mem.type =>
 
   /** Creates a combinational/asynchronous-read, sequential/synchronous-write [[Mem]].
     *
@@ -164,7 +164,7 @@ private[chisel3] trait MemBaseIntf[T <: Data] extends SourceInfoDoc { self: MemB
   ): Unit = _writeImpl(idx, data, mask, clock)
 }
 
-private[chisel3] trait SyncReadMem$Intf extends SourceInfoDoc { self: SyncReadMem.type =>
+private[chisel3] trait SyncReadMemObjIntf extends SourceInfoDoc { self: SyncReadMem.type =>
 
   /** Creates a sequential/synchronous-read, sequential/synchronous-write [[SyncReadMem]].
     *

--- a/core/src/main/scala-2/chisel3/ModuleIntf.scala
+++ b/core/src/main/scala-2/chisel3/ModuleIntf.scala
@@ -7,7 +7,7 @@ import scala.language.experimental.macros
 import chisel3.experimental.{BaseModule, SourceInfo}
 import chisel3.internal.sourceinfo.InstTransform
 
-private[chisel3] trait Module$Intf extends SourceInfoDoc { self: Module.type =>
+private[chisel3] trait ModuleObjIntf extends SourceInfoDoc { self: Module.type =>
 
   /** A wrapper method that all Module instantiations must be wrapped in
     * (necessary to help Chisel track internal state).

--- a/core/src/main/scala-2/chisel3/MuxIntf.scala
+++ b/core/src/main/scala-2/chisel3/MuxIntf.scala
@@ -7,7 +7,7 @@ import scala.language.experimental.macros
 import chisel3.experimental.SourceInfo
 import chisel3.internal.sourceinfo.MuxTransform
 
-private[chisel3] trait Mux$Intf extends SourceInfoDoc { self: Mux.type =>
+private[chisel3] trait MuxObjIntf extends SourceInfoDoc { self: Mux.type =>
 
   /** Creates a mux, whose output is one of the inputs depending on the
     * value of the condition.

--- a/core/src/main/scala-2/chisel3/VerificationStatementIntf.scala
+++ b/core/src/main/scala-2/chisel3/VerificationStatementIntf.scala
@@ -20,7 +20,7 @@ import scala.language.experimental.macros
   */
 trait VerifPrintMacrosDoc
 
-private[chisel3] trait Assert$Intf extends VerifPrintMacrosDoc { self: assert.type =>
+private[chisel3] trait AssertObjIntf extends VerifPrintMacrosDoc { self: assert.type =>
 
   /** Checks for a condition to be valid in the circuit at rising clock edge
     * when not in reset. If the condition evaluates to false, the circuit
@@ -69,7 +69,7 @@ private[chisel3] trait Assert$Intf extends VerifPrintMacrosDoc { self: assert.ty
     macro VerifStmtMacrosCompat.assert._applyMacroWithNoMessage
 }
 
-private[chisel3] trait Assume$Intf extends VerifPrintMacrosDoc { self: assume.type =>
+private[chisel3] trait AssumeObjIntf extends VerifPrintMacrosDoc { self: assume.type =>
 
   /** Assumes a condition to be valid in the circuit at all times.
     * Acts like an assertion in simulation and imposes a declarative
@@ -122,7 +122,7 @@ private[chisel3] trait Assume$Intf extends VerifPrintMacrosDoc { self: assume.ty
     macro VerifStmtMacrosCompat.assume._applyMacroWithNoMessage
 }
 
-private[chisel3] trait Cover$Impl extends VerifPrintMacrosDoc { self: cover.type =>
+private[chisel3] trait CoverObjImpl extends VerifPrintMacrosDoc { self: cover.type =>
 
   /** Declares a condition to be covered.
     * At ever clock event, a counter is incremented iff the condition is active

--- a/core/src/main/scala-2/chisel3/probe/PackageIntf.scala
+++ b/core/src/main/scala-2/chisel3/probe/PackageIntf.scala
@@ -7,7 +7,7 @@ import chisel3.experimental.SourceInfo
 
 import scala.language.experimental.macros
 
-private[chisel3] trait Probe$Intf extends SourceInfoDoc {
+private[chisel3] trait ProbeObjIntf extends SourceInfoDoc {
 
   /** Access the value of a probe.
     *

--- a/core/src/main/scala-2/chisel3/properties/ObjectIntf.scala
+++ b/core/src/main/scala-2/chisel3/properties/ObjectIntf.scala
@@ -7,7 +7,7 @@ import scala.language.experimental.macros
 import chisel3.experimental.SourceInfo
 import chisel3.internal.sourceinfo.InstTransform
 
-private[chisel3] trait DynamicObject$Intf { self: DynamicObject.type =>
+private[chisel3] trait DynamicObjectObjIntf { self: DynamicObject.type =>
 
   /** A wrapper method to wrap Class instantiations and return a DynamicObject.
     *

--- a/core/src/main/scala-3/chisel3/AggregateIntf.scala
+++ b/core/src/main/scala-3/chisel3/AggregateIntf.scala
@@ -43,7 +43,7 @@ private[chisel3] trait VecIntf[T <: Data] { self: Vec[T] =>
   ): T = _reduceTreeImpl(redOp, layerOp)
 }
 
-private[chisel3] trait VecInit$Intf extends SourceInfoDoc { self: VecInit.type =>
+private[chisel3] trait VecInitObjIntf extends SourceInfoDoc { self: VecInit.type =>
 
   /** Creates a new [[Vec]] composed of elements of the input Seq of [[Data]]
     * nodes.

--- a/core/src/main/scala-3/chisel3/FormalContractIntf.scala
+++ b/core/src/main/scala-3/chisel3/FormalContractIntf.scala
@@ -4,7 +4,7 @@ package chisel3
 
 import scala.quoted.*
 
-private[chisel3] trait FormalContract$Intf { self: FormalContract.type =>
+private[chisel3] trait FormalContractObjIntf { self: FormalContract.type =>
 
   /** Create a `contract` block with one or more arguments and results. */
   transparent inline def apply[T <: Data](inline args: T*): Any =

--- a/core/src/main/scala-3/chisel3/MemIntf.scala
+++ b/core/src/main/scala-3/chisel3/MemIntf.scala
@@ -5,7 +5,7 @@ package chisel3
 import chisel3.experimental.SourceInfo
 import chisel3.Mem.HasVecDataType
 
-private[chisel3] trait Mem$Intf { self: Mem.type =>
+private[chisel3] trait MemObjIntf { self: Mem.type =>
 
   /** Creates a combinational/asynchronous-read, sequential/synchronous-write [[Mem]].
     *
@@ -116,7 +116,7 @@ private[chisel3] trait MemBaseIntf[T <: Data] extends SourceInfoDoc { self: MemB
   ): Unit = _writeImpl(idx, data, mask, clock)
 }
 
-private[chisel3] trait SyncReadMem$Intf { self: SyncReadMem.type =>
+private[chisel3] trait SyncReadMemObjIntf { self: SyncReadMem.type =>
 
   /** Creates a sequential/synchronous-read, sequential/synchronous-write [[SyncReadMem]].
     *

--- a/core/src/main/scala-3/chisel3/ModuleIntf.scala
+++ b/core/src/main/scala-3/chisel3/ModuleIntf.scala
@@ -4,7 +4,7 @@ package chisel3
 
 import chisel3.experimental.{BaseModule, SourceInfo}
 
-private[chisel3] trait Module$Intf extends SourceInfoDoc { self: Module.type =>
+private[chisel3] trait ModuleObjIntf extends SourceInfoDoc { self: Module.type =>
 
   /** A wrapper method that all Module instantiations must be wrapped in
     * (necessary to help Chisel track internal state).

--- a/core/src/main/scala-3/chisel3/MuxIntf.scala
+++ b/core/src/main/scala-3/chisel3/MuxIntf.scala
@@ -4,7 +4,7 @@ package chisel3
 
 import chisel3.experimental.SourceInfo
 
-private[chisel3] trait Mux$Intf extends SourceInfoDoc { self: Mux.type =>
+private[chisel3] trait MuxObjIntf extends SourceInfoDoc { self: Mux.type =>
 
   /** Creates a mux, whose output is one of the inputs depending on the
     * value of the condition.

--- a/core/src/main/scala-3/chisel3/VerificationStatementIntf.scala
+++ b/core/src/main/scala-3/chisel3/VerificationStatementIntf.scala
@@ -9,7 +9,7 @@ trait VerifPrintMacrosDoc
 private val emptySourceLine: VerifStmtMacrosCompat.SourceLineInfo =
   ("[Source line unavailable: see https://github.com/chipsalliance/chisel/issues/5049]", 0)
 
-private[chisel3] trait Assert$Intf extends VerifPrintMacrosDoc { self: assert.type =>
+private[chisel3] trait AssertObjIntf extends VerifPrintMacrosDoc { self: assert.type =>
 
   def apply(
     cond:    Bool,
@@ -34,7 +34,7 @@ private[chisel3] trait Assert$Intf extends VerifPrintMacrosDoc { self: assert.ty
     VerifStmtMacrosCompat.assert._applyWithSourceLinePrintable(cond, emptySourceLine, None)
 }
 
-private[chisel3] trait Assume$Intf extends VerifPrintMacrosDoc { self: assume.type =>
+private[chisel3] trait AssumeObjIntf extends VerifPrintMacrosDoc { self: assume.type =>
 
   def apply(
     cond:    Bool,
@@ -59,7 +59,7 @@ private[chisel3] trait Assume$Intf extends VerifPrintMacrosDoc { self: assume.ty
     VerifStmtMacrosCompat.assume._applyWithSourceLinePrintable(cond, emptySourceLine, None)
 }
 
-private[chisel3] trait Cover$Impl extends VerifPrintMacrosDoc { self: cover.type =>
+private[chisel3] trait CoverObjImpl extends VerifPrintMacrosDoc { self: cover.type =>
   def apply(cond: Bool, message: String)(implicit sourceInfo: SourceInfo): Cover =
     VerifStmtMacrosCompat.cover._applyWithSourceLine(cond, emptySourceLine, Some(message))
   def apply(cond: Bool)(implicit sourceInfo: SourceInfo): Cover =

--- a/core/src/main/scala-3/chisel3/probe/PackageIntf.scala
+++ b/core/src/main/scala-3/chisel3/probe/PackageIntf.scala
@@ -5,8 +5,8 @@ package chisel3.probe
 import chisel3._
 import chisel3.experimental.SourceInfo
 
-// Empty olyfill for trait needed by Scala 2
-private[chisel3] trait Probe$Intf
+// Empty polyfill for trait needed by Scala 2
+private[chisel3] trait ProbeObjIntf
 
 /** Access the value of a probe.
   *

--- a/core/src/main/scala-3/chisel3/properties/ObjectIntf.scala
+++ b/core/src/main/scala-3/chisel3/properties/ObjectIntf.scala
@@ -2,6 +2,6 @@
 
 package chisel3.properties
 
-private[chisel3] trait DynamicObject$Intf { self: DynamicObject.type =>
+private[chisel3] trait DynamicObjectObjIntf { self: DynamicObject.type =>
   // TODO implement
 }

--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -646,7 +646,7 @@ sealed class Vec[T <: Data] private[chisel3] (gen: => T, val length: Int)
 
 object Vec extends VecFactory
 
-object VecInit extends VecInit$Intf {
+object VecInit extends VecInitObjIntf {
 
   private[chisel3] def _applyImpl[T <: Data](elts: Seq[T])(implicit sourceInfo: SourceInfo): Vec[T] = {
     // REVIEW TODO: this should be removed in favor of the apply(elts: T*)

--- a/core/src/main/scala/chisel3/FormalContract.scala
+++ b/core/src/main/scala/chisel3/FormalContract.scala
@@ -61,7 +61,7 @@ import chisel3.internal.firrtl.ir._
   * }
   * }}}
   */
-object FormalContract extends FormalContract$Intf {
+object FormalContract extends FormalContractObjIntf {
 
   /** Create a formal contract from a sequence of expressions.
     *

--- a/core/src/main/scala/chisel3/Mem.scala
+++ b/core/src/main/scala/chisel3/Mem.scala
@@ -13,7 +13,7 @@ import chisel3.internal.firrtl.ir._
 import chisel3.Mem.HasVecDataType
 import chisel3.experimental.{requireIsChiselType, requireIsHardware, SourceInfo, SourceLine}
 
-object Mem extends Mem$Intf {
+object Mem extends MemObjIntf {
 
   @implicitNotFound("Masked write requires that the data type is a Vec, got ${T}.")
   type HasVecDataType[T] = T <:< Vec[_]
@@ -206,7 +206,7 @@ sealed class Mem[T <: Data] private[chisel3] (t: T, length: BigInt, sourceInfo: 
   }
 }
 
-object SyncReadMem extends SyncReadMem$Intf {
+object SyncReadMem extends SyncReadMemObjIntf {
 
   type ReadUnderWrite = fir.ReadUnderWrite.Value
   val Undefined = fir.ReadUnderWrite.Undefined

--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -31,7 +31,7 @@ import chisel3.util.simpleClassName
 import chisel3.experimental.annotate
 import chisel3.experimental.hierarchy.Hierarchy
 
-object Module extends Module$Intf {
+object Module extends ModuleObjIntf {
 
   private[chisel3] def _applyImpl[T <: BaseModule](bc: => T)(implicit sourceInfo: SourceInfo): T = {
     // Instantiate the module definition.

--- a/core/src/main/scala/chisel3/Mux.scala
+++ b/core/src/main/scala/chisel3/Mux.scala
@@ -8,7 +8,7 @@ import chisel3.experimental.{requireIsHardware, SourceInfo}
 import chisel3.internal.firrtl.ir._
 import chisel3.internal.firrtl.ir.PrimOp._
 
-object Mux extends Mux$Intf {
+object Mux extends MuxObjIntf {
 
   protected def _applyImpl[T <: Data](
     cond: Bool,

--- a/core/src/main/scala/chisel3/VerificationStatement.scala
+++ b/core/src/main/scala/chisel3/VerificationStatement.scala
@@ -13,7 +13,7 @@ abstract class VerificationStatement extends NamedComponent {
   _parent.foreach(_.addId(this))
 }
 
-object assert extends Assert$Intf {
+object assert extends AssertObjIntf {
 
   /** Named class for assertions. */
   final class Assert private[chisel3] () extends VerificationStatement
@@ -25,7 +25,7 @@ object assert extends Assert$Intf {
   def apply(cond: Boolean): Unit = Predef.assert(cond, "")
 }
 
-object assume extends Assume$Intf {
+object assume extends AssumeObjIntf {
 
   /** Named class for assumptions. */
   final class Assume private[chisel3] () extends VerificationStatement
@@ -37,7 +37,7 @@ object assume extends Assume$Intf {
   def apply(cond: Boolean): Unit = Predef.assume(cond, "")
 }
 
-object cover extends Cover$Impl {
+object cover extends CoverObjImpl {
 
   /** Named class for cover statements. */
   final class Cover private[chisel3] () extends VerificationStatement

--- a/core/src/main/scala/chisel3/probe/package.scala
+++ b/core/src/main/scala/chisel3/probe/package.scala
@@ -12,7 +12,7 @@ import chisel3.experimental.{requireIsHardware, SourceInfo}
 import chisel3.experimental.dataview.reifyIdentityView
 import chisel3.reflect.DataMirror.{checkTypeEquivalence, collectAllMembers, hasProbeTypeModifier}
 
-package object probe extends Probe$Intf {
+package object probe extends ProbeObjIntf {
 
   private[chisel3] def setProbeModifier[T <: Data](data: T, probeInfo: Option[ProbeInfo]): Unit = {
     probeInfo.foreach { _ =>

--- a/core/src/main/scala/chisel3/properties/Object.scala
+++ b/core/src/main/scala/chisel3/properties/Object.scala
@@ -77,7 +77,7 @@ class DynamicObject private[chisel3] (val className: ClassType) extends HasId wi
   }
 }
 
-object DynamicObject extends DynamicObject$Intf {
+object DynamicObject extends DynamicObjectObjIntf {
 
   protected def _applyImpl[T <: Class](bc: => T)(implicit sourceInfo: SourceInfo): DynamicObject = {
     // Instantiate the Class definition.

--- a/release.mill
+++ b/release.mill
@@ -99,9 +99,7 @@ trait Unipublish extends ChiselCrossModule with ChiselPublishModule with Mima {
     ProblemFilter.exclude[MissingTypesProblem]("chisel3.util.Reverse$"),
     ProblemFilter.exclude[MissingTypesProblem]("chisel3.ltl.Property$"),
     ProblemFilter.exclude[MissingTypesProblem]("chisel3.ltl.Sequence$"),
-    ProblemFilter.exclude[MissingClassProblem]("chisel3.Cover$Impl"),
-    ProblemFilter.exclude[IncompatibleResultTypeProblem]("chisel3.util.BitPat.fromUIntToBitPatComparable"),
-    ProblemFilter.exclude[IncompatibleResultTypeProblem]("chisel3.util.BitPat.fromUIntToBitPatComparable")
+    ProblemFilter.exclude[MissingClassProblem]("chisel3.Cover$Impl")
   )
 
   def pluginVersion = v.scalaCrossToVersion(crossScalaVersion)

--- a/release.mill
+++ b/release.mill
@@ -73,7 +73,35 @@ trait Unipublish extends ChiselCrossModule with ChiselPublishModule with Mima {
     // Field.Type members are package-private and safe to add
     ProblemFilter.exclude[ReversedMissingMethodProblem]("chisel3.domain.Field#Type.createProperty"),
     ProblemFilter.exclude[ReversedMissingMethodProblem]("chisel3.domain.Field#Type.expectedPropertyType"),
-    ProblemFilter.exclude[ReversedMissingMethodProblem]("chisel3.domain.Field#Type.typeName")
+    ProblemFilter.exclude[ReversedMissingMethodProblem]("chisel3.domain.Field#Type.typeName"),
+    // Renamed package private *$Intf traits to *ObjInterface
+    ProblemFilter.exclude[MissingClassProblem]("chisel3.*$Intf"),
+    ProblemFilter.exclude[MissingTypesProblem]("chisel3.FormalContract$"),
+    ProblemFilter.exclude[MissingTypesProblem]("chisel3.Mem$"),
+    ProblemFilter.exclude[MissingTypesProblem]("chisel3.Module$"),
+    ProblemFilter.exclude[MissingTypesProblem]("chisel3.Mux$"),
+    ProblemFilter.exclude[MissingTypesProblem]("chisel3.SyncReadMem$"),
+    ProblemFilter.exclude[MissingTypesProblem]("chisel3.VecInit$"),
+    ProblemFilter.exclude[MissingTypesProblem]("chisel3.assert$"),
+    ProblemFilter.exclude[MissingTypesProblem]("chisel3.assume$"),
+    ProblemFilter.exclude[MissingTypesProblem]("chisel3.cover$"),
+    ProblemFilter.exclude[MissingTypesProblem]("chisel3.choice.ModuleChoice$"),
+    ProblemFilter.exclude[MissingTypesProblem]("chisel3.probe.package$"),
+    ProblemFilter.exclude[MissingTypesProblem]("chisel3.properties.DynamicObject$"),
+    ProblemFilter.exclude[MissingTypesProblem]("chisel3.util.BitPat$"),
+    ProblemFilter.exclude[MissingClassProblem]("chisel3.util.BitPat$Intf$fromUIntToBitPatComparable"),
+    ProblemFilter.exclude[MissingTypesProblem]("chisel3.util.Fill$"),
+    ProblemFilter.exclude[MissingTypesProblem]("chisel3.util.FillInterleaved$"),
+    ProblemFilter.exclude[MissingTypesProblem]("chisel3.util.Mux1H$"),
+    ProblemFilter.exclude[MissingTypesProblem]("chisel3.util.MuxLookup$"),
+    ProblemFilter.exclude[MissingTypesProblem]("chisel3.util.PopCount$"),
+    ProblemFilter.exclude[MissingTypesProblem]("chisel3.util.PriorityMux$"),
+    ProblemFilter.exclude[MissingTypesProblem]("chisel3.util.Reverse$"),
+    ProblemFilter.exclude[MissingTypesProblem]("chisel3.ltl.Property$"),
+    ProblemFilter.exclude[MissingTypesProblem]("chisel3.ltl.Sequence$"),
+    ProblemFilter.exclude[MissingClassProblem]("chisel3.Cover$Impl"),
+    ProblemFilter.exclude[IncompatibleResultTypeProblem]("chisel3.util.BitPat.fromUIntToBitPatComparable"),
+    ProblemFilter.exclude[IncompatibleResultTypeProblem]("chisel3.util.BitPat.fromUIntToBitPatComparable")
   )
 
   def pluginVersion = v.scalaCrossToVersion(crossScalaVersion)

--- a/src/main/scala-2/chisel3/choice/ModuleChoiceIntf.scala
+++ b/src/main/scala-2/chisel3/choice/ModuleChoiceIntf.scala
@@ -8,7 +8,7 @@ import chisel3.{Data, FixedIOBaseModule, SourceInfoDoc}
 import chisel3.experimental.SourceInfo
 import chisel3.internal.sourceinfo.InstChoiceTransform
 
-private[chisel3] trait ModuleChoice$Intf extends SourceInfoDoc { self: ModuleChoice.type =>
+private[chisel3] trait ModuleChoiceObjIntf extends SourceInfoDoc { self: ModuleChoice.type =>
 
   /** A wrapper method for Module instantiation based on option choices.
     * (necessary to help Chisel track internal state).

--- a/src/main/scala-2/chisel3/ltl/LTLIntf.scala
+++ b/src/main/scala-2/chisel3/ltl/LTLIntf.scala
@@ -108,7 +108,7 @@ private[chisel3] trait PropertyIntf { self: Property =>
   def clock(clock: Clock)(implicit sourceInfo: SourceInfo): Property = _clockImpl(clock)
 }
 
-private[chisel3] trait Sequence$Intf { self: Sequence.type =>
+private[chisel3] trait SequenceObjIntf { self: Sequence.type =>
 
   /** Delay a sequence by a fixed number of cycles. Equivalent to `##delay` in
     * SVA.
@@ -220,7 +220,7 @@ private[chisel3] trait Sequence$Intf { self: Sequence.type =>
   def apply(atoms: SequenceAtom*)(implicit sourceInfo: SourceInfo): Sequence = _apply(atoms: _*)
 }
 
-private[chisel3] trait Property$Intf { self: Property.type =>
+private[chisel3] trait PropertyObjIntf { self: Property.type =>
 
   /** Negate a property. Equivalent to `not prop` in SVA. */
   def not(prop: Property)(implicit sourceInfo: SourceInfo): Property = _not(prop)

--- a/src/main/scala-2/chisel3/util/BitPatIntf.scala
+++ b/src/main/scala-2/chisel3/util/BitPatIntf.scala
@@ -9,20 +9,27 @@ import chisel3.internal.sourceinfo.SourceInfoTransform
 import scala.collection.mutable
 import scala.util.hashing.MurmurHash3
 
+private[chisel3] class BaseFomUIntToBitPatComparable(x: UInt) extends SourceInfoDoc {
+  import scala.language.experimental.macros
+
+  final def ===(that: BitPat): Bool = macro SourceInfoTransform.thatArg
+  final def =/=(that: BitPat): Bool = macro SourceInfoTransform.thatArg
+
+  /** @group SourceInfoTransformMacro */
+  def do_===(that: BitPat)(implicit sourceInfo: SourceInfo): Bool = that === x
+
+  /** @group SourceInfoTransformMacro */
+  def do_=/=(that: BitPat)(implicit sourceInfo: SourceInfo): Bool = that =/= x
+}
+
+private[chisel3] trait BitPat$Intf { self: BitPat.type =>
+  @deprecated("Use uintToBitPatComparable instead", "Chisel 7.11.0")
+  class fromUIntToBitPatComparable(x: UInt) extends BaseFomUIntToBitPatComparable(x)
+  @deprecated("Use uintToBitPatComparable instead", "Chisel 7.11.0")
+  def fromUIntToBitPatComparable(x: UInt): fromUIntToBitPatComparable = new fromUIntToBitPatComparable(x)
+}
 private[chisel3] trait BitPatObjIntf { self: BitPat.type =>
-  implicit class fromUIntToBitPatComparable(x: UInt) extends SourceInfoDoc {
-
-    import scala.language.experimental.macros
-
-    final def ===(that: BitPat): Bool = macro SourceInfoTransform.thatArg
-    final def =/=(that: BitPat): Bool = macro SourceInfoTransform.thatArg
-
-    /** @group SourceInfoTransformMacro */
-    def do_===(that: BitPat)(implicit sourceInfo: SourceInfo): Bool = that === x
-
-    /** @group SourceInfoTransformMacro */
-    def do_=/=(that: BitPat)(implicit sourceInfo: SourceInfo): Bool = that =/= x
-  }
+  implicit class uintToBitPatComparable(x: UInt) extends BaseFomUIntToBitPatComparable(x)
 }
 
 private[chisel3] trait BitPatIntf extends SourceInfoDoc { self: BitPat =>

--- a/src/main/scala-2/chisel3/util/BitPatIntf.scala
+++ b/src/main/scala-2/chisel3/util/BitPatIntf.scala
@@ -9,7 +9,7 @@ import chisel3.internal.sourceinfo.SourceInfoTransform
 import scala.collection.mutable
 import scala.util.hashing.MurmurHash3
 
-private[chisel3] trait BitPat$Intf { self: BitPat.type =>
+private[chisel3] trait BitPatObjIntf { self: BitPat.type =>
   implicit class fromUIntToBitPatComparable(x: UInt) extends SourceInfoDoc {
 
     import scala.language.experimental.macros

--- a/src/main/scala-2/chisel3/util/BitwiseIntf.scala
+++ b/src/main/scala-2/chisel3/util/BitwiseIntf.scala
@@ -10,7 +10,7 @@ import chisel3.experimental.SourceInfo
 import chisel3.internal.sourceinfo.SourceInfoTransform
 import scala.language.experimental.macros
 
-private[chisel3] trait FillInterleaved$Intf { self: FillInterleaved.type =>
+private[chisel3] trait FillInterleavedObjIntf { self: FillInterleaved.type =>
 
   /** Creates n repetitions of each bit of x in order.
     *
@@ -31,7 +31,7 @@ private[chisel3] trait FillInterleaved$Intf { self: FillInterleaved.type =>
   def do_apply(n: Int, in: Seq[Bool])(implicit sourceInfo: SourceInfo): UInt = _applyImpl(n, in)
 }
 
-private[chisel3] trait PopCount$Intf { self: PopCount.type =>
+private[chisel3] trait PopCountObjIntf { self: PopCount.type =>
 
   def apply(in: Iterable[Bool]): UInt = macro SourceInfoTransform.inArg
 
@@ -44,7 +44,7 @@ private[chisel3] trait PopCount$Intf { self: PopCount.type =>
   def do_apply(in: Bits)(implicit sourceInfo: SourceInfo): UInt = _applyImpl(in)
 }
 
-private[chisel3] trait Fill$Intf { self: Fill.type =>
+private[chisel3] trait FillObjIntf { self: Fill.type =>
 
   /** Create n repetitions of x using a tree fanout topology.
     *
@@ -57,7 +57,7 @@ private[chisel3] trait Fill$Intf { self: Fill.type =>
   def do_apply(n: Int, x: UInt)(implicit sourceInfo: SourceInfo): UInt = _applyImpl(n, x)
 }
 
-private[chisel3] trait Reverse$Intf { self: Reverse.type =>
+private[chisel3] trait ReverseObjIntf { self: Reverse.type =>
 
   def apply(in: UInt): UInt = macro SourceInfoTransform.inArg
 

--- a/src/main/scala-2/chisel3/util/MuxIntf.scala
+++ b/src/main/scala-2/chisel3/util/MuxIntf.scala
@@ -10,7 +10,7 @@ import chisel3.experimental.SourceInfo
 import chisel3.internal.sourceinfo.{MuxLookupTransform, SourceInfoTransform}
 import scala.language.experimental.macros
 
-private[chisel3] trait Mux1H$Intf { self: Mux1H.type =>
+private[chisel3] trait Mux1HObjIntf { self: Mux1H.type =>
 
   def apply[T <: Data](sel: Seq[Bool], in: Seq[T]): T = macro SourceInfoTransform.selInArg
   def do_apply[T <: Data](sel: Seq[Bool], in: Seq[T])(implicit sourceInfo: SourceInfo): T = _applyImpl(sel, in)
@@ -26,7 +26,7 @@ private[chisel3] trait Mux1H$Intf { self: Mux1H.type =>
 
 }
 
-private[chisel3] trait PriorityMux$Intf { self: PriorityMux.type =>
+private[chisel3] trait PriorityMuxObjIntf { self: PriorityMux.type =>
 
   def apply[T <: Data](in:    Seq[(Bool, T)]):                                  T = macro SourceInfoTransform.inArg
   def do_apply[T <: Data](in: Seq[(Bool, T)])(implicit sourceInfo: SourceInfo): T = _applyImpl(in)
@@ -38,7 +38,7 @@ private[chisel3] trait PriorityMux$Intf { self: PriorityMux.type =>
   def do_apply[T <: Data](sel: Bits, in: Seq[T])(implicit sourceInfo: SourceInfo): T = _applyImpl(sel, in)
 }
 
-private[chisel3] trait MuxLookup$Intf extends SourceInfoDoc { self: MuxLookup.type =>
+private[chisel3] trait MuxLookupObjIntf extends SourceInfoDoc { self: MuxLookup.type =>
 
   /** @param key a key to search for
     * @param default a default value if nothing is found

--- a/src/main/scala-3/chisel3/choice/ModuleChoiceIntf.scala
+++ b/src/main/scala-3/chisel3/choice/ModuleChoiceIntf.scala
@@ -5,7 +5,7 @@ package chisel3.choice
 import chisel3.{Data, FixedIOBaseModule}
 import chisel3.experimental.SourceInfo
 
-private[chisel3] trait ModuleChoice$Intf { self: ModuleChoice.type =>
+private[chisel3] trait ModuleChoiceObjIntf { self: ModuleChoice.type =>
 
   /** A wrapper method for Module instantiation based on option choices.
     * (necessary to help Chisel track internal state).

--- a/src/main/scala-3/chisel3/ltl/LTLIntf.scala
+++ b/src/main/scala-3/chisel3/ltl/LTLIntf.scala
@@ -108,7 +108,7 @@ private[chisel3] trait PropertyIntf { self: Property =>
   def clock(clock: Clock)(using SourceInfo): Property = _clockImpl(clock)
 }
 
-private[chisel3] trait Sequence$Intf { self: Sequence.type =>
+private[chisel3] trait SequenceObjIntf { self: Sequence.type =>
 
   /** Delay a sequence by a fixed number of cycles. Equivalent to `##delay` in
     * SVA.
@@ -220,7 +220,7 @@ private[chisel3] trait Sequence$Intf { self: Sequence.type =>
   def apply(atoms: SequenceAtom*)(using SourceInfo): Sequence = _apply(atoms: _*)
 }
 
-private[chisel3] trait Property$Intf { self: Property.type =>
+private[chisel3] trait PropertyObjIntf { self: Property.type =>
 
   /** Negate a property. Equivalent to `not prop` in SVA. */
   def not(prop: Property)(using SourceInfo): Property = _not(prop)

--- a/src/main/scala-3/chisel3/util/BitPatIntf.scala
+++ b/src/main/scala-3/chisel3/util/BitPatIntf.scala
@@ -13,7 +13,7 @@ private[chisel3] trait BitPatObjIntf { self: BitPat.type =>
     def =/=(that: BitPat)(using SourceInfo): Bool = that =/= x
   }
 }
-// Polyfill for a Scala 2 binary compatibiliy workaround
+// Polyfill for a Scala 2 binary compatibility workaround
 private[chisel3] trait BitPat$Intf
 
 private[chisel3] trait BitPatIntf extends SourceInfoDoc { self: BitPat =>

--- a/src/main/scala-3/chisel3/util/BitPatIntf.scala
+++ b/src/main/scala-3/chisel3/util/BitPatIntf.scala
@@ -7,7 +7,7 @@ import chisel3.experimental.SourceInfo
 import scala.collection.mutable
 import scala.util.hashing.MurmurHash3
 
-private[chisel3] trait BitPat$Intf { self: BitPat.type =>
+private[chisel3] trait BitPatObjIntf { self: BitPat.type =>
   implicit class fromUIntToBitPatComparable(x: UInt) {
     def ===(that: BitPat)(using SourceInfo): Bool = that === x
     def =/=(that: BitPat)(using SourceInfo): Bool = that =/= x

--- a/src/main/scala-3/chisel3/util/BitPatIntf.scala
+++ b/src/main/scala-3/chisel3/util/BitPatIntf.scala
@@ -13,6 +13,8 @@ private[chisel3] trait BitPatObjIntf { self: BitPat.type =>
     def =/=(that: BitPat)(using SourceInfo): Bool = that =/= x
   }
 }
+// Polyfill for a Scala 2 binary compatibiliy workaround
+private[chisel3] trait BitPat$Intf
 
 private[chisel3] trait BitPatIntf extends SourceInfoDoc { self: BitPat =>
   import chisel3.util.experimental.BitSet

--- a/src/main/scala-3/chisel3/util/BitwiseIntf.scala
+++ b/src/main/scala-3/chisel3/util/BitwiseIntf.scala
@@ -8,7 +8,7 @@ package chisel3.util
 import chisel3._
 import chisel3.experimental.SourceInfo
 
-private[chisel3] trait FillInterleaved$Intf { self: FillInterleaved.type =>
+private[chisel3] trait FillInterleavedObjIntf { self: FillInterleaved.type =>
 
   /** Creates n repetitions of each bit of x in order.
     *
@@ -23,13 +23,13 @@ private[chisel3] trait FillInterleaved$Intf { self: FillInterleaved.type =>
   def apply(n: Int, in: Seq[Bool])(using SourceInfo): UInt = _applyImpl(n, in)
 }
 
-private[chisel3] trait PopCount$Intf { self: PopCount.type =>
+private[chisel3] trait PopCountObjIntf { self: PopCount.type =>
 
   def apply(in: Iterable[Bool])(using SourceInfo): UInt = _applyImpl(in)
   def apply(in: Bits)(using SourceInfo):           UInt = _applyImpl(in)
 }
 
-private[chisel3] trait Fill$Intf { self: Fill.type =>
+private[chisel3] trait FillObjIntf { self: Fill.type =>
 
   /** Create n repetitions of x using a tree fanout topology.
     *
@@ -39,7 +39,7 @@ private[chisel3] trait Fill$Intf { self: Fill.type =>
   def apply(n: Int, x: UInt)(using SourceInfo): UInt = _applyImpl(n, x)
 }
 
-private[chisel3] trait Reverse$Intf { self: Reverse.type =>
+private[chisel3] trait ReverseObjIntf { self: Reverse.type =>
 
   def apply(in: UInt)(using SourceInfo): UInt = _applyImpl(in)
 }

--- a/src/main/scala-3/chisel3/util/MuxIntf.scala
+++ b/src/main/scala-3/chisel3/util/MuxIntf.scala
@@ -8,7 +8,7 @@ package chisel3.util
 import chisel3._
 import chisel3.experimental.SourceInfo
 
-private[chisel3] trait Mux1H$Intf { self: Mux1H.type =>
+private[chisel3] trait Mux1HObjIntf { self: Mux1H.type =>
 
   def apply[T <: Data](sel: Seq[Bool], in: Seq[T])(using SourceInfo): T = _applyImpl(sel, in)
 
@@ -19,7 +19,7 @@ private[chisel3] trait Mux1H$Intf { self: Mux1H.type =>
   def apply(sel: UInt, in: UInt)(using SourceInfo): Bool = _applyImpl(sel, in)
 }
 
-private[chisel3] trait PriorityMux$Intf { self: PriorityMux.type =>
+private[chisel3] trait PriorityMuxObjIntf { self: PriorityMux.type =>
 
   def apply[T <: Data](in: Seq[(Bool, T)])(using SourceInfo): T = _applyImpl(in)
 
@@ -28,7 +28,7 @@ private[chisel3] trait PriorityMux$Intf { self: PriorityMux.type =>
   def apply[T <: Data](sel: Bits, in: Seq[T])(using SourceInfo): T = _applyImpl(sel, in)
 }
 
-private[chisel3] trait MuxLookup$Intf { self: MuxLookup.type =>
+private[chisel3] trait MuxLookupObjIntf { self: MuxLookup.type =>
 
   /** @param key a key to search for
     * @param default a default value if nothing is found

--- a/src/main/scala/chisel3/choice/ModuleChoice.scala
+++ b/src/main/scala/chisel3/choice/ModuleChoice.scala
@@ -11,7 +11,7 @@ import chisel3.internal.binding.InstanceChoiceBinding
 import chisel3.internal.Builder.pushCommand
 import chisel3.internal.firrtl.ir.DefInstanceChoice
 
-object ModuleChoice extends ModuleChoice$Intf {
+object ModuleChoice extends ModuleChoiceObjIntf {
 
   protected def _applyImpl[T <: Data](
     default: => FixedIOBaseModule[T],

--- a/src/main/scala/chisel3/ltl/LTL.scala
+++ b/src/main/scala/chisel3/ltl/LTL.scala
@@ -120,7 +120,7 @@ sealed trait Sequence extends Property with SequenceIntf {
   * This object exposes the primary API to create and compose sequences from
   * booleans and shorter sequences.
   */
-object Sequence extends Sequence$Intf {
+object Sequence extends SequenceObjIntf {
 
   implicit class BoolSequence(val inner: Bool) extends Sequence with SequenceAtom
 
@@ -252,7 +252,7 @@ sealed trait Property extends PropertyIntf {
   * This object exposes the primary API to create and compose properties from
   * booleans, sequences, and other properties.
   */
-object Property extends Property$Intf {
+object Property extends PropertyObjIntf {
 
   protected def _not(prop: Property)(implicit sourceInfo: SourceInfo): Property =
     OpaqueProperty(LTLNotIntrinsic(prop.inner))

--- a/src/main/scala/chisel3/util/BitPat.scala
+++ b/src/main/scala/chisel3/util/BitPat.scala
@@ -7,7 +7,7 @@ import chisel3.experimental.SourceInfo
 import scala.collection.mutable
 import scala.util.hashing.MurmurHash3
 
-object BitPat extends BitPatObjIntf {
+object BitPat extends BitPatObjIntf with BitPat$Intf {
 
   private[chisel3] implicit val bitPatOrder: Ordering[BitPat] = new Ordering[BitPat] {
     import scala.math.Ordered.orderingToOrdered

--- a/src/main/scala/chisel3/util/BitPat.scala
+++ b/src/main/scala/chisel3/util/BitPat.scala
@@ -7,7 +7,7 @@ import chisel3.experimental.SourceInfo
 import scala.collection.mutable
 import scala.util.hashing.MurmurHash3
 
-object BitPat extends BitPat$Intf {
+object BitPat extends BitPatObjIntf {
 
   private[chisel3] implicit val bitPatOrder: Ordering[BitPat] = new Ordering[BitPat] {
     import scala.math.Ordered.orderingToOrdered

--- a/src/main/scala/chisel3/util/Bitwise.scala
+++ b/src/main/scala/chisel3/util/Bitwise.scala
@@ -19,7 +19,7 @@ import chisel3.experimental.SourceInfo
   * FillInterleaved(2, Seq(true.B, false.B, false.B, true.B))  // equivalent to "b11 00 00 11".U
   * }}}
   */
-object FillInterleaved extends FillInterleaved$Intf {
+object FillInterleaved extends FillInterleavedObjIntf {
 
   protected def _applyImpl(n: Int, in: UInt)(implicit sourceInfo: SourceInfo): UInt = _applyImpl(n, in.asBools)
 
@@ -38,7 +38,7 @@ object FillInterleaved extends FillInterleaved$Intf {
   * PopCount(myUIntWire)  // dynamic count
   * }}}
   */
-object PopCount extends PopCount$Intf {
+object PopCount extends PopCountObjIntf {
 
   protected def _applyImpl(in: Iterable[Bool])(implicit sourceInfo: SourceInfo): UInt = SeqUtils.count(in.toSeq)
 
@@ -121,7 +121,7 @@ object PopCount extends PopCount$Intf {
   * Fill(2, myUIntWire)  // dynamic fill
   * }}}
   */
-object Fill extends Fill$Intf {
+object Fill extends FillObjIntf {
 
   protected def _applyImpl(n: Int, x: UInt)(implicit sourceInfo: SourceInfo): UInt = {
     n match {
@@ -149,7 +149,7 @@ object Fill extends Fill$Intf {
   * Reverse(myUIntWire)  // dynamic reverse
   * }}}
   */
-object Reverse extends Reverse$Intf {
+object Reverse extends ReverseObjIntf {
 
   private def doit(in: UInt, length: Int)(implicit sourceInfo: SourceInfo): UInt =
     length match {

--- a/src/main/scala/chisel3/util/Mux.scala
+++ b/src/main/scala/chisel3/util/Mux.scala
@@ -23,7 +23,7 @@ import chisel3.internal.Builder
   *
   * @note results unspecified unless exactly one select signal is high
   */
-object Mux1H extends Mux1H$Intf {
+object Mux1H extends Mux1HObjIntf {
   protected def _applyImpl[T <: Data](sel: Seq[Bool], in: Seq[T])(implicit sourceInfo: SourceInfo): T = {
     if (sel.size != in.size) {
       Builder.error(s"Mux1H: input Seqs must have the same length, got sel ${sel.size} and in ${in.size}")
@@ -53,7 +53,7 @@ object Mux1H extends Mux1H$Intf {
   * }}}
   * Returns the output of the Mux tree.
   */
-object PriorityMux extends PriorityMux$Intf {
+object PriorityMux extends PriorityMuxObjIntf {
 
   protected def _applyImpl[T <: Data](in: Seq[(Bool, T)]): T = SeqUtils.priorityMux(in)
 
@@ -75,7 +75,7 @@ object PriorityMux extends PriorityMux$Intf {
   * MuxLookup(myEnum, default)(Seq(MyEnum.a -> 1.U, MyEnum.b -> 2.U, MyEnum.c -> 3.U))
   * }}}
   */
-object MuxLookup extends MuxLookup$Intf {
+object MuxLookup extends MuxLookupObjIntf {
 
   protected def _applyEnumImpl[S <: EnumType, T <: Data](
     key:     S,


### PR DESCRIPTION
Fixes #5212 (well works around IntelliJ's bug but what are you gonna do 🤷‍♀️)

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [ ] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [ ] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Bugfix



#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

This works around a bug in IntelliJ which assumes that $ signifies an inner class and thus it does not properly find public APIs defined in these traits.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
