### PR TITLE
Ensure past intrinsics are emitted with an explicit clock

### DIFF
--- a/src/main/scala/chisel3/ltl/LTL.scala
+++ b/src/main/scala/chisel3/ltl/LTL.scala
@@ -136,7 +136,7 @@ object Sequence extends SequenceObjIntf {
     OpaqueSequence(LTLDelayIntrinsic(delay, None)(seq.inner))
 
   protected def _past(seq: Sequence, delay: Int)(implicit sourceInfo: SourceInfo): Sequence =
-    OpaqueSequence(LTLPastIntrinsic(delay)(seq.inner))
+    OpaqueSequence(LTLPastIntrinsic(delay, Some(Module.clock))(seq.inner))
 
   protected def _pastClock(seq: Sequence, delay: Int, clock: Clock)(implicit sourceInfo: SourceInfo): Sequence =
     OpaqueSequence(LTLPastIntrinsic(delay, Some(clock))(seq.inner))

--- a/src/main/scala/chisel3/ltl/LTL.scala
+++ b/src/main/scala/chisel3/ltl/LTL.scala
@@ -136,7 +136,7 @@ object Sequence extends SequenceObjIntf {
     OpaqueSequence(LTLDelayIntrinsic(delay, None)(seq.inner))
 
   protected def _past(seq: Sequence, delay: Int)(implicit sourceInfo: SourceInfo): Sequence =
-    OpaqueSequence(LTLPastIntrinsic(delay, Some(Module.clock))(seq.inner))
+    _pastClock(seq, delay, Module.clock)
 
   protected def _pastClock(seq: Sequence, delay: Int, clock: Clock)(implicit sourceInfo: SourceInfo): Sequence =
     OpaqueSequence(LTLPastIntrinsic(delay, Some(clock))(seq.inner))

--- a/src/test/scala/chiselTests/LTLSpec.scala
+++ b/src/test/scala/chiselTests/LTLSpec.scala
@@ -75,15 +75,15 @@ class LTLSpec extends AnyFlatSpec with Matchers with ChiselSim with FileCheck {
     ChiselStage.emitSystemVerilog(new DelaysMod)
   }
 
-  class PastMod extends RawModule {
+  class PastMod extends Module {
     implicit val info: SourceInfo = SourceLine("Foo.scala", 1, 2)
     val a, b = IO(Input(Bool()))
-    val clock = IO(Input(Clock()))
+    val myClock = IO(Input(Clock()))
     val s0: Sequence = a.past()
     val s1: Sequence = a.past(3)
     val s2: Sequence = Sequence.past(b, 2)
-    val s3: Sequence = a.past(clock)
-    val s4: Sequence = a.past(2, clock)
+    val s3: Sequence = a.past(myClock)
+    val s4: Sequence = a.past(2, myClock)
   }
   it should "support sequence past operations" in {
     val sourceLoc = "@[Foo.scala 1:2]"
@@ -92,12 +92,12 @@ class LTLSpec extends AnyFlatSpec with Matchers with ChiselSim with FileCheck {
       .fileCheck()(
         s"""|CHECK: input a : UInt<1>
             |CHECK: input b : UInt<1>
-            |CHECK: input clock : Clock
-            |CHECK: intrinsic(circt_ltl_past<delay = 1> : UInt<1>, a) $sourceLoc
-            |CHECK: intrinsic(circt_ltl_past<delay = 3> : UInt<1>, a) $sourceLoc
-            |CHECK: intrinsic(circt_ltl_past<delay = 2> : UInt<1>, b) $sourceLoc
+            |CHECK: input myClock : Clock
             |CHECK: intrinsic(circt_ltl_past<delay = 1> : UInt<1>, a, clock) $sourceLoc
-            |CHECK: intrinsic(circt_ltl_past<delay = 2> : UInt<1>, a, clock) $sourceLoc
+            |CHECK: intrinsic(circt_ltl_past<delay = 3> : UInt<1>, a, clock) $sourceLoc
+            |CHECK: intrinsic(circt_ltl_past<delay = 2> : UInt<1>, b, clock) $sourceLoc
+            |CHECK: intrinsic(circt_ltl_past<delay = 1> : UInt<1>, a, myClock) $sourceLoc
+            |CHECK: intrinsic(circt_ltl_past<delay = 2> : UInt<1>, a, myClock) $sourceLoc
             |""".stripMargin
       )
   }


### PR DESCRIPTION
Slight modification to the intrinsic introduced by #5260 to ensure explicit clocks are always emitted - this is so we can avoid relying on implicit clock inference from IR in CIRCT ([relevant CIRCT PR](https://github.com/llvm/circt/pull/10392)).

First time Chisel contributor so please let me know if I've missed anything!

AI-assisted-by: Claude Code: claude-sonnet-4.6

CC: @fabianschuiki 

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Backend code generation

#### Desired Merge Strategy

- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

Emitted `past` intrinsics are now always emitted with explicit clocks.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.