### PR TITLE
Bump FIRRTL version to 7.0.0

### DIFF
--- a/core/src/main/scala/chisel3/internal/firrtl/Serializer.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/Serializer.scala
@@ -26,7 +26,7 @@ private[chisel3] object Serializer {
   private val Indent = "  "
 
   // The version supported by the serializer.
-  val version = "6.0.0"
+  val version = "7.0.0"
 
   def getRef(id: HasId, sourceInfo: SourceInfo): Arg =
     id.getOptionRef.getOrElse {

--- a/firrtl/src/main/scala/firrtl/ir/Serializer.scala
+++ b/firrtl/src/main/scala/firrtl/ir/Serializer.scala
@@ -17,7 +17,7 @@ object Serializer {
   val Indent = "  "
 
   // The version supported by the serializer.
-  val version = Version(6, 0, 0)
+  val version = Version(7, 0, 0)
 
   /** Converts a `FirrtlNode` into its string representation with
     * default indentation.

--- a/firrtl/src/test/scala/firrtlTests/ExtModuleTests.scala
+++ b/firrtl/src/test/scala/firrtlTests/ExtModuleTests.scala
@@ -8,7 +8,7 @@ import firrtl.testutils._
 class ExtModuleTests extends FirrtlFlatSpec {
   "extmodule" should "serialize and re-parse equivalently" in {
     val input =
-      """|FIRRTL version 6.0.0
+      """|FIRRTL version 7.0.0
          |circuit Top :
          |  extmodule Top knownlayer A, B, C :
          |    input y : UInt<0>

--- a/src/test/scala-2/circtTests/stage/ChiselStageSpec.scala
+++ b/src/test/scala-2/circtTests/stage/ChiselStageSpec.scala
@@ -1114,7 +1114,7 @@ class ChiselStageSpec extends AnyFunSpec with Matchers with chiselTests.LogUtils
 
       val text = ChiselStage.emitCHIRRTL(new ChiselStageSpec.Foo(hasDontTouch = true))
       info("found a version string")
-      text should include("FIRRTL version 6.0.0")
+      text should include("FIRRTL version 7.0.0")
       info("found an Annotation")
       text should include("firrtl.transforms.DontTouchAnnotation")
       info("found a circuit")


### PR DESCRIPTION
Bump the FIRRTL version beyond 6.0.0 as the FIRRTL spec version 6.0.0 has
been cut and Chisel is emitting things _beyond_ it.

AI-assited-by: pi.dev:claude-sonnet-4-6

#### Release Notes

Bump emitted FIRRTL version to 7.0.0.
