### PR TITLE
[Scala3] Bugfix: AffectsChiselPrefix bug in plugin helpers

### DIFF
--- a/plugin/src/main/scala-3/chisel3/internal/plugin/PluginHelpers.scala
+++ b/plugin/src/main/scala-3/chisel3/internal/plugin/PluginHelpers.scala
@@ -254,7 +254,7 @@ object ChiselTypeHelpers {
   }
 
   def isPrefixed(t: Type)(using Context): Boolean = {
-    val affectsTpe = getClassIfDefined("chisel3.experimental.AffectsChiselName")
+    val affectsTpe = getClassIfDefined("chisel3.experimental.AffectsChiselPrefix")
     t.baseClasses.contains(affectsTpe)
   }
 }

--- a/src/test/scala/chiselTests/naming/PrefixSpec.scala
+++ b/src/test/scala/chiselTests/naming/PrefixSpec.scala
@@ -3,7 +3,6 @@
 package chiselTests.naming
 
 import chisel3._
-import chisel3.aop.Select
 import chisel3.experimental.{noPrefix, prefix, skipPrefix, AffectsChiselPrefix}
 import chisel3.testing.scalatest.FileCheck
 import circt.stage.ChiselStage


### PR DESCRIPTION
Move PrefixSpec

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Bugfix


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
