### PR TITLE
[Properties] Add boolean property operations

### DIFF
--- a/core/src/main/scala/chisel3/properties/Property.scala
+++ b/core/src/main/scala/chisel3/properties/Property.scala
@@ -366,6 +366,64 @@ sealed trait Property[T] extends Element { self =>
   ): Property[Boolean] = {
     ev.propEq(this, that)
   }
+
+  /** Boolean AND of two boolean properties (only available for Property[Boolean])
+    *
+    * @param that the other boolean property
+    * @return Property[Boolean] that is the AND of this and that
+    */
+  final def &&(that: Property[T])(
+    implicit ev: T =:= Boolean,
+    sourceInfo:  SourceInfo
+  ): Property[Boolean] = {
+    PropertyBooleanBinaryOps.and(
+      this.asInstanceOf[Property[Boolean]],
+      that.asInstanceOf[Property[Boolean]]
+    )
+  }
+
+  /** Boolean OR of two boolean properties (only available for Property[Boolean])
+    *
+    * @param that the other boolean property
+    * @return Property[Boolean] that is the OR of this and that
+    */
+  final def ||(that: Property[T])(
+    implicit ev: T =:= Boolean,
+    sourceInfo:  SourceInfo
+  ): Property[Boolean] = {
+    PropertyBooleanBinaryOps.or(
+      this.asInstanceOf[Property[Boolean]],
+      that.asInstanceOf[Property[Boolean]]
+    )
+  }
+
+  /** Boolean XOR of two boolean properties (only available for Property[Boolean])
+    *
+    * @param that the other boolean property
+    * @return Property[Boolean] that is the XOR of this and that
+    */
+  final def ^(that: Property[T])(
+    implicit ev: T =:= Boolean,
+    sourceInfo:  SourceInfo
+  ): Property[Boolean] = {
+    PropertyBooleanBinaryOps.xor(
+      this.asInstanceOf[Property[Boolean]],
+      that.asInstanceOf[Property[Boolean]]
+    )
+  }
+
+  /** Boolean NOT of a boolean property (only available for Property[Boolean])
+    *
+    * Implemented as XOR with the constant `true`.
+    *
+    * @return Property[Boolean] that is the logical negation of this
+    */
+  final def unary_!(
+    implicit ev: T =:= Boolean,
+    sourceInfo:  SourceInfo
+  ): Property[Boolean] = {
+    PropertyBooleanBinaryOps.not(this.asInstanceOf[Property[Boolean]])
+  }
 }
 
 private[chisel3] sealed trait ClassTypeProvider[A] {
@@ -630,6 +688,32 @@ object PropertyBooleanOps {
       case cls: Class =>
         cls.addCommand(firrtl.ir.PropertyAssert(sourceInfo, cond.ref, message))
     }
+}
+
+/** Binary boolean property operations: AND, OR, XOR.
+  */
+object PropertyBooleanBinaryOps {
+  import PropertyExpressionHelpers._
+
+  /** Compute the AND of two boolean properties. */
+  def and(lhs: Property[Boolean], rhs: Property[Boolean])(implicit sourceInfo: SourceInfo): Property[Boolean] =
+    cmpOp(sourceInfo, fir.BoolAndOp, lhs, rhs)
+
+  /** Compute the OR of two boolean properties. */
+  def or(lhs: Property[Boolean], rhs: Property[Boolean])(implicit sourceInfo: SourceInfo): Property[Boolean] =
+    cmpOp(sourceInfo, fir.BoolOrOp, lhs, rhs)
+
+  /** Compute the XOR of two boolean properties.
+    *
+    * Note: NOT can be expressed as `xor(a, Property(true))`, or more
+    * conveniently via the `not` helper or `unary_!` operator.
+    */
+  def xor(lhs: Property[Boolean], rhs: Property[Boolean])(implicit sourceInfo: SourceInfo): Property[Boolean] =
+    cmpOp(sourceInfo, fir.BoolXorOp, lhs, rhs)
+
+  /** Compute the logical NOT of a boolean property, implemented as XOR with the constant `true`. */
+  def not(operand: Property[Boolean])(implicit sourceInfo: SourceInfo): Property[Boolean] =
+    xor(operand, Property(true))
 }
 
 /** Companion object for Property.

--- a/firrtl/src/main/scala/firrtl/ir/IR.scala
+++ b/firrtl/src/main/scala/firrtl/ir/IR.scala
@@ -305,6 +305,12 @@ case object ListConcatOp extends PropPrimOp("list_concat")
 case object StringConcatOp extends PropPrimOp("string_concat")
 @deprecated("All APIs in package firrtl are deprecated.", "Chisel 7.0.0")
 case object PropEqOp extends PropPrimOp("prop_eq")
+@deprecated("All APIs in package firrtl are deprecated.", "Chisel 7.0.0")
+case object BoolAndOp extends PropPrimOp("bool_and")
+@deprecated("All APIs in package firrtl are deprecated.", "Chisel 7.0.0")
+case object BoolOrOp extends PropPrimOp("bool_or")
+@deprecated("All APIs in package firrtl are deprecated.", "Chisel 7.0.0")
+case object BoolXorOp extends PropPrimOp("bool_xor")
 
 /** Property expressions.
   *

--- a/src/test/scala/chiselTests/properties/PropertyBooleanBinaryOpsSpec.scala
+++ b/src/test/scala/chiselTests/properties/PropertyBooleanBinaryOpsSpec.scala
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiselTests.properties
+
+import chisel3._
+import chisel3.properties.Property
+import chisel3.testing.scalatest.FileCheck
+import circt.stage.ChiselStage
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class PropertyBooleanBinaryOpsSpec extends AnyFlatSpec with Matchers with FileCheck {
+  behavior.of("PropertyBooleanBinaryOps")
+
+  it should "support AND of two boolean properties" in {
+    ChiselStage
+      .emitCHIRRTL(new RawModule {
+        val a = IO(Input(Property[Boolean]()))
+        val b = IO(Input(Property[Boolean]()))
+        val out = IO(Output(Property[Boolean]()))
+        out := a && b
+      })
+      .fileCheck() {
+        """|CHECK: input a : Bool
+           |CHECK: input b : Bool
+           |CHECK: output out : Bool
+           |CHECK: wire {{.+}} : Bool
+           |CHECK: propassign {{.+}}, bool_and(a, b)
+           |CHECK: propassign out, {{.+}}
+           |""".stripMargin
+      }
+  }
+
+  it should "support OR of two boolean properties" in {
+    ChiselStage
+      .emitCHIRRTL(new RawModule {
+        val a = IO(Input(Property[Boolean]()))
+        val b = IO(Input(Property[Boolean]()))
+        val out = IO(Output(Property[Boolean]()))
+        out := a || b
+      })
+      .fileCheck() {
+        """|CHECK: input a : Bool
+           |CHECK: input b : Bool
+           |CHECK: output out : Bool
+           |CHECK: wire {{.+}} : Bool
+           |CHECK: propassign {{.+}}, bool_or(a, b)
+           |CHECK: propassign out, {{.+}}
+           |""".stripMargin
+      }
+  }
+
+  it should "support XOR of two boolean properties" in {
+    ChiselStage
+      .emitCHIRRTL(new RawModule {
+        val a = IO(Input(Property[Boolean]()))
+        val b = IO(Input(Property[Boolean]()))
+        val out = IO(Output(Property[Boolean]()))
+        out := a ^ b
+      })
+      .fileCheck() {
+        """|CHECK: input a : Bool
+           |CHECK: input b : Bool
+           |CHECK: output out : Bool
+           |CHECK: wire {{.+}} : Bool
+           |CHECK: propassign {{.+}}, bool_xor(a, b)
+           |CHECK: propassign out, {{.+}}
+           |""".stripMargin
+      }
+  }
+
+  it should "support NOT of a boolean property via unary_!" in {
+    ChiselStage
+      .emitCHIRRTL(new RawModule {
+        val a = IO(Input(Property[Boolean]()))
+        val out = IO(Output(Property[Boolean]()))
+        out := !a
+      })
+      .fileCheck() {
+        """|CHECK: input a : Bool
+           |CHECK: output out : Bool
+           |CHECK: propassign {{.+}}, bool_xor(a, Bool(true))
+           |CHECK: propassign out, {{.+}}
+           |""".stripMargin
+      }
+  }
+
+  it should "support NOT idiom via XOR with literal true" in {
+    ChiselStage
+      .emitCHIRRTL(new RawModule {
+        val a = IO(Input(Property[Boolean]()))
+        val out = IO(Output(Property[Boolean]()))
+        out := a ^ Property(true)
+      })
+      .fileCheck() {
+        """|CHECK: input a : Bool
+           |CHECK: output out : Bool
+           |CHECK: propassign {{.+}}, bool_xor(a, Bool(true))
+           |CHECK: propassign out, {{.+}}
+           |""".stripMargin
+      }
+  }
+
+  it should "support chaining boolean property operations" in {
+    ChiselStage
+      .emitCHIRRTL(new RawModule {
+        val a = IO(Input(Property[Boolean]()))
+        val b = IO(Input(Property[Boolean]()))
+        val c = IO(Input(Property[Boolean]()))
+        val out = IO(Output(Property[Boolean]()))
+        out := (a && b) || c
+      })
+      .fileCheck() {
+        """|CHECK: input a : Bool
+           |CHECK: input b : Bool
+           |CHECK: input c : Bool
+           |CHECK: output out : Bool
+           |CHECK: propassign {{.+}}, bool_and(a, b)
+           |CHECK: propassign {{.+}}, bool_or({{.+}}, c)
+           |CHECK: propassign out, {{.+}}
+           |""".stripMargin
+      }
+  }
+
+  // Just test that this compiles all the way to Verilog.
+  it should "compile to SystemVerilog" in {
+    ChiselStage.emitSystemVerilog(new RawModule {
+      val a = IO(Input(Property[Boolean]()))
+      val b = IO(Input(Property[Boolean]()))
+      val out = IO(Output(Property[Boolean]()))
+      out := (a && b) || (a ^ b)
+    })
+  }
+}


### PR DESCRIPTION
Add four new binary boolean property operations to Chisel: and, or, xor,
and not.  Not is implemented in terms of xor.

This depends on https://github.com/llvm/circt/pull/10322 for Verilog compilation
support.

Assisted-by: pi.dev:claude-sonnet-4-6

#### Release Notes

Add AND, OR, XOR, and NOT operations for FIRRTL boolean properties.
