### PR TITLE
[core] No paren clock domain relationship method

### DIFF
--- a/core/src/main/scala/chisel3/domains/ClockDomain.scala
+++ b/core/src/main/scala/chisel3/domains/ClockDomain.scala
@@ -22,7 +22,7 @@ object ClockDomain extends Domain()(sourceInfo = UnlocatableSourceInfo) {
     sealed trait Type {
       override final def toString: String = this.getClass.getSimpleName.stripSuffix("$").toLowerCase
 
-      final def toProperty(): Property[String] = Property(toString)
+      final def toProperty: Property[String] = Property(toString)
     }
 
     /** A synchronous relationship
@@ -56,7 +56,7 @@ object ClockDomain extends Domain()(sourceInfo = UnlocatableSourceInfo) {
     * @param name the name of this domain
     */
   def apply(name: String): chisel3.domain.Type =
-    ClockDomain(Property(name), Property(name), Relationship.Synchronous.toProperty())
+    ClockDomain(Property(name), Property(name), Relationship.Synchronous.toProperty)
 
   /** Create a derived clock domain.
     *
@@ -80,7 +80,7 @@ object ClockDomain extends Domain()(sourceInfo = UnlocatableSourceInfo) {
     ClockDomain(
       Property.concat(source.field.name.asInstanceOf[Property[String]], Property(suffix)),
       source.field.name,
-      Relationship.Synchronous.toProperty()
+      Relationship.Synchronous.toProperty
     )
 
   /** Create a new clock domain with a rational relationship to another clock domain.
@@ -92,7 +92,7 @@ object ClockDomain extends Domain()(sourceInfo = UnlocatableSourceInfo) {
     ClockDomain(
       Property.concat(source.field.name.asInstanceOf[Property[String]], Property(suffix)),
       source.field.name,
-      Relationship.Rational.toProperty()
+      Relationship.Rational.toProperty
     )
 
 }


### PR DESCRIPTION
Remove the trailing parentheses on the `toProperty` method of
`ClockDomain.Relationship.Type`.  The thinking, when I originally wrote
this, is that this is "Builder effecting" and should therefore have
parentheses.  However, as @jackkoenig brought up, it is generally more
accurate to have parentheses mean "FIRRTL effecting".
