### PR TITLE
[cd] Support any number of # for release notes header

### DIFF
--- a/.github/workflows/config/release-notes.json
+++ b/.github/workflows/config/release-notes.json
@@ -73,7 +73,7 @@
         "name": "RELEASE_NOTES",
         "source": "BODY",
         "transformer": {
-          "pattern": ".*#### Release Notes(?:[\n\\s]|(?:<!--.*?-->))*((?:\\S(?!!--)).*?)[\n\\s]*\n#.*",
+          "pattern": ".*##* Release Notes(?:[\n\\s]|(?:<!--.*?-->))*((?:\\S(?!!--)).*?)[\n\\s]*\n#.*",
           "flags": "gus",
           "target": "\n$1"
         }


### PR DESCRIPTION
Companion to https://github.com/chipsalliance/chisel/pull/5363.

This change is forwards and backwards compatible for the old and new PR templates.

Checked using https://regex101.com/ . Note to myself in the future or anyone else trying it-- because this regex is in a JSON string, we had to double escape certain characters e.g. `\S` is escaped as `\\S` but we didn't have to double escape `\n`. So the exact regex won't work as copy-pasted but slightly modified it does.

#### Type of Improvement

- Internal or build-related (includes code refactoring/cleanup)


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

Previously it would require exactly 4, now the Release Notes subsection can use 1 or more #.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
