### PR TITLE
API to set extmodule defname separately from desiredName

### DIFF
--- a/core/src/main/scala/chisel3/internal/BaseBlackBox.scala
+++ b/core/src/main/scala/chisel3/internal/BaseBlackBox.scala
@@ -76,4 +76,7 @@ private[chisel3] abstract class BaseBlackBox extends BaseModule {
   }
 
   requirements.foreach(addRequirement)
+
+  /** The Verilog name of the module that this extmodule represents. Defaults to [[desiredName]]. */
+  protected[chisel3] def defName: String = desiredName
 }

--- a/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
@@ -494,7 +494,7 @@ private[chisel3] object Converter {
         convert(id._getSourceLocator),
         name,
         (ports ++ ctx.secretPorts).map(p => convert(p, typeAliases, topDir)),
-        id.desiredName,
+        id.defName,
         params.keys.toList.sorted.map { name => convert(name, params(name)) },
         knownLayers.map(_.fullName),
         requirements

--- a/core/src/main/scala/chisel3/internal/firrtl/Serializer.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/Serializer.scala
@@ -665,7 +665,7 @@ private[chisel3] object Serializer {
         }
         b ++= " :"; serialize(id._getSourceLocator)
         (ports ++ ctx.secretPorts).foreach { p => newLineAndIndent(1); serialize(p, typeAliases, topDir) }
-        newLineAndIndent(1); b ++= "defname = "; b ++= id.desiredName
+        newLineAndIndent(1); b ++= "defname = "; b ++= id.defName
         params.keys.toList.sorted.foreach { name =>
           newLineAndIndent(1); b ++= "parameter "; serialize(name, params(name))
         }

--- a/src/test/scala-2/chiselTests/ExtModule.scala
+++ b/src/test/scala-2/chiselTests/ExtModule.scala
@@ -344,13 +344,11 @@ class ExtModuleSpec extends AnyFlatSpec with Matchers with ChiselSim with FileCh
 
   it should "use defName for the FIRRTL defname field" in {
     class MyExtMod extends ExtModule {
-      val in = IO(Input(UInt(8.W)))
       override def desiredName = "prefixed_MyExtMod"
       override def defName = "MyExtMod"
     }
     class Top extends Module {
       val m = Module(new MyExtMod)
-      m.in := 0.U
     }
     ChiselStage
       .emitCHIRRTL(new Top)

--- a/src/test/scala-2/chiselTests/ExtModule.scala
+++ b/src/test/scala-2/chiselTests/ExtModule.scala
@@ -342,6 +342,25 @@ class ExtModuleSpec extends AnyFlatSpec with Matchers with ChiselSim with FileCh
       )
   }
 
+  it should "use defName for the FIRRTL defname field" in {
+    class MyExtMod extends ExtModule {
+      val in = IO(Input(UInt(8.W)))
+      override def desiredName = "prefixed_MyExtMod"
+      override def defName = "MyExtMod"
+    }
+    class Top extends Module {
+      val m = Module(new MyExtMod)
+      m.in := 0.U
+    }
+    ChiselStage
+      .emitCHIRRTL(new Top)
+      .fileCheck()(
+        """|CHECK: extmodule prefixed_MyExtMod :
+           |CHECK: defname = MyExtMod
+           |""".stripMargin
+      )
+  }
+
   it should "escape special characters in requirements" in {
     class Bar extends ExtModule(requirements = Seq("\"quoted\"", "back\\slash"))
 


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Feature (or new API)


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

- Allow `ExtModule` to specify `defName` separetly from `desiredName` to support cases where two unique parametrizations of an ExtModule map to the same Verilog module.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
