### PR TITLE
Deprecate Scala versions <= 2.13.8

### DIFF
--- a/plugin/src/main/scala-2/chisel3/internal/plugin/ChiselPlugin.scala
+++ b/plugin/src/main/scala-2/chisel3/internal/plugin/ChiselPlugin.scala
@@ -58,10 +58,11 @@ class ChiselPlugin(val global: Global) extends Plugin {
   )
 
   override def init(options: List[String], error: String => Unit): Boolean = {
-    // Deprecate Scala 2.12 via the compiler plugin
-    val scalaVersion = scala.util.Properties.versionNumberString.split('.')
-    if (scalaVersion(0).toInt == 2 && scalaVersion(1).toInt == 12) {
-      val msg = s"Chisel 5 is the last version that will support Scala 2.12. Please upgrade to Scala 2.13."
+    // Deprecate Scala <= 2.13.8 via the compiler plugin
+    val Array(epoch, major, minor) = scala.util.Properties.versionNumberString.split('.')
+    if (epoch == "2" && major == "13" && minor.toInt <= 8) {
+      val msg = s"Chisel 7 is the last version that will support Scala <= 2.13.8. " +
+        "Please upgrade to a newer minor version of Scala 2.13."
 
       global.reporter.warning(NoPosition, msg)
     }


### PR DESCRIPTION
I manually checked that the warning prints (at compile time).

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement


- API deprecation


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
