### PR TITLE
Use require instead of Builder.error for Mux size mismatch

### DIFF
--- a/src/main/scala/chisel3/util/Mux.scala
+++ b/src/main/scala/chisel3/util/Mux.scala
@@ -25,9 +25,10 @@ import chisel3.internal.Builder
   */
 object Mux1H extends Mux1HObjIntf {
   protected def _applyImpl[T <: Data](sel: Seq[Bool], in: Seq[T])(implicit sourceInfo: SourceInfo): T = {
-    if (sel.size != in.size) {
-      Builder.error(s"Mux1H: input Seqs must have the same length, got sel ${sel.size} and in ${in.size}")
-    }
+    require(
+      sel.size == in.size,
+      s"Mux1H: input Seqs must have the same length, got sel ${sel.size} and in ${in.size}"
+    )
     _applyImpl(sel.zip(in))
   }
 
@@ -58,9 +59,10 @@ object PriorityMux extends PriorityMuxObjIntf {
   protected def _applyImpl[T <: Data](in: Seq[(Bool, T)]): T = SeqUtils.priorityMux(in)
 
   protected def _applyImpl[T <: Data](sel: Seq[Bool], in: Seq[T])(implicit sourceInfo: SourceInfo): T = {
-    if (sel.size != in.size) {
-      Builder.error(s"PriorityMux: input Seqs must have the same length, got sel ${sel.size} and in ${in.size}")
-    }
+    require(
+      sel.size == in.size,
+      s"PriorityMux: input Seqs must have the same length, got sel ${sel.size} and in ${in.size}"
+    )
     _applyImpl(sel.zip(in))
   }
 

--- a/src/test/scala/chiselTests/OneHotMuxSpec.scala
+++ b/src/test/scala/chiselTests/OneHotMuxSpec.scala
@@ -33,7 +33,7 @@ class OneHotMuxSpec extends AnyFreeSpec with Matchers with ChiselSim {
     e.getMessage should include("Mux1H must have a non-empty argument")
   }
   "Mux1H should give a error when given different size Seqs" in {
-    val e = intercept[ChiselException] {
+    val e = intercept[IllegalArgumentException] {
       emitCHIRRTL(
         new RawModule {
           Mux1H(Seq(true.B, false.B), Seq(1.U, 2.U, 3.U))
@@ -41,7 +41,6 @@ class OneHotMuxSpec extends AnyFreeSpec with Matchers with ChiselSim {
         args = Array("--throw-on-first-error")
       )
     }
-    e.getMessage should include("OneHotMuxSpec.scala") // Make sure source locator comes from this file
     e.getMessage should include("Mux1H: input Seqs must have the same length, got sel 2 and in 3")
   }
   // The input bitvector is sign extended to the width of the sequence

--- a/src/test/scala/chiselTests/util/PriorityMuxSpec.scala
+++ b/src/test/scala/chiselTests/util/PriorityMuxSpec.scala
@@ -67,7 +67,7 @@ class PriorityMuxSpec extends AnyFlatSpec with Matchers with ChiselSim {
   }
 
   it should "give a error when given different size Seqs" in {
-    val e = intercept[ChiselException] {
+    val e = intercept[IllegalArgumentException] {
       emitCHIRRTL(
         new RawModule {
           PriorityMux(Seq(true.B, false.B), Seq(1.U, 2.U, 3.U))
@@ -75,7 +75,6 @@ class PriorityMuxSpec extends AnyFlatSpec with Matchers with ChiselSim {
         args = Array("--throw-on-first-error")
       )
     }
-    e.getMessage should include("PriorityMuxSpec.scala") // Make sure source locator comes from this file
     e.getMessage should include("PriorityMux: input Seqs must have the same length, got sel 2 and in 3")
   }
 
@@ -84,5 +83,21 @@ class PriorityMuxSpec extends AnyFlatSpec with Matchers with ChiselSim {
     emitCHIRRTL(new RawModule {
       PriorityMux("b10".U(2.W), Seq(1.U, 2.U, 3.U))
     })
+  }
+
+  it should "not drop arguments when sel.size < in.size" in {
+    // Regression test for issue #4444
+    val e = intercept[IllegalArgumentException] {
+      emitCHIRRTL(
+        new RawModule {
+          val a, b = IO(Input(Bool()))
+          val foo, bar, fizz = IO(Input(UInt(8.W)))
+          val out = IO(Output(UInt(8.W)))
+          out := PriorityMux(Seq(a, b), Seq(foo, bar, fizz))
+        },
+        args = Array("--throw-on-first-error")
+      )
+    }
+    e.getMessage should include("PriorityMux: input Seqs must have the same length, got sel 2 and in 3")
   }
 }


### PR DESCRIPTION
## Summary
- Change `Mux1H` and `PriorityMux` from `Builder.error` to `require` for mismatched sequence sizes, so the error is thrown immediately instead of deferred
- `Builder.error` allowed execution to continue, causing `zip` to silently truncate the longer sequence and produce incorrect circuits
- Update tests to expect `IllegalArgumentException` instead of `ChiselException`, add regression test for #4444
- Fixes #4444

## Test plan
- Updated existing mismatch tests for both `Mux1H` and `PriorityMux` to verify `IllegalArgumentException` is thrown
- Added regression test: `PriorityMux(Seq(a, b), Seq(foo, bar, fizz))` now fails fast instead of silently dropping `fizz`