### PR TITLE
[Scala3] Rename private HasId.forceName to _forceName

### DIFF
--- a/core/src/main/scala/chisel3/RawModule.scala
+++ b/core/src/main/scala/chisel3/RawModule.scala
@@ -111,18 +111,18 @@ abstract class RawModule extends BaseModule {
   private def nameId(id: HasId) = id match {
     case id: ModuleClone[_]   => id.setRefAndPortsRef(_namespace) // special handling
     case id: InstanceClone[_] => id.setAsInstanceRef()
-    case id: BaseModule       => id.forceName(default = id.desiredName, _namespace)
-    case id: MemBase[_]       => id.forceName(default = "MEM", _namespace)
-    case id: stop.Stop        => id.forceName(default = "stop", _namespace)
-    case id: assert.Assert    => id.forceName(default = "assert", _namespace)
-    case id: assume.Assume    => id.forceName(default = "assume", _namespace)
-    case id: cover.Cover      => id.forceName(default = "cover", _namespace)
-    case id: printf.Printf    => id.forceName(default = "printf", _namespace)
+    case id: BaseModule       => id._forceName(default = id.desiredName, _namespace)
+    case id: MemBase[_]       => id._forceName(default = "MEM", _namespace)
+    case id: stop.Stop        => id._forceName(default = "stop", _namespace)
+    case id: assert.Assert    => id._forceName(default = "assert", _namespace)
+    case id: assume.Assume    => id._forceName(default = "assume", _namespace)
+    case id: cover.Cover      => id._forceName(default = "cover", _namespace)
+    case id: printf.Printf    => id._forceName(default = "printf", _namespace)
     case id: DynamicObject => {
       // Force name of the DynamicObject, and set its Property[ClassType] type's ref to the DynamicObject.
       // The type's ref can't be set upon instantiation, because the DynamicObject hasn't been named yet.
       // This also updates the source Class ref to the DynamicObject ref now that it's named.
-      id.forceName(default = "_object", _namespace)
+      id._forceName(default = "_object", _namespace)
       id.getReference.setRef(id.getRef)
       id.setSourceClassRef()
     }
@@ -136,23 +136,23 @@ abstract class RawModule extends BaseModule {
       if (id.isSynthesizable) {
         id.topBinding match {
           case OpBinding(_, _) =>
-            id.forceName(default = "_T", _namespace)
+            id._forceName(default = "_T", _namespace)
           case MemoryPortBinding(_, _) =>
-            id.forceName(default = "MPORT", _namespace)
+            id._forceName(default = "MPORT", _namespace)
           case PortBinding(_) =>
-            id.forceName(default = "PORT", _namespace, true, x => ModuleIO(this, x))
+            id._forceName(default = "PORT", _namespace, true, x => ModuleIO(this, x))
           case RegBinding(_, _) =>
-            id.forceName(default = "REG", _namespace)
+            id._forceName(default = "REG", _namespace)
           case WireBinding(_, _) =>
-            id.forceName(default = "_WIRE", _namespace)
+            id._forceName(default = "_WIRE", _namespace)
           case InstanceChoiceBinding(_, _) =>
-            id.forceName(default = "_INST", _namespace)
+            id._forceName(default = "_INST", _namespace)
           // probes have their refs set eagerly
           case _ => // don't name literals
         }
       }
     case m: SramTarget =>
-      id.forceName(default = "MEM", _namespace)
+      id._forceName(default = "MEM", _namespace)
   }
 
   private[chisel3] override def generateComponent(): Option[Component] = {

--- a/core/src/main/scala/chisel3/experimental/dataview/package.scala
+++ b/core/src/main/scala/chisel3/experimental/dataview/package.scala
@@ -41,7 +41,7 @@ package object dataview {
       // The names of views do not matter except for when a view is annotated. For Views that correspond
       // To a single Data, we just forward the name of the Target. For Views that correspond to more
       // than one Data, we return this assigned name but rename it in the Convert stage
-      result.forceName("view", Builder.viewNamespace)
+      result._forceName("view", Builder.viewNamespace)
       result
     }
 

--- a/core/src/main/scala/chisel3/experimental/hierarchy/ModuleClone.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/ModuleClone.scala
@@ -53,9 +53,9 @@ private[chisel3] class ModuleClone[T <: BaseModule](val getProto: T)(implicit si
 
   private[chisel3] def setRefAndPortsRef(namespace: Namespace): Unit = {
     val record = _portsRecord
-    // Use .forceName to re-use default name resolving behavior
-    record.forceName(default = this.desiredName, namespace)
-    // Now take the Ref that forceName set and convert it to the correct Arg
+    // Use ._forceName to re-use default name resolving behavior
+    record._forceName(default = this.desiredName, namespace)
+    // Now take the Ref that _forceName set and convert it to the correct Arg
     val instName = record.getRef match {
       case Ref(name) => name
       case bad       => throwException(s"Internal Error! Cloned-module Record $record has unexpected ref $bad")

--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/Lookupable.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/Lookupable.scala
@@ -334,7 +334,7 @@ object Lookupable {
 
     result.bind(newBinding)
     result.setAllParents(Some(ViewParent))
-    result.forceName("view", Builder.viewNamespace)
+    result._forceName("view", Builder.viewNamespace)
     result
   }
 

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -214,7 +214,7 @@ private[chisel3] trait HasId extends chisel3.InstanceId {
   // Uses a namespace to convert suggestion into a true name
   // Will not do any naming if the reference already assigned.
   // (e.g. tried to suggest a name to part of a Record)
-  private[chisel3] def forceName(
+  private[chisel3] def _forceName(
     default:    => String,
     namespace:  Namespace,
     errorIfDup: Boolean = false,
@@ -1079,7 +1079,7 @@ private[chisel3] object Builder extends LazyLogging {
         try {
           val m = f
           if (!inDefinition) { // This avoids definition name index skipping with D/I
-            m.forceName(m.name, globalNamespace)
+            m._forceName(m.name, globalNamespace)
           }
           m
         } catch {

--- a/core/src/main/scala/chisel3/properties/Class.scala
+++ b/core/src/main/scala/chisel3/properties/Class.scala
@@ -51,7 +51,7 @@ class Class extends BaseModule {
           // Force name of the Object, and set its Property[ClassType] type's ref to the Object.
           // The type's ref can't be set within instantiate, because the Object hasn't been named yet.
           // This also updates the source Class ref to the DynamicObject ref now that it's named.
-          id.forceName(default = "_object", _namespace)
+          id._forceName(default = "_object", _namespace)
           id.getReference.setRef(id.getRef)
           id.setSourceClassRef()
         }
@@ -65,7 +65,7 @@ class Class extends BaseModule {
           if (id.isSynthesizable) {
             id.topBinding match {
               case ClassBinding(_) =>
-                id.forceName(default = "_T", _namespace)
+                id._forceName(default = "_T", _namespace)
               case _ => ()
             }
           }

--- a/release.mill
+++ b/release.mill
@@ -99,7 +99,13 @@ trait Unipublish extends ChiselCrossModule with ChiselPublishModule with Mima {
     ProblemFilter.exclude[MissingTypesProblem]("chisel3.util.Reverse$"),
     ProblemFilter.exclude[MissingTypesProblem]("chisel3.ltl.Property$"),
     ProblemFilter.exclude[MissingTypesProblem]("chisel3.ltl.Sequence$"),
-    ProblemFilter.exclude[MissingClassProblem]("chisel3.Cover$Impl")
+    ProblemFilter.exclude[MissingClassProblem]("chisel3.Cover$Impl"),
+    // HasId.forceName is package private
+    ProblemFilter.exclude[DirectMissingMethodProblem]("chisel3.Data.forceName*"),
+    ProblemFilter.exclude[DirectMissingMethodProblem]("chisel3.MemBase.forceName*"),
+    ProblemFilter.exclude[DirectMissingMethodProblem]("chisel3.experimental.BaseModule.forceName*"),
+    ProblemFilter.exclude[DirectMissingMethodProblem]("chisel3.VerificationStatement.forceName*"),
+    ProblemFilter.exclude[DirectMissingMethodProblem]("chisel3.properties.DynamicObject.forceName*")
   )
 
   def pluginVersion = v.scalaCrossToVersion(crossScalaVersion)

--- a/src/test/scala/chiselTests/experimental/ForceNames.scala
+++ b/src/test/scala/chiselTests/experimental/ForceNames.scala
@@ -27,7 +27,7 @@ object ForceNamesHierarchy {
     val in = IO(Input(UInt(3.W)))
     val out = IO(Output(UInt(3.W)))
     val inst = Module(new MyLeaf)
-    chisel3.util.experimental.forceName(inst, "inst")
+    forceName(inst, "inst")
     inst.in := in
     out := inst.out
   }


### PR DESCRIPTION

### Summary

I fix to my complaint here: https://github.com/chipsalliance/chisel/pull/5340/changes#r3267823454

### Release Notes

This avoids collisions with the publice forceName API in Scala 3.

### Development notes
- AI tool(s) used: Claude Code (Claude Sonnet 4.6)
- Merge strategy (defaults to squash): squash
- Milestone: none

