### PR TITLE
Add BaseModule.ignoreParentPrefix

### DIFF
--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -72,6 +72,8 @@ object Module extends ModuleObjIntf {
     Builder.readyForModuleConstr = true
     Builder.elaborationTrace.pushModule()
 
+    val savedPrefixStack = Builder.getModulePrefixStack
+
     val module = Builder.State.guard(Builder.State.default) {
       val module: T = bc
 
@@ -95,6 +97,7 @@ object Module extends ModuleObjIntf {
       if (module.localModulePrefix.isDefined) {
         Builder.popModulePrefix() // Pop localModulePrefix if it was defined
       }
+      if (module.ignoreParentPrefix) Builder.setModulePrefixStack(savedPrefixStack)
 
       module
     }
@@ -990,6 +993,18 @@ package experimental {
       * Defaults to true, users can override to false if they don't want a separator.
       */
     def localModulePrefixUseSeparator: Boolean = true
+
+    /** If true, this module (and its children) ignores any inherited module prefix from the parent context
+      * (i.e. from [[withModulePrefix]] or a parent's [[localModulePrefix]]), but still respects this
+      * module's own [[localModulePrefix]].
+      *
+      * Defaults to false.
+      */
+    def ignoreParentPrefix: Boolean = false
+
+    // Clear the inherited prefix stack so modulePrefix and children ignore parent context.
+    // evaluate() saves the stack before construction and restores it after closing.
+    if (ignoreParentPrefix) Builder.clearModulePrefixStack()
 
     /** The resolved module prefix used for this Module.
       *

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -1190,6 +1190,9 @@ private[chisel3] object Builder extends LazyLogging {
     context.modulePrefixStack = tail
   }
 
+  // Returns the current module prefix stack without modifying it
+  def getModulePrefixStack: List[(String, Boolean)] = chiselContext.get().modulePrefixStack
+
   // Clears the module prefix stack and returns the prior value
   def clearModulePrefixStack(): List[(String, Boolean)] = {
     val context = chiselContext.get()

--- a/docs/src/explanations/moduleprefix.md
+++ b/docs/src/explanations/moduleprefix.md
@@ -251,6 +251,56 @@ class Child extends Module {
 
 This results in the definition `Bar_Child`.
 
+## ignoreParentPrefix
+
+Override `ignoreParentPrefix` to `true` to make a module (and its children) ignore any prefix
+inherited from the instantiation context — i.e., from an enclosing `withModulePrefix` block or
+a parent's `localModulePrefix`.
+The module's own `localModulePrefix` is still respected.
+
+This is useful when a module belongs to a fixed namespace regardless of where it is instantiated.
+
+```scala mdoc:silent:reset
+import chisel3._
+
+class Top extends Module {
+  withModulePrefix("Foo") {
+    val sub = Module(new Sub)
+  }
+}
+
+class Sub extends Module {
+  override def ignoreParentPrefix = true
+  // ..
+}
+```
+
+This results in the two module definitions `Top` and `Sub` — the `Foo` prefix is ignored.
+
+You can combine `ignoreParentPrefix` with `localModulePrefix` to pin a module to its own namespace:
+
+```scala mdoc:silent:reset
+import chisel3._
+
+class Top extends Module {
+  withModulePrefix("Foo") {
+    val sub = Module(new Sub)
+  }
+}
+
+class Sub extends Module {
+  override def ignoreParentPrefix = true
+  override def localModulePrefix = Some("Bar")
+  // ..
+}
+```
+
+This results in the two module definitions `Top` and `Bar_Sub`.
+The inherited `Foo` prefix is ignored, but `Bar` from `localModulePrefix` still applies.
+
+Unlike `noModulePrefix` (which is applied at the call site), `ignoreParentPrefix` is defined on
+the module class itself, so the behaviour is consistent no matter where the module is instantiated.
+
 ## External Modules
 
 `BlackBox` and `ExtModule` are unaffected by `withModulePrefix`.

--- a/src/test/scala-2/chiselTests/ModulePrefixSpec.scala
+++ b/src/test/scala-2/chiselTests/ModulePrefixSpec.scala
@@ -452,6 +452,126 @@ class ModulePrefixSpec extends AnyFlatSpec with Matchers with FileCheck {
     )
   }
 
+  behavior.of("BaseModule.ignoreParentPrefix")
+
+  it should "cause a module to ignore an inherited prefix" in {
+    class Foo extends RawModule {
+      override def ignoreParentPrefix = true
+      val a = Wire(Bool())
+    }
+    class Top extends RawModule {
+      withModulePrefix("Outer") {
+        val foo = Module(new Foo)
+      }
+    }
+    ChiselStage
+      .emitCHIRRTL(new Top)
+      .fileCheck()(
+        """|CHECK-LABEL: module Foo :
+           |CHECK-LABEL: module Top :
+           |CHECK:         inst foo of Foo
+           |""".stripMargin
+      )
+  }
+
+  it should "still respect localModulePrefix when ignoreParentPrefix is true" in {
+    class Foo extends RawModule {
+      override def ignoreParentPrefix = true
+      override def localModulePrefix = Some("Local")
+      val a = Wire(Bool())
+    }
+    class Top extends RawModule {
+      withModulePrefix("Outer") {
+        val foo = Module(new Foo)
+      }
+    }
+    ChiselStage
+      .emitCHIRRTL(new Top)
+      .fileCheck()(
+        """|CHECK-LABEL: module Local_Foo :
+           |CHECK-LABEL: module Top :
+           |CHECK:         inst foo of Local_Foo
+           |""".stripMargin
+      )
+  }
+
+  it should "cause children to also ignore the inherited prefix" in {
+    class Bar extends RawModule {
+      val a = Wire(Bool())
+    }
+    class Foo extends RawModule {
+      override def ignoreParentPrefix = true
+      val bar = Module(new Bar)
+    }
+    class Top extends RawModule {
+      withModulePrefix("Outer") {
+        val foo = Module(new Foo)
+      }
+    }
+    ChiselStage
+      .emitCHIRRTL(new Top)
+      .fileCheck()(
+        """|CHECK-LABEL: module Bar :
+           |CHECK-LABEL: module Foo :
+           |CHECK:         inst bar of Bar
+           |CHECK-LABEL: module Top :
+           |CHECK:         inst foo of Foo
+           |""".stripMargin
+      )
+  }
+
+  it should "restore the prefix after the module so siblings are unaffected" in {
+    class Foo extends RawModule {
+      override def ignoreParentPrefix = true
+      val a = Wire(Bool())
+    }
+    class Bar extends RawModule {
+      val a = Wire(Bool())
+    }
+    class Top extends RawModule {
+      withModulePrefix("Outer") {
+        val foo = Module(new Foo)
+        val bar = Module(new Bar)
+      }
+    }
+    ChiselStage
+      .emitCHIRRTL(new Top)
+      .fileCheck()(
+        """|CHECK-LABEL: module Foo :
+           |CHECK-LABEL: module Outer_Bar :
+           |CHECK-LABEL: module Top :
+           |CHECK:         inst foo of Foo
+           |CHECK:         inst bar of Outer_Bar
+           |""".stripMargin
+      )
+  }
+
+  it should "allow localModulePrefix to propagate to children when ignoreParentPrefix is set" in {
+    class Bar extends RawModule {
+      val a = Wire(Bool())
+    }
+    class Foo extends RawModule {
+      override def ignoreParentPrefix = true
+      override def localModulePrefix = Some("Local")
+      val bar = Module(new Bar)
+    }
+    class Top extends RawModule {
+      withModulePrefix("Outer") {
+        val foo = Module(new Foo)
+      }
+    }
+    ChiselStage
+      .emitCHIRRTL(new Top)
+      .fileCheck()(
+        """|CHECK-LABEL: module Local_Bar :
+           |CHECK-LABEL: module Local_Foo :
+           |CHECK:         inst bar of Local_Bar
+           |CHECK-LABEL: module Top :
+           |CHECK:         inst foo of Local_Foo
+           |""".stripMargin
+      )
+  }
+
   behavior.of("noModulePrefix")
 
   it should "remove module prefix within the block" in {


### PR DESCRIPTION

Assisted-by: Claude:claude-sonnet-4-6

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Feature (or new API)


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

This allows a module to completely ignore any prefix information from its parent.


### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
