### PR TITLE
[docs] Add AI Tool Use Policy

### DIFF
--- a/docs/src/developers.md
+++ b/docs/src/developers.md
@@ -5,3 +5,5 @@ Tips and tricks for Chisel developers:
 * [ScalaDoc](developers/scaladoc)
 * [Test Coverage](developers/test-coverage)
 * [Developers Style Guide](developers/style)
+* [Lit Tests](developers/lit-test)
+* [AI Tool Use Policy](developers/ai-tool-policy)

--- a/docs/src/developers/ai-tool-policy.md
+++ b/docs/src/developers/ai-tool-policy.md
@@ -12,7 +12,7 @@ Contributors may use AI tools to assist with their work, but must:
 
 - **Keep a human in the loop** - All AI-generated content must be reviewed and understood by the contributor before submission
 - **Take full accountability** - The contributor is the author and is responsible for their contributions
-- **Be transparent** - Label contributions containing AI-generated content with a message trailer: `Assisted-by: <tool>:<model>`, e.g., `Assisted-by: Claude Code:claude-sonnet-4-6`.  Include this trailer in commit messages, Pull Requests, or wherever authorship is normally indicated.  CIRCT is more restrictive than the upstream LLVM policy and requires the use of AI transparency even when contributions are less than "substantial".
+- **Be transparent** - Label contributions containing AI-generated content with a message trailer: `Assisted-by: <tool>:<model>`, e.g., `Assisted-by: Claude Code:claude-sonnet-4-6`.  Include this trailer in commit messages, Pull Requests, or wherever authorship is normally indicated, regardless of the scope of the contribution.
 - **Ensure quality** - Contributions should be worth more to the project than the time required to review them
 
 ## What This Means
@@ -35,4 +35,4 @@ Using AI to regenerate copyrighted material does not remove the copyright.
 
 ## References
 
-This policy is closely related to and derived from the [CIRCT AI Tool Use Policy](https://circt.llvm.org/docs/AIToolPolicy/) which is derived from the [LLVM AI Tool Use Policy](https://llvm.org/docs/AIToolPolicy.html).
+This policy is closely related to and derived from the [CIRCT AI Tool UseP q0olicy](https://circt.llvm.org/docs/AIToolPolicy/) which is derived from the [LLVM AI Tool Use Policy](https://llvm.org/docs/AIToolPolicy.html).

--- a/docs/src/developers/ai-tool-policy.md
+++ b/docs/src/developers/ai-tool-policy.md
@@ -1,0 +1,37 @@
+---
+layout: docs
+title:  "AI Tool policy"
+section: "chisel3"
+---
+
+# Chisel AI Tool Use Policy
+
+## Summary
+
+Contributors may use AI tools to assist with their work, but must:
+
+- **Keep a human in the loop** - All AI-generated content must be reviewed and understood by the contributor before submission
+- **Take full accountability** - The contributor is the author and is responsible for their contributions
+- **Be transparent** - Label contributions containing AI-generated content with a message trailer: `Assisted-by: <tool>:<model>`, e.g., `Assisted-by: Claude Code:claude-sonnet-4-6`.  Include this trailer in commit messages, Pull Requests, or wherever authorship is normally indicated.  CIRCT is more restrictive than the upstream LLVM policy and requires the use of AI transparency even when contributions are less than "substantial".
+- **Ensure quality** - Contributions should be worth more to the project than the time required to review them
+
+## What This Means
+
+**Allowed:**
+- Using AI tools to generate code that you review, understand, and can explain
+- Using AI for documentation that you verify for correctness
+- Using AI to help debug or optimize code you understand
+
+**Not Allowed:**
+- Submitting AI-generated code without thorough human review
+- Using automated agents that take action without human approval (e.g., GitHub `@claude` agent)
+- Using AI tools to fix "good first issue" labeled issues (these are learning opportunities for newcomers)
+- Passing maintainer feedback to an LLM without understanding and addressing it yourself
+
+## Legal Requirements
+
+Contributors using AI tools must still ensure they have the legal right to contribute code under the Apache-2.0 WITH LLVM-exception license. Using AI to regenerate copyrighted material does not remove the copyright.
+
+## References
+
+This policy is closely related to and derived from the [CIRCT AI Tool Use Policy](https://circt.llvm.org/docs/AIToolPolicy/) which is derived from the [LLVM AI Tool Use Policy](https://llvm.org/docs/AIToolPolicy.html).

--- a/docs/src/developers/ai-tool-policy.md
+++ b/docs/src/developers/ai-tool-policy.md
@@ -35,4 +35,4 @@ Using AI to regenerate copyrighted material does not remove the copyright.
 
 ## References
 
-This policy is closely related to and derived from the [CIRCT AI Tool UseP q0olicy](https://circt.llvm.org/docs/AIToolPolicy/) which is derived from the [LLVM AI Tool Use Policy](https://llvm.org/docs/AIToolPolicy.html).
+This policy is closely related to and derived from the [CIRCT AI Tool Use policy](https://circt.llvm.org/docs/AIToolPolicy/) which is derived from the [LLVM AI Tool Use Policy](https://llvm.org/docs/AIToolPolicy.html).

--- a/docs/src/developers/ai-tool-policy.md
+++ b/docs/src/developers/ai-tool-policy.md
@@ -30,7 +30,8 @@ Contributors may use AI tools to assist with their work, but must:
 
 ## Legal Requirements
 
-Contributors using AI tools must still ensure they have the legal right to contribute code under the Apache-2.0 WITH LLVM-exception license. Using AI to regenerate copyrighted material does not remove the copyright.
+Contributors using AI tools must still ensure they have the legal right to contribute code under the Apache-2.0 license.
+Using AI to regenerate copyrighted material does not remove the copyright.
 
 ## References
 


### PR DESCRIPTION
Add an AI Tool Use Policy.  This is the same policy that is being used in
upstream CIRCT (which is derived from the LLVM policy).  There is far less
need to keep these consistent than CIRCT and LLVM as there is no intention
to ever upstream Chisel into either of these projects while there is an
intention to upstream CIRCT into LLVM (eventually...).

Roughly, this policy is stating that AI tool use is allowed, it should be
clearly stated, and that there needs to be a human-in-the-loop on pre-PR
code review, on PR submission, and on PR review.  This also is more clear
about how tool use attribution should be done.

#### Release Notes

Add AI Tool Use Policy to documentation.
