### PR TITLE
[core] Fix definitions not propagating domains

### DIFF
--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/Definition.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/Definition.scala
@@ -132,6 +132,7 @@ object Definition extends SourceInfoDoc {
     Builder.annotations ++= ir._circuit.annotations
     Builder.layers ++= dynamicContext.layers
     Builder.options ++= dynamicContext.options
+    Builder.domains ++= dynamicContext.domains
     dynamicContext.definitions.foreach(Builder.addDefinition)
     module._circuit = Builder.currentModule
     module.toDefinition

--- a/src/test/scala/chiselTests/DomainSpec.scala
+++ b/src/test/scala/chiselTests/DomainSpec.scala
@@ -8,6 +8,7 @@ import chisel3.domains.ClockDomain
 import chisel3.experimental.dataview._
 import chisel3.properties.Property
 import chisel3.testing.FileCheck
+import chisel3.experimental.hierarchy.{Instantiate, instantiable, public}
 import circt.stage.ChiselStage
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -125,6 +126,29 @@ class DomainSpec extends AnyFlatSpec with Matchers with FileCheck {
          |""".stripMargin
     }
 
+  }
+
+  they should "work if only a Definition has a domain" in {
+
+    @instantiable
+    class Baz extends RawModule {
+      @public
+      val a = IO(Input(ClockDomain.Type()))
+    }
+
+    @instantiable
+    class Bar extends RawModule {
+      private val baz = Instantiate(new Baz)
+    }
+
+    class Foo extends RawModule {
+      private val bar = Instantiate(new Bar)
+    }
+
+    ChiselStage.emitCHIRRTL(new Foo).fileCheck() {
+      """|CHECK: domain ClockDomain :
+         |""".stripMargin
+    }
   }
 
   behavior of "The associate method"

--- a/src/test/scala/chiselTests/DomainSpec.scala
+++ b/src/test/scala/chiselTests/DomainSpec.scala
@@ -8,7 +8,7 @@ import chisel3.domains.ClockDomain
 import chisel3.experimental.dataview._
 import chisel3.properties.Property
 import chisel3.testing.FileCheck
-import chisel3.experimental.hierarchy.{Instantiate, instantiable, public}
+import chisel3.experimental.hierarchy.{instantiable, public, Instantiate}
 import circt.stage.ChiselStage
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers


### PR DESCRIPTION
Fix a bug where domains created by a `Definition` were not properly added
to the root `Builder` context.

Assisted-by: pi.dev:claude-opus-4-7

#### Release Notes

Fix bug where domains used by a `Definition` would not be added to the `Builder` context.
