### PR TITLE
[documentation] Revamp PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,49 +1,23 @@
-### Contributor Checklist
-
-- [ ] Did you add Scaladoc to every public function/method?
-- [ ] Did you add at least one test demonstrating the PR?
-- [ ] Did you delete any extraneous printlns/debugging code?
-- [ ] Did you specify the type of improvement?
-- [ ] Did you add appropriate documentation in `docs/src`?
-- [ ] Did you request a desired merge strategy?
-- [ ] Did you add text to be included in the Release Notes for this change?
+### Summary
 
 <!--
-If you PR has any impact on the user API or affects backend code generation,
-please describe the change in the "Release Notes" section below.
+Describe what this PR changes and why it's needed.
+If necessary, describe any future work this change adds or any negative effects of this change (tech debt, code smells)
 -->
 
-#### Type of Improvement
-
-<!-- Choose one or more from the following (delete those that do not apply): -->
-- Feature (or new API)
-- API modification
-- API deprecation
-- Backend code generation
-- Performance improvement
-- Bugfix
-- Documentation or website-related
-- Dependency update
-- Internal or build-related (includes code refactoring/cleanup)
-
-
-#### Desired Merge Strategy
-
-<!-- If approved, how should this PR be merged? Delete those that do not apply -->
-- Squash: The PR will be squashed and merged (choose this if you have no preference).
-- Rebase: You will rebase the PR onto master and it will be merged with a merge commit.
-
-#### Release Notes
+### Release Notes
 <!--
 The title of your PR will be included in the release notes in addition to any text in this section.
 Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
 -->
 
-### Reviewer Checklist (only modified by reviewer)
-- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
-- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
-- [ ] Did you review?
-- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
-- [ ] Did you do one of the following when ready to merge:
-  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
-  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
+<!--
+Uncomment the following optional section if you need to add more details. Delete the fields you don't need.
+-->
+
+<!--
+### Development notes
+-- AI tool(s) used: 
+-- Merge strategy (defaults to squash): 
+-- Milestone: 
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,6 +13,8 @@ Please be sure to elaborate on any API changes or deprecations and any impact on
 
 <!--
 Uncomment the following optional section if you need to add more details. Delete the fields you don't need.
+
+If you used AI on this PR, please see our AI Tool Use Policy: https://www.chisel-lang.org/docs/developers/ai-tool-policy
 -->
 
 <!--

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 
 <!--
 Describe what this PR changes and why it's needed.
-If necessary, describe any future work this change adds or any negative effects of this change (tech debt, code smells)
+If necessary, describe any future work this change adds or any negative effects of this change (tech debt, code smells).
 -->
 
 ### Release Notes
@@ -17,7 +17,7 @@ Uncomment the following optional section if you need to add more details. Delete
 
 <!--
 ### Development notes
--- AI tool(s) used: 
--- Merge strategy (defaults to squash): 
--- Milestone: 
+- AI tool(s) used: 
+- Merge strategy (defaults to squash): 
+- Milestone: 
 -->


### PR DESCRIPTION
### Summary

Revamps the PR template to look like this. The contributor checklist and reviewer checklist should eventually live on the website 

### Release Notes
Chisel contribution PR was streamlined

<!--
Uncomment the following optional section if you need to add more details. Delete the fields you don't need.
-->

### Development notes
-- AI tool(s) used: None
-- Merge strategy (defaults to squash): Squash
-- Milestone: Chisel 7.x